### PR TITLE
ref(*): update https -> ssh urls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,7 +3237,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 [[package]]
 name = "wact-client"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/wact?rev=955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895#955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895"
+source = "git+ssh://git@github.com/fermyon/wact.git?rev=955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895#955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "wact-core"
 version = "0.1.0"
-source = "git+https://github.com/fermyon/wact?rev=955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895#955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895"
+source = "git+ssh://git@github.com/fermyon/wact.git?rev=955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895#955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@
     structopt      = "0.3"
     tokio          = { version = "1.11", features = [ "full" ] }
     toml           = "0.5"
-    wact-client    = { git = "https://github.com/fermyon/wact", rev = "955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895" }
-    wact-core      = { git = "https://github.com/fermyon/wact", rev = "955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895" }
+    wact-client    = { git = "ssh://git@github.com/fermyon/wact.git", rev = "955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895" }
+    wact-core      = { git = "ssh://git@github.com/fermyon/wact.git", rev = "955eb8fe4ace52e3bd9994c1199f5ec5b9ce7895" }
 
 [workspace]
     members = [ "crates/engine", "crates/hippo-client", "crates/http", "crates/redis", "crates/templates" ]


### PR DESCRIPTION
I was having trouble authenticating with the fermyon/wact repo as part of `cargo build`. Using the ssh urls in place of the https ones helped me get past that issue. Does it make sense to update these in the cargo.toml and cargo.lock files for this project?