### PR TITLE
Execute components in their own threads

### DIFF
--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -11,6 +11,7 @@ use std::{
     net::SocketAddr,
     sync::{Arc, RwLock},
 };
+use tokio::task::spawn_blocking;
 use tracing::log;
 use wasi_common::pipe::{ReadPipe, WritePipe};
 
@@ -95,7 +96,7 @@ impl HttpExecutor for WagiHttpExecutor {
                 )
             })?;
         tracing::trace!("Calling Wasm entry point");
-        start.call(&mut store, &[], &mut [])?;
+        spawn_blocking(move || start.call(&mut store, &[], &mut [])).await??;
         tracing::trace!("Module execution complete");
 
         wagi::handlers::compose_response(iostream.stdout.lock)


### PR DESCRIPTION
There seems to be a small avg performance hit, but interestingly it seems to actually be improving 95%ile latency under some loads:

```
# Without threading
$ bombardier -c 100 -n 1000 http://localhost:3001/blog/2022-02-08-hello-world -l
...
Statistics        Avg      Stdev        Max
  Reqs/sec       510.44     172.52    1625.29
  Latency      190.13ms    85.28ms   486.78ms
  Latency Distribution
     50%   191.04ms
     75%   232.21ms
     90%   305.27ms
     95%   352.63ms
     99%   422.41ms

# With threading
$ bombardier -c 100 -n 1000 http://localhost:3002/blog/2022-02-08-hello-world -l
...
Statistics        Avg      Stdev        Max
  Reqs/sec       405.53     258.79    1558.11
  Latency      242.72ms    59.96ms   415.87ms
  Latency Distribution
     50%   243.95ms
     75%   280.96ms
     90%   315.36ms
     95%   346.30ms
     99%   384.08ms
```