### PR TITLE
chore: remove Cargo.toml indentation

### DIFF
--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-    name    = "spin-config"
-    version = "0.1.0"
-    edition = "2021"
-    authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
+name = "spin-config"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
 
 [dependencies]
-    anyhow = "1.0"
-    serde  = { version = "1.0", features = [ "derive" ] }
-    toml   = "0.5"
+anyhow = "1.0"
+serde = { version = "1.0", features = [ "derive" ] }
+toml = "0.5"

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
-    name    = "spin-engine"
-    version = "0.1.0"
-    edition = "2021"
-    authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
+name = "spin-engine"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
 
 [dependencies]
-    anyhow             = "1.0.44"
-    async-trait        = "0.1.51"
-    bytes              = "1.1.0"
-    dirs               = "4.0"
-    fs_extra           = "1.2.0"
-    futures            = "0.3.17"
-    git2               = "0.13"
+anyhow = "1.0.44"
+async-trait = "0.1.51"
+bytes = "1.1.0"
+dirs = "4.0"
+fs_extra = "1.2.0"
+futures = "0.3.17"
+git2 = "0.13"
 glob = "0.3.0"
 lazy_static = "1.4.0"
 regex = "1.5.4"
-    serde              = { version = "1.0.130", features = [ "derive" ] }
+serde = { version = "1.0.130", features = [ "derive" ] }
 sha2 = "0.10.1"
-    spin-config        = { path = "../config" }
-    structopt          = "0.3.23"
-    tempfile = "3.3.0"
-    tokio              = { version = "1.10.0", features = [ "fs" ] }
-    toml               = "0.5.8"
-    tracing            = { version = "0.1", features = [ "log" ] }
-    tracing-futures    = "0.2"
-    tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
-    wasi-common        = "0.33"
-    wasmtime           = "0.33"
-    wasmtime-wasi      = "0.33"
-    wit-bindgen-rust   = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
+spin-config = { path = "../config" }
+structopt = "0.3.23"
+tempfile = "3.3.0"
+tokio = { version = "1.10.0", features = [ "fs" ] }
+toml = "0.5.8"
+tracing = { version = "0.1", features = [ "log" ] }
+tracing-futures = "0.2"
+tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
+wasi-common = "0.33"
+wasmtime = "0.33"
+wasmtime-wasi = "0.33"
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
 
 [dev-dependencies]
-    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -1,31 +1,31 @@
 [package]
-    name    = "spin-http-engine"
-    version = "0.1.0"
-    edition = "2021"
-    authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
+name = "spin-http-engine"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
 
 [lib]
-    doctest = false
+doctest = false
 
 [dependencies]
-    anyhow               = "1.0"
-    async-trait          = "0.1"
-    bytes                = "1.1"
-    ctrlc = "3.2.1"
-    futures              = "0.3"
-    http                 = "0.2"
-    hyper                = { version = "0.14", features = [ "full" ] }
-    indexmap             = "1.8"
-    serde                = { version = "1.0", features = [ "derive" ] }
-    spin-config          = { path = "../config" }
-    spin-engine          = { path = "../engine" }
-    tokio                = { version = "1.10", features = [ "full" ] }
-    tracing              = { version = "0.1", features = [ "log" ] }
-    tracing-futures      = "0.2"
-    tracing-subscriber   = { version = "0.3.7", features = [ "env-filter" ] }
-    url                  = "2.2"
-    wit-bindgen-rust     = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
-    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
-    wasi-common          = "0.33"
-    wasmtime             = "0.33"
-    wasmtime-wasi        = "0.33"
+anyhow = "1.0"
+async-trait = "0.1"
+bytes = "1.1"
+ctrlc = "3.2.1"
+futures = "0.3"
+http = "0.2"
+hyper = { version = "0.14", features = [ "full" ] }
+indexmap = "1.8"
+serde = { version = "1.0", features = [ "derive" ] }
+spin-config = { path = "../config" }
+spin-engine = { path = "../engine" }
+tokio = { version = "1.10", features = [ "full" ] }
+tracing = { version = "0.1", features = [ "log" ] }
+tracing-futures = "0.2"
+tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
+url = "2.2"
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
+wasi-common = "0.33"
+wasmtime = "0.33"
+wasmtime-wasi = "0.33"

--- a/crates/redis/Cargo.toml
+++ b/crates/redis/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-    name    = "spin-redis"
-    version = "0.1.0"
-    edition = "2021"
-    authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
+name = "spin-redis"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
 
 [dependencies]
-    anyhow               = "1.0"
-    async-trait          = "0.1"
-    env_logger           = "0.9"
-    futures              = "0.3"
-    log                  = { version = "0.4", default-features = false }
-    serde                = { version = "1.0", features = [ "derive" ] }
-    spin-engine          = { path = "../engine" }
-    redis                = { version = "0.21", features = [ "tokio-comp" ] }
-    tokio                = { version = "1.14", features = [ "full" ] }
-    wit-bindgen-rust     = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
-    wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
-    wasi-common          = "0.33"
-    wasmtime             = "0.33"
-    wasmtime-wasi        = "0.33"
+anyhow = "1.0"
+async-trait = "0.1"
+env_logger = "0.9"
+futures = "0.3"
+log = { version = "0.4", default-features = false }
+serde = { version = "1.0", features = [ "derive" ] }
+spin-engine = { path = "../engine" }
+redis = { version = "0.21", features = [ "tokio-comp" ] }
+tokio = { version = "1.14", features = [ "full" ] }
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
+wit-bindgen-wasmtime = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
+wasi-common = "0.33"
+wasmtime = "0.33"
+wasmtime-wasi = "0.33"

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-    name    = "spin-templates"
-    version = "0.1.0"
-    edition = "2021"
-    authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
+name = "spin-templates"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
 
 
 [dependencies]
-    anyhow      = "1.0"
-    async-trait = "0.1"
-    bytes       = "1.1"
-    dirs        = "3.0"
-    env_logger  = "0.9"
-    fs_extra    = "1.2"
-    futures     = "0.3"
-    git2        = "0.13"
-    log         = { version = "0.4", default-features = false }
-    serde       = { version = "1.0", features = [ "derive" ] }
-    symlink     = "0.1"
-    tokio       = { version = "1.10", features = [ "fs" ] }
-    toml        = "0.5"
-    walkdir     = "2"
+anyhow = "1.0"
+async-trait = "0.1"
+bytes = "1.1"
+dirs = "3.0"
+env_logger = "0.9"
+fs_extra = "1.2"
+futures = "0.3"
+git2 = "0.13"
+log = { version = "0.4", default-features = false }
+serde = { version = "1.0", features = [ "derive" ] }
+symlink = "0.1"
+tokio = { version = "1.10", features = [ "fs" ] }
+toml = "0.5"
+walkdir = "2"

--- a/templates/spin-http/Cargo.toml
+++ b/templates/spin-http/Cargo.toml
@@ -1,18 +1,17 @@
 [package]
-    name    = "spinhelloworld"
-    version = "0.1.0"
-    edition = "2021"
+name    = "spinhelloworld"
+version = "0.1.0"
+edition = "2021"
 
 [lib]
-    crate-type = [ "cdylib" ]
+crate-type = [ "cdylib" ]
 
 [dependencies]
-    # The wit-bindgen-rust dependency generates bindings for interfaces.
-    wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
+# The wit-bindgen-rust dependency generates bindings for interfaces.
+wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "439c5f8cee12a7f831103c27e2198cfd4b4bad24" }
 
 [workspace]
 
-
 # Metadata about this component.
 [package.metadata.component]
-    name = "spinhelloworld"
+name = "spinhelloworld"

--- a/templates/spin-http/spin.toml
+++ b/templates/spin-http/spin.toml
@@ -1,11 +1,11 @@
-name        = "spin-hello-world"
-version     = "1.0.0"
+name = "spin-hello-world"
+version = "1.0.0"
 description = "A simple application that returns hello and goodbye."
-authors     = [ "Radu Matei <radu@fermyon.com>" ]
-trigger     = "http"
+authors = [ "Radu Matei <radu@fermyon.com>" ]
+trigger = "http"
 
 [[component]]
-    source = "target/wasm32-wasi/release/spinhelloworld.wasm"
-    id     = "hello"
+source = "target/wasm32-wasi/release/spinhelloworld.wasm"
+id = "hello"
 [component.trigger]
-    route = "/hello/..."
+route = "/hello/..."


### PR DESCRIPTION
This commit reverts the (implicit) decision to indent all TOML files and
align entries to the right.

It was a personal preference that is not in line with what the community
uses for TOML files.

I still have a strong preference towards alphabetically sorted dependencies
in the Cargo.toml file.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>