### PR TITLE
feat(wagi): pass arguments to wagi modules

### DIFF
--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -26,7 +26,7 @@ impl HttpExecutor for SpinHttpExecutor {
             "Executing request using the Spin executor for component {}",
             component
         );
-        let (store, instance) = engine.prepare_component(component, None, None, None)?;
+        let (store, instance) = engine.prepare_component(component, None, None, None, None)?;
         let res = Self::execute_impl(store, instance, base, raw_route, req).await?;
         log::info!(
             "Request finished, sending response with status code {}",

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -36,6 +36,13 @@ impl HttpExecutor for WagiHttpExecutor {
             component
         );
 
+        let uri_path = req.uri().path();
+        let mut args = vec![uri_path.to_string()];
+        req.uri()
+            .query()
+            .map(|q| q.split('&').for_each(|item| args.push(item.to_string())))
+            .take();
+
         let (parts, body) = req.into_parts();
 
         let body = body::to_bytes(body).await?.to_vec();
@@ -71,8 +78,13 @@ impl HttpExecutor for WagiHttpExecutor {
             headers.insert(k, v);
         }
 
-        let (mut store, instance) =
-            engine.prepare_component(component, None, Some(iostream.clone()), Some(headers))?;
+        let (mut store, instance) = engine.prepare_component(
+            component,
+            None,
+            Some(iostream.clone()),
+            Some(headers),
+            Some(args),
+        )?;
 
         let start = instance
             .get_func(&mut store, WAGI_DEFAULT_ENTRYPOINT)


### PR DESCRIPTION
Arguments parsed from the URL are passed to WebAssembly modules when
using the Wagi executor.

https://github.com/deislabs/wagi/blob/main/docs/writing_modules.md#arguments