### PR TITLE
chore: enable Cargo Clippy and address issues 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,17 @@ jobs:
           tar xf wasi-sdk-12.0-linux.tar.gz
           sudo mkdir -p /opt/wasi-sdk
           sudo mv wasi-sdk-12.0/* /opt/wasi-sdk/
+
+
+      - name: Install latest Rust stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
+          components: clippy, rustfmt
+
       - name: "Install Wasm Rust targets"
         run: |
-          rustup install 1.56.0
-          rustup default 1.56.0
           rustup target add wasm32-wasi
           rustup target add wasm32-unknown-unknown
       - uses: engineerd/configurator@v0.0.8
@@ -38,5 +45,5 @@ jobs:
         run: CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build
       - name: Run tests
         run:
-          RUST_LOG=fermyon_templates=info,fermyon_templates=info
-          cargo test --all --all-features -- --nocapture
+          RUST_LOG=spin=info cargo test --all --all-features -- --nocapture
+          cargo clippy -- -D warnings

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
     "recommendations": [
-        "tamasfe.even-better-toml",
         "matklad.rust-analyzer",
-        "serayuzgur.crates"
+        "serayuzgur.crates",
     ]
 }

--- a/crates/engine/src/assets.rs
+++ b/crates/engine/src/assets.rs
@@ -223,8 +223,8 @@ mod test {
 
     #[test]
     fn test_is_under() {
-        assert_eq!(true, is_under("/foo", "/foo/bar"));
-        assert_eq!(false, is_under("/foo", "/bar/baz"));
-        assert_eq!(false, is_under("/foo", "/foo/../bar/baz"));
+        assert!(is_under("/foo", "/foo/bar"));
+        assert!(!is_under("/foo", "/bar/baz"));
+        assert!(!is_under("/foo", "/foo/../bar/baz"));
     }
 }

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -102,14 +102,14 @@ impl HttpTrigger {
                         }
                     };
                     match res {
-                        Ok(res) => return Ok(res),
+                        Ok(res) => Ok(res),
                         Err(e) => {
                             log::error!("Error processing request: {:?}", e);
-                            return Ok(Self::internal_error());
+                            Ok(Self::internal_error())
                         }
                     }
                 }
-                Err(_) => return Ok(Self::not_found()),
+                Err(_) => Ok(Self::not_found()),
             },
         }
     }
@@ -178,7 +178,7 @@ fn on_ctrl_c() -> Result<impl std::future::Future<Output = Result<(), tokio::tas
 pub(crate) trait HttpExecutor: Clone + Send + Sync + 'static {
     async fn execute(
         engine: &ExecutionContext,
-        component: &String,
+        component: &str,
         req: Request<Body>,
         client_addr: SocketAddr,
     ) -> Result<Response<Body>>;

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -110,7 +110,7 @@ impl RoutePattern {
         // TODO
         // This only strips a single trailing slash.
         // Should we attempt to strip all trailing slashes?
-        match s.strip_suffix("/") {
+        match s.strip_suffix('/') {
             Some(s) => s.into(),
             None => s,
         }
@@ -127,31 +127,28 @@ mod route_tests {
         init();
 
         let rp = RoutePattern::from("/foo/bar");
-        assert_eq!(rp.matches("/foo/bar"), true);
-        assert_eq!(rp.matches("/foo/bar/"), true);
-        assert_eq!(rp.matches("/foo"), false);
-        assert_eq!(rp.matches("/foo/bar/thisshouldbefalse"), false);
-        assert_eq!(rp.matches("/abc"), false);
+        assert!(rp.matches("/foo/bar"));
+        assert!(rp.matches("/foo/bar/"));
+        assert!(!rp.matches("/foo"));
+        assert!(!rp.matches("/foo/bar/thisshouldbefalse"));
+        assert!(!rp.matches("/abc"));
     }
 
     #[test]
     fn test_pattern_route() {
         let rp = RoutePattern::from("/...");
-        assert_eq!(rp.matches("/foo/bar/"), true);
-        assert_eq!(rp.matches("/foo"), true);
-        assert_eq!(rp.matches("/foo/bar/baz"), true);
-        assert_eq!(rp.matches("/this/should/really/match/everything/"), true);
-        assert_eq!(rp.matches("/"), true);
+        assert!(rp.matches("/foo/bar/"));
+        assert!(rp.matches("/foo"));
+        assert!(rp.matches("/foo/bar/baz"));
+        assert!(rp.matches("/this/should/really/match/everything/"));
+        assert!(rp.matches("/"));
 
         let rp = RoutePattern::from("/foo/...");
-        assert_eq!(rp.matches("/foo/bar/"), true);
-        assert_eq!(rp.matches("/foo"), true);
-        assert_eq!(rp.matches("/foo/bar/baz"), true);
-        assert_eq!(
-            rp.matches("/this/should/really/not/match/everything/"),
-            false
-        );
-        assert_eq!(rp.matches("/"), false);
+        assert!(rp.matches("/foo/bar/"));
+        assert!(rp.matches("/foo"));
+        assert!(rp.matches("/foo/bar/baz"));
+        assert!(!rp.matches("/this/should/really/not/match/everything/"));
+        assert!(!rp.matches("/"));
     }
 
     #[test]

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -17,7 +17,7 @@ impl HttpExecutor for SpinHttpExecutor {
     #[instrument(skip(engine))]
     async fn execute(
         engine: &ExecutionContext,
-        component: &String,
+        component: &str,
         req: Request<Body>,
         _client_addr: SocketAddr,
     ) -> Result<Response<Body>> {

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -14,7 +14,7 @@ impl HttpExecutor for WagiHttpExecutor {
     #[instrument(skip(_engine))]
     async fn execute(
         _engine: &ExecutionContext,
-        _component: &String,
+        _component: &str,
         _req: Request<Body>,
         _client_addr: SocketAddr,
     ) -> Result<Response<Body>> {

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -75,7 +75,7 @@ impl TemplatesManager {
     }
 
     /// Add a local directory as a template.
-    pub fn add_local(&self, name: &str, src: &PathBuf) -> Result<()> {
+    pub fn add_local(&self, name: &str, src: &Path) -> Result<()> {
         let src = std::fs::canonicalize(src)?;
         let dst = &self
             .root
@@ -159,7 +159,7 @@ impl TemplatesManager {
     }
 
     /// Ensure the root directory exists, or else create it.
-    async fn ensure(root: &PathBuf) -> Result<()> {
+    async fn ensure(root: &Path) -> Result<()> {
         if !root.exists() {
             log::debug!("creating cache root directory `{}`", root.display());
             fs::create_dir_all(root).await.with_context(|| {

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -72,8 +72,8 @@ impl List {
                 table.add_row(vec![
                     t,
                     repo.clone().name,
-                    repo.clone().git.unwrap_or("".to_string()),
-                    repo.clone().branch.unwrap_or("".to_string()),
+                    repo.clone().git.unwrap_or_else(|| "".to_string()),
+                    repo.clone().branch.unwrap_or_else(|| "".to_string()),
                 ]);
             }
         }


### PR DESCRIPTION
This commit addresses almost all Cargo Clippy warnings (there is one
warning that is ignored, since solving it requires a bit of refactoring).

It also updates the VS Code configuration to run the `cargo clippy`
command on each save, so the warnings are available in the editor.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>