### PR TITLE
fix: improve error when component source not found

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -118,8 +118,9 @@ pub enum ModuleSource {
     /// A local path to the entrypoint Wasm module.
     FileReference(PathBuf),
 
-    /// A buffer that contains the entrypoint Wasm module.
-    Buffer(Vec<u8>),
+    /// A buffer that contains the entrypoint Wasm module and
+    /// source information.
+    Buffer(Vec<u8>, String),
 }
 
 impl Debug for ModuleSource {
@@ -128,9 +129,11 @@ impl Debug for ModuleSource {
             ModuleSource::FileReference(fp) => {
                 f.debug_struct("FileReference").field("file", fp).finish()
             }
-            ModuleSource::Buffer(bytes) => {
-                f.debug_struct("Buffer").field("len", &bytes.len()).finish()
-            }
+            ModuleSource::Buffer(bytes, info) => f
+                .debug_struct("Buffer")
+                .field("len", &bytes.len())
+                .field("info", info)
+                .finish(),
         }
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -109,20 +109,22 @@ impl<T: Default> Builder<T> {
                 ModuleSource::FileReference(p) => {
                     let module = Module::from_file(&self.engine, &p).with_context(|| {
                         format!(
-                            "Cannot create module for component {} from file {:?}",
-                            &c.id, &p
+                            "Cannot create module for component {} from file {}",
+                            &c.id,
+                            &p.display()
                         )
                     })?;
                     log::trace!("Created module for component {} from file {:?}", &c.id, &p);
                     module
                 }
-                ModuleSource::Buffer(bytes) => {
+                ModuleSource::Buffer(bytes, info) => {
                     let module = Module::from_binary(&self.engine, &bytes).with_context(|| {
-                        format!("Cannot create module for component {} from buffer", &c.id)
+                        format!("Cannot create module for component {} from {}", &c.id, info)
                     })?;
                     log::trace!(
-                        "Created module for component {} from buffer with size {}",
+                        "Created module for component {} from {} with size {}",
                         &c.id,
+                        info,
                         bytes.len()
                     );
                     module

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -96,7 +96,7 @@ async fn core(
         .await
         .with_context(|| anyhow!("Cannot get module source from bindle"))?;
 
-    let source = ModuleSource::Buffer(bytes);
+    let source = ModuleSource::Buffer(bytes, format!("parcel {}", raw.source));
     let id = raw.id;
     let parcels = invoice
         .parcel


### PR DESCRIPTION
closes #108 

This commit improves the error message returned to a user when the
source of a component is not found.
It also improves the trace info when instantiating components.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>