### PR TITLE
fix: improve internal logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,34 +1,34 @@
 [package]
-    name    = "spin-cli"
-    version = "0.1.0"
-    edition = "2021"
-    authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
+name = "spin-cli"
+version = "0.1.0"
+edition = "2021"
+authors = [ "Radu Matei <radu.matei@fermyon.com>" ]
 
 [dependencies]
-    anyhow             = "1.0"
-    async-trait        = "0.1"
-    bytes              = "1.1"
-    comfy-table        = "5.0"
-    dirs               = "4.0"
-    env_logger         = "0.9"
-    futures            = "0.3"
-    path-absolutize = "3.0.11"
-    semver             = "1.0"
-    serde              = { version = "1.0", features = [ "derive" ] }
-    spin-config        = { path = "crates/config" }
-    spin-engine        = { path = "crates/engine" }
-    spin-http-engine   = { path = "crates/http" }
-    spin-templates     = { path = "crates/templates" }
-    structopt          = "0.3"
-    tokio              = { version = "1.11", features = [ "full" ] }
-    toml               = "0.5"
-    tracing            = { version = "0.1", features = [ "log" ] }
-    tracing-futures    = "0.2"
-    tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
+anyhow = "1.0"
+async-trait = "0.1"
+bytes = "1.1"
+comfy-table = "5.0"
+dirs = "4.0"
+env_logger = "0.9"
+futures = "0.3"
+path-absolutize = "3.0.11"
+semver = "1.0"
+serde = { version = "1.0", features = [ "derive" ] }
+spin-config = { path = "crates/config" }
+spin-engine = { path = "crates/engine" }
+spin-http-engine = { path = "crates/http" }
+spin-templates = { path = "crates/templates" }
+structopt = "0.3"
+tokio = { version = "1.11", features = [ "full" ] }
+toml = "0.5"
+tracing = { version = "0.1", features = [ "log" ] }
+tracing-futures = "0.2"
+tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 
 [workspace]
-    members = [ "crates/config", "crates/engine", "crates/http", "crates/templates" ]
+members = [ "crates/config", "crates/engine", "crates/http", "crates/templates" ]
 
 [[bin]]
-    name = "spin"
-    path = "src/bin/spin.rs"
+name = "spin"
+path = "src/bin/spin.rs"

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -18,7 +18,7 @@ use spin_config::{Configuration, CoreComponent, TriggerConfig};
 use spin_engine::{Builder, ExecutionContextConfiguration};
 use spin_http::SpinHttpData;
 use std::{net::SocketAddr, sync::Arc};
-use tracing::{instrument, log};
+use tracing::log;
 use wagi::WagiHttpExecutor;
 
 wit_bindgen_wasmtime::import!("wit/ephemeral/spin-http.wit");
@@ -48,7 +48,6 @@ pub struct HttpTrigger {
 
 impl HttpTrigger {
     /// Create a new Spin HTTP trigger.
-    #[instrument]
     pub async fn new(
         address: String,
         app: Configuration<CoreComponent>,
@@ -61,7 +60,7 @@ impl HttpTrigger {
 
         let engine = Arc::new(Builder::build_default(config).await?);
         let router = Router::build(&app)?;
-        log::info!("Created new HTTP trigger.");
+        log::debug!("Created new HTTP trigger.");
 
         Ok(Self {
             address,
@@ -129,7 +128,6 @@ impl HttpTrigger {
     }
 
     /// Run the HTTP trigger indefinitely.
-    #[instrument(skip(self))]
     pub async fn run(&self) -> Result<()> {
         let mk_svc = make_service_fn(move |addr: &AddrStream| {
             let t = self.clone();
@@ -218,7 +216,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[instrument]
     async fn test_spin_http() -> Result<()> {
         init();
 

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -6,7 +6,7 @@ use anyhow::{bail, Result};
 use indexmap::IndexMap;
 use spin_config::{Configuration, CoreComponent};
 use std::fmt::Debug;
-use tracing::{instrument, log};
+use tracing::log;
 
 // TODO
 // The current implementation of the router clones the components, which could
@@ -27,7 +27,6 @@ pub(crate) struct Router {
 
 impl Router {
     /// Build a router based on application configuration.
-    #[instrument]
     pub(crate) fn build(app: &Configuration<CoreComponent>) -> Result<Self> {
         let routes = app
             .components
@@ -38,7 +37,7 @@ impl Router {
             })
             .collect();
 
-        log::info!(
+        log::trace!(
             "Constructed router for application {}: {:?}",
             app.info.name,
             routes
@@ -57,7 +56,6 @@ impl Router {
     /// if no component matches.
     /// If there are multiple possible components registered for the same route or
     /// wildcard, return the last one in the components vector.
-    #[instrument]
     pub(crate) fn route<S: Into<String> + Debug>(&self, p: S) -> Result<CoreComponent> {
         let p = p.into();
 

--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use http::Uri;
 use hyper::{Body, Request, Response};
 use std::{net::SocketAddr, str::FromStr};
-use tracing::{instrument, log};
+use tracing::log;
 use wasmtime::{Instance, Store};
 
 #[derive(Clone)]
@@ -14,14 +14,13 @@ pub struct SpinHttpExecutor;
 
 #[async_trait]
 impl HttpExecutor for SpinHttpExecutor {
-    #[instrument(skip(engine))]
     async fn execute(
         engine: &ExecutionContext,
         component: &str,
         req: Request<Body>,
         _client_addr: SocketAddr,
     ) -> Result<Response<Body>> {
-        log::info!(
+        log::trace!(
             "Executing request using the Spin executor for component {}",
             component
         );

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -4,21 +4,20 @@ use anyhow::Result;
 use async_trait::async_trait;
 use hyper::{Body, Request, Response};
 use std::net::SocketAddr;
-use tracing::{instrument, log};
+use tracing::log;
 
 #[derive(Clone)]
 pub struct WagiHttpExecutor;
 
 #[async_trait]
 impl HttpExecutor for WagiHttpExecutor {
-    #[instrument(skip(_engine))]
     async fn execute(
         _engine: &ExecutionContext,
         _component: &str,
         _req: Request<Body>,
         _client_addr: SocketAddr,
     ) -> Result<Response<Body>> {
-        log::info!(
+        log::trace!(
             "Executing request using the Wagi executor for component {}",
             _component
         );

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -21,7 +21,7 @@ impl Redis for RedisEngine {
 
         let (store, instance) = self.0.prepare(None)?;
         self.execute_impl(store, instance, payload)?;
-        log::info!("Request execution time: {:#?}", start.elapsed());
+        log::trace!("Request execution time: {:#?}", start.elapsed());
 
         Ok(())
     }

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -1,7 +1,6 @@
 use anyhow::Error;
 use spin_cli::commands::{new::NewCommand, templates::TemplateCommands, up::Up};
 use structopt::{clap::AppSettings, StructOpt};
-use tracing::instrument;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
@@ -29,7 +28,6 @@ enum SpinApp {
 
 impl SpinApp {
     /// The main entry point to Spin.
-    #[instrument]
     pub async fn run(self) -> Result<(), Error> {
         match self {
             SpinApp::Templates(cmd) => cmd.run().await,

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -4,7 +4,6 @@ use spin_config::{ApplicationOrigin, Configuration, CoreComponent, RawConfigurat
 use spin_http_engine::HttpTrigger;
 use std::{fs::File, io::Read, path::PathBuf};
 use structopt::{clap::AppSettings, StructOpt};
-use tracing::instrument;
 
 /// Start the Fermyon HTTP runtime.
 #[derive(StructOpt, Debug)]
@@ -27,7 +26,6 @@ pub struct Up {
 }
 
 impl Up {
-    #[instrument]
     pub async fn run(self) -> Result<()> {
         let app = self.app_from_file()?;
 


### PR DESCRIPTION
This commit fixes the way internal logging took place in Spin.
Specifically, it removes most of the `#[instrument]` spans in favor
of a limited number of them, and updates the usage of `log::info`,
changing most of them to `trace` of `debug`.


After this PR, here is a sample of how logging looks like (removed timestamps for brevity).

Running with `INFO` as the log level:

```
➜ RUST_LOG=spin=info,spin_cli=info,spin_engine=info spin up --app spin.toml
INFO build: spin_engine::assets: Mounting files from '/Users/radu/projects/src/github.com/misc/spintests/invoker-tests/componentB' to '/var/folders/rs/7g5937rn0sq1vyrtwf0_48140000gn/T/.tmpdhV4cm'
INFO spin_http_engine: Serving on address 127.0.0.1:3000

INFO spin_http_engine: Processing request for application spin-hello-world on URI /B
INFO spin_http_engine::spin: Request finished, sending response with status code 200 OK
```


Running with `TRACE` as the log level:

```
➜ RUST_LOG=spin=trace,spin_cli=trace,spin_engine=trace spin up --app spin.toml
TRACE spin_engine: Created execution context configuration.
DEBUG build: spin_engine: Created temporary directory '/var/folders/rs/7g5937rn0sq1vyrtwf0_48140000gn/T/.tmpYLG3xL'
TRACE build: spin_engine: Created module from file "target/wasm32-wasi/release/spinhelloworld.wasm"
DEBUG build: spin_engine: Created pre-instance from module "target/wasm32-wasi/release/spinhelloworld.wasm"
INFO build: spin_engine::assets: Mounting files from '/Users/radu/projects/src/github.com/misc/spintests/invoker-tests/componentB' to '/var/folders/rs/7g5937rn0sq1vyrtwf0_48140000gn/T/.tmpYLG3xL'
TRACE build: spin_engine: Execution context initialized.
TRACE spin_http_engine::routes: Constructed router for application spin-hello-world: {Exact("/B"): CoreComponent { source: FileReference("target/wasm32-wasi/release/spinhelloworld.wasm"), id: "component-b", wasm: WasmConfig { environment: None, files: None, allowed_http_hosts: None }, trigger: Http(HttpConfig { route: "/B", executor: Some(Spin) }) }}
DEBUG spin_http_engine: Created new HTTP trigger.
INFO spin_http_engine: Serving on address 127.0.0.1:3000

INFO spin_http_engine: Processing request for application spin-hello-world on URI /B
TRACE spin_http_engine::spin: Executing request using the Spin executor for component component-b
DEBUG prepare_component{component="component-b"}: spin_engine: Preparing component component-b
DEBUG prepare_component{component="component-b"}: spin_engine: Creating store.
INFO spin_http_engine::spin: Request finished, sending response with status code 200 OK
```

Signed-off-by: Radu Matei <radu.matei@fermyon.com>