### PR TITLE
feat: add Bindle loader

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3,7 +3,11 @@
 #![deny(missing_docs)]
 
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    fmt::{Debug, Formatter},
+    path::PathBuf,
+};
 
 /// Application configuration.
 #[derive(Clone, Debug)]
@@ -49,8 +53,6 @@ pub struct CoreComponent {
     /// multiple components of the same application.
     pub id: String,
     /// Per-component WebAssembly configuration.
-    /// This takes precedence over the application-level
-    /// WebAssembly configuration.
     pub wasm: WasmConfig,
     /// Trigger configuration.
     pub trigger: TriggerConfig,
@@ -111,12 +113,28 @@ pub struct DirectoryMount {
 }
 
 /// Source for the entrypoint Wasm module of a component.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum ModuleSource {
     /// A local path to the entrypoint Wasm module.
     FileReference(PathBuf),
+
+    /// A buffer that contains the entrypoint Wasm module.
+    Buffer(Vec<u8>),
 }
 
+impl Debug for ModuleSource {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+        match self {
+            ModuleSource::FileReference(fp) => {
+                f.debug_struct("FileReference").field("file", fp).finish()
+            }
+            ModuleSource::Buffer(bytes) => {
+                f.debug_struct("Buffer").field("len", &bytes.len()).finish()
+            }
+        }
+    }
+}
+//f.debug_struct("Buffer").field("buffer", bytes.len().finish()
 /// Configuration for the HTTP trigger.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct HttpConfig {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -105,18 +105,21 @@ impl<T: Default> Builder<T> {
         let mut components = HashMap::new();
         for c in &self.config.app.components {
             let core = c.clone();
-
-            // TODO
             let module = match c.source.clone() {
                 ModuleSource::FileReference(p) => {
                     let module = Module::from_file(&self.engine, &p)?;
                     log::trace!("Created module from file {:?}", p);
                     module
                 }
+                ModuleSource::Buffer(bytes) => {
+                    let module = Module::from_binary(&self.engine, &bytes)?;
+                    log::trace!("Created module from buffer with size {}", bytes.len());
+                    module
+                }
             };
 
             let pre = Arc::new(self.linker.instantiate_pre(&mut self.store, &module)?);
-            log::debug!("Created pre-instance from module"); // TODO: show source?
+            log::debug!("Created pre-instance from module.");
 
             components.insert(c.id.clone(), Component { core, pre });
         }

--- a/crates/loader/src/bindle/assets.rs
+++ b/crates/loader/src/bindle/assets.rs
@@ -1,0 +1,92 @@
+#![deny(missing_docs)]
+
+use super::utils::BindleReader;
+use crate::assets::{create_dir, ensure_under};
+use anyhow::{anyhow, bail, Context, Result};
+use bindle::{Id, Label};
+use futures::future;
+use spin_config::DirectoryMount;
+use std::path::Path;
+use tokio::fs;
+use tracing::log;
+
+pub(crate) async fn prepare_component(
+    reader: &BindleReader,
+    bindle_id: &Id,
+    parcels: &[Label],
+    base_dst: impl AsRef<Path>,
+    component: &str,
+) -> Result<DirectoryMount> {
+    let copier = Copier {
+        reader: reader.clone(),
+        id: bindle_id.clone(),
+    };
+    copier.prepare(parcels, base_dst, component).await
+}
+
+pub(crate) struct Copier {
+    reader: BindleReader,
+    id: Id,
+}
+
+impl Copier {
+    async fn prepare(
+        &self,
+        parcels: &[Label],
+        base_dst: impl AsRef<Path>,
+        component: &str,
+    ) -> Result<DirectoryMount> {
+        log::info!(
+            "Mounting files from '{}' to '{}'",
+            self.id,
+            base_dst.as_ref().display()
+        );
+
+        let host = create_dir(&base_dst, component).await?;
+        let guest = "/".to_string();
+        self.copy_all(parcels, &host).await?;
+
+        Ok(DirectoryMount { host, guest })
+    }
+
+    async fn copy_all(&self, parcels: &[Label], dir: impl AsRef<Path>) -> Result<()> {
+        match future::join_all(parcels.iter().map(|p| self.copy(p, &dir)))
+            .await
+            .into_iter()
+            .filter_map(|r| r.err())
+            .map(|e| log::error!("{:?}", e))
+            .count()
+        {
+            0 => Ok(()),
+            n => bail!("Error copying assets: {} file(s) not copied", n),
+        }
+    }
+
+    /// Copy
+    async fn copy(&self, p: &Label, dir: impl AsRef<Path>) -> Result<()> {
+        let to = dir.as_ref().join(&p.name);
+
+        ensure_under(&dir, &to)?;
+
+        log::trace!(
+            "Copying asset file '{}@{}' -> '{}'",
+            self.id,
+            p.sha256,
+            to.display()
+        );
+        fs::create_dir_all(to.parent().expect("Cannot copy to file '/'")).await?;
+        let buf =
+            self.reader.get_parcel(&p.sha256).await.with_context(|| {
+                anyhow!("Failed to fetch asset parcel '{}@{}'", self.id, p.sha256)
+            })?;
+        fs::write(&to, &buf).await.with_context(|| {
+            anyhow!(
+                "Failed to write asset parcel '{}@{}' to {}",
+                self.id,
+                p.sha256,
+                to.display()
+            )
+        })?;
+        Ok(())
+    }
+}

--- a/crates/loader/src/bindle/config.rs
+++ b/crates/loader/src/bindle/config.rs
@@ -1,0 +1,41 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Application configuration file format.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RawAppManifest {
+    pub trigger: spin_config::ApplicationTrigger,
+
+    /// Configuration for the application components.
+    #[serde(rename = "component")]
+    pub components: Vec<RawComponentManifest>,
+}
+
+/// Core component configuration.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RawComponentManifest {
+    /// The module source.
+    pub source: String,
+    /// ID of the component. Used at runtime to select between
+    /// multiple components of the same application.
+    pub id: String,
+    /// Per-component WebAssembly configuration.
+    #[serde(flatten)]
+    pub wasm: RawWasmConfig,
+    /// Trigger configuration.
+    pub trigger: spin_config::TriggerConfig,
+}
+
+/// WebAssembly configuration.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RawWasmConfig {
+    /// Environment variables to be mapped inside the Wasm module at runtime.
+    pub environment: Option<HashMap<String, String>>,
+    /// The parcel group to be mapped inside the Wasm module at runtime.
+    pub files: Option<String>,
+    /// Optional list of HTTP hosts the component is allowed to connect.
+    pub allowed_http_hosts: Option<Vec<String>>,
+}

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -1,0 +1,147 @@
+//! Functionality to get a prepared Spin application from Bindle.
+
+#![deny(missing_docs)]
+
+/// Module to prepare the assets for the components of an application.
+mod assets;
+/// Configuration representation for a Spin apoplication in Bindle.
+mod config;
+/// Bindle helper functions.
+mod utils;
+
+use self::config::RawComponentManifest;
+use crate::bindle::{
+    config::RawAppManifest,
+    utils::{find_manifest, BindleReader, BindleTokenManager},
+};
+use anyhow::{anyhow, Context, Result};
+use bindle::{
+    client::{tokens::NoToken, Client},
+    Invoice,
+};
+use futures::future;
+use spin_config::{
+    ApplicationInformation, ApplicationOrigin, Configuration, CoreComponent, ModuleSource,
+    WasmConfig,
+};
+use std::path::{Path, PathBuf};
+use tracing::log;
+
+/// Given a Bindle server URL and reference, pull it, expand its assets locally, and get a
+/// prepared application configuration consumable by a Spin execution context.
+/// If a directory is provided, use it as the base directory to expand the assets,
+/// otherwise create a new temporary directory.
+pub async fn from_bindle(
+    id: &str,
+    url: &str,
+    base_dst: Option<PathBuf>,
+) -> Result<Configuration<CoreComponent>> {
+    // TODO
+    // Handle Bindle authentication.
+    let manager = BindleTokenManager::NoToken(NoToken);
+    let client = Client::new(url, manager)?;
+    let reader = BindleReader::remote(&client, &id.parse()?);
+
+    prepare(id, url, &reader, base_dst).await
+}
+
+async fn prepare(
+    id: &str,
+    url: &str,
+    reader: &BindleReader,
+    base_dst: Option<PathBuf>,
+) -> Result<Configuration<CoreComponent>> {
+    let dir = match base_dst {
+        Some(d) => d,
+        None => tempfile::tempdir()?.into_path(),
+    };
+
+    // first, get the invoice.
+    let invoice = reader
+        .get_invoice()
+        .await
+        .with_context(|| anyhow!("Failed to load invoice '{}' from '{}'", id, url))?;
+
+    // then, reconstruct application manifest from the parcel.
+    let raw: RawAppManifest =
+        toml::from_slice(&reader.get_parcel(&find_manifest(&invoice)?).await?)?;
+    log::trace!("Recreated manifest from bindle: {:?}", raw);
+
+    let info = info(&raw, &invoice, url);
+    log::trace!("Application information from bindle: {:?}", info);
+    let components = future::join_all(
+        raw.components
+            .into_iter()
+            .map(|c| async { core(c, &invoice, reader, &dir).await })
+            .collect::<Vec<_>>(),
+    )
+    .await
+    .into_iter()
+    .map(|x| x.expect("Cannot prepare component"))
+    .collect::<Vec<_>>();
+
+    Ok(Configuration { info, components })
+}
+
+async fn core(
+    raw: RawComponentManifest,
+    invoice: &Invoice,
+    reader: &BindleReader,
+    base_dst: impl AsRef<Path>,
+) -> Result<CoreComponent> {
+    let bytes = reader
+        .get_parcel(&raw.source)
+        .await
+        .with_context(|| anyhow!("Cannot get module source from bindle"))?;
+
+    let source = ModuleSource::Buffer(bytes);
+    let id = raw.id;
+    let parcels = invoice
+        .parcel
+        .as_ref()
+        .unwrap_or(&vec![])
+        .iter()
+        .map(|p| p.label.clone())
+        .collect::<Vec<_>>();
+    let mounts = match raw.wasm.files {
+        Some(_) => vec![
+            assets::prepare_component(reader, &invoice.bindle.id, &parcels, base_dst, &id).await?,
+        ],
+        None => vec![],
+    };
+    let environment = raw.wasm.environment.unwrap_or_default();
+    let allowed_http_hosts = raw.wasm.allowed_http_hosts.unwrap_or_default();
+    let wasm = WasmConfig {
+        environment,
+        mounts,
+        allowed_http_hosts,
+    };
+    let trigger = raw.trigger;
+
+    Ok(CoreComponent {
+        source,
+        id,
+        wasm,
+        trigger,
+    })
+}
+
+/// Convert the raw application manifest from the bindle invoice into the
+/// standard application configuration.
+fn info(raw: &RawAppManifest, invoice: &Invoice, url: &str) -> ApplicationInformation {
+    ApplicationInformation {
+        // TODO
+        // Handle API version and namespace.
+        api_version: "0.1.0".to_string(),
+        name: invoice.bindle.id.name().to_string(),
+        version: invoice.bindle.id.version_string(),
+        description: invoice.bindle.description.clone(),
+        authors: invoice.bindle.authors.clone().unwrap_or_default(),
+        trigger: raw.trigger.clone(),
+        namespace: None,
+        origin: ApplicationOrigin::Bindle {
+            id: invoice.bindle.id.to_string(),
+            server: url.to_string(),
+        },
+    }
+}

--- a/crates/loader/src/bindle/utils.rs
+++ b/crates/loader/src/bindle/utils.rs
@@ -1,0 +1,205 @@
+#![deny(missing_docs)]
+
+use anyhow::{anyhow, bail, Context, Result};
+use async_trait::async_trait;
+use bindle::{
+    client::{
+        self,
+        tokens::{NoToken, TokenManager},
+        Client,
+    },
+    standalone::StandaloneRead,
+    Id, Invoice, Label, Parcel,
+};
+use itertools::Itertools;
+use reqwest::RequestBuilder;
+use std::{fmt::Debug, path::Path, sync::Arc};
+use tokio::fs;
+
+static EMPTY: &Vec<bindle::Parcel> = &vec![];
+
+// Alternative to storing `spin.toml` as a parcel, this could be
+// distinguished it through a group, or an annotation.
+
+/// The media type of a `spin.toml` parcel as part of a bindle.
+pub(crate) const SPIN_MANIFEST_MEDIA_TYPE: &str = "application/vnd.fermyon.spin+toml";
+
+pub(crate) fn find_manifest(inv: &Invoice) -> Result<String> {
+    let parcels = inv
+        .parcel
+        .as_ref()
+        .unwrap_or(EMPTY)
+        .iter()
+        .filter_map(|p| {
+            if p.label.media_type == SPIN_MANIFEST_MEDIA_TYPE {
+                Some(&p.label)
+            } else {
+                None
+            }
+        })
+        .collect_vec();
+
+    match parcels.len() {
+        0 => bail!("Invoice does not contain a Spin manifest"),
+        1 => Ok(parcels[0].sha256.clone()),
+        _ => bail!("Invoice contains multiple Spin manifests"),
+    }
+}
+
+// This isn't currently transitive - I don't think we have a need for that
+// but could add it if we did (WAGI has code for this but it's a huge faff)
+#[allow(dead_code)]
+pub(crate) fn parcels_in_group(inv: &Invoice, group: &str) -> Vec<Label> {
+    inv.parcel
+        .as_ref()
+        .unwrap_or(EMPTY)
+        .iter()
+        .filter_map(|p| {
+            if is_member(p, group) {
+                Some(p.label.clone())
+            } else {
+                None
+            }
+        })
+        .collect_vec()
+}
+
+pub(crate) fn is_member(parcel: &Parcel, group: &str) -> bool {
+    if let Some(conditions) = &parcel.conditions {
+        if let Some(member_of) = &conditions.member_of {
+            return member_of.contains(&group.to_owned());
+        }
+    }
+    false
+}
+
+// What changes do we need to make to the schema?
+//
+// application information -> shouldn't this come from the invoice rather than the manifest
+//
+// component ->
+//   source -> should be a parcel sha
+//   files -> could be an array of parcel shas, or the name of a group
+
+/*
+
+name        = "spin-hello-world"
+version     = "1.0.0"
+description = "A simple application that returns hello and goodbye."
+authors     = [ "Radu Matei <radu@fermyon.com>" ]
+trigger     = "http"
+
+[[component]]
+    source = "parcel_parcel_parcel"
+    id     = "hello"
+    files = group_group_group
+[component.trigger]
+    route = "/hello"
+
+
+*/
+
+#[derive(Clone)]
+pub(crate) enum BindleTokenManager {
+    NoToken(NoToken),
+}
+
+#[async_trait]
+impl TokenManager for BindleTokenManager {
+    async fn apply_auth_header(&self, builder: RequestBuilder) -> client::Result<RequestBuilder> {
+        match self {
+            Self::NoToken(t) => t.apply_auth_header(builder).await,
+        }
+    }
+}
+
+impl Debug for BindleTokenManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoToken(_) => f.debug_tuple("NoToken").finish(),
+        }
+    }
+}
+
+/// Encapsulate a Bindle source.
+#[derive(Clone, Debug)]
+pub(crate) struct BindleReader {
+    inner: BindleReaderInner,
+}
+
+impl BindleReader {
+    /// Gets the content of a parcel from the bindle source.
+    pub(crate) async fn get_parcel(&self, id: &str) -> Result<Vec<u8>> {
+        match &self.inner {
+            BindleReaderInner::Remote(c, bindle_id) => c
+                .get_parcel(bindle_id, id)
+                .await
+                .with_context(|| anyhow!("Error fetching remote parcel {}@{}", bindle_id, id)),
+
+            BindleReaderInner::Standalone(s) => {
+                let path = s.parcel_dir.join(format!("{}.dat", id));
+                fs::read(&path).await.with_context(|| {
+                    anyhow!(
+                        "Error reading standalone parcel {} from {}",
+                        id,
+                        path.display()
+                    )
+                })
+            }
+        }
+    }
+
+    /// Get the invoice from the bindle source
+    pub(crate) async fn get_invoice(&self) -> Result<Invoice> {
+        match &self.inner {
+            BindleReaderInner::Remote(c, id) => c
+                .get_invoice(id)
+                .await
+                .with_context(|| anyhow!("Error fetching remote invoice {}", id)),
+
+            BindleReaderInner::Standalone(s) => {
+                let bytes = fs::read(&s.invoice_file).await.with_context(|| {
+                    anyhow!(
+                        "Error reading bindle invoice rom '{}'",
+                        s.invoice_file.display()
+                    )
+                })?;
+                toml::from_slice(&bytes).with_context(|| {
+                    anyhow!(
+                        "Error parsing file '{}' as invoice",
+                        s.invoice_file.display()
+                    )
+                })
+            }
+        }
+    }
+
+    pub(crate) fn remote(c: &Client<BindleTokenManager>, id: &Id) -> Self {
+        Self {
+            inner: BindleReaderInner::Remote(c.clone(), id.clone()),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn standalone(base_path: impl AsRef<Path>, id: &Id) -> Result<Self> {
+        let s = StandaloneRead::new(&base_path, id).await?;
+        Ok(Self {
+            inner: BindleReaderInner::Standalone(Arc::new(s)),
+        })
+    }
+}
+
+#[derive(Clone)]
+enum BindleReaderInner {
+    Standalone(Arc<StandaloneRead>),
+    Remote(Client<BindleTokenManager>, Id),
+}
+
+impl Debug for BindleReaderInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Standalone(_) => f.debug_tuple("Standalone").finish(),
+            Self::Remote(_, _) => f.debug_tuple("Remote").finish(),
+        }
+    }
+}

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -11,7 +11,11 @@
 #![deny(missing_docs)]
 
 mod assets;
+mod bindle;
 mod local;
 
 /// Load a Spin application configuration from a spin.toml manifest file.
 pub use local::from_file;
+
+/// Load a Spin application configuration from Bindle.
+pub use crate::bindle::from_bindle;

--- a/crates/loader/src/local/assets.rs
+++ b/crates/loader/src/local/assets.rs
@@ -29,9 +29,12 @@ pub(crate) async fn prepare_component(
     Ok(DirectoryMount { guest, host })
 }
 
-struct FileMount {
-    src: PathBuf,
-    relative_dst: String,
+/// A file that a component requires to be present at runtime.
+pub struct FileMount {
+    /// The source
+    pub src: PathBuf,
+    /// The location where the component expects the file.
+    pub relative_dst: String,
 }
 
 impl FileMount {

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -52,8 +52,6 @@ pub struct RawComponentManifest {
     /// multiple components of the same application.
     pub id: String,
     /// Per-component WebAssembly configuration.
-    /// This takes precedence over the application-level
-    /// WebAssembly configuration.
     #[serde(flatten)]
     pub wasm: RawWasmConfig,
     /// Trigger configuration.


### PR DESCRIPTION
This commit re-adds the ability to run applications given a bindle ID
and server URL.

This is still a draft, as static assets haven't been properly tested (ref https://github.com/fermyon/spin/pull/90#issuecomment-1047412505)

- [x] test static assets — partly done, managed to 
get an application with one file to work — further work needs coordinating with 
#90.


This is ready for review now.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>