### PR TITLE
chore: refactor the assets module

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,15 +47,17 @@ Each `component` object has the following fields:
   pointing to a remote bindle.
 - `environment` (OPTIONAL): Environment variables to be mapped inside the Wasm
   module at runtime.
-- `files` (OPTIONAL): Paths (relative to the configuration file) of files to be
-  mapped inside the Wasm module at runtime.
+- `files` (OPTIONAL): Paths (relative to the configuration file) of files and
+  file patterns to be mapped inside the Wasm module at runtime. Note all the
+  files will have read-only permissions in the WebAssembly module, and cannot be
+  modified at runtime.
 - `allowed_http_hosts` (OPTIONAL): List of HTTP hosts the component is allowed
-  to connect to.
+  to connect to. (TODO: not yet implemented)
 - `trigger` (REQUIRED): Trigger configuration for the component.
 - `dependencies` (OPTIONAL): List of dependencies to be resolved and satisfied
-  at runtime by the host.
+  at runtime by the host. (TODO: not yet implemented)
 - `build` (OPTIONAL): Currently unused build information or configuration that
-  could be used by a plugin to build the component.
+  could be used by a plugin to build the component. (TODO: not yet implemented)
 
 ### Component sources
 
@@ -84,14 +86,14 @@ components. Currently, the only trigger implemented for Spin is the HTTP
 trigger, which contains the following fields:
 
 - `route` (REQUIRED): The HTTP route the component will be invoked for.
-- `implementation` (OPTIONAL, TODO): The HTTP interface the component
-  implements. This can either be `spin`, or `wagi`.s
+- `executor` (OPTIONAL): The HTTP executor the component expects. This can
+  either be `spin`, or `wagi`.s
 
 ```toml
 [component.trigger]
-    route          = "/hello"
-    implementation = "spin"
-  # implementation = "wagi"
+    route = "/hello"
+    executor = "spin"
+  # executor = "wagi"
 ```
 
 ### Dependencies


### PR DESCRIPTION
This commit refactors the assets module from the execution context
crate with the main purpose of having a consistent style between the
modules of the same crate.

Note that this does not change any of the logic in the module at all.
Specifically, the commit does a few main things:

 - it renames most functions and identifiers to be slightly less
verbose, and adds comments where needed. This, together with
running `rustfmt` again on this module, makes the style similar to
the rest of the project.
- it updates most functions that took two separate `impl AsRef<Path>`
parameters to have generic `AsRef<Path>` arguments.
- simplifies the use of Rust maps and removes unnecessary `let`
bindings where possible.

Finally, the one change in this commit that has an impact on the
functionality is marking all copied files as read-only.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>