### PR TITLE
feat: add WASI outbound experimental HTTP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber 0.3.8",
  "wasi-common",
+ "wasi-experimental-http-wasmtime 0.9.0 (git+https://github.com/deislabs/wasi-experimental-http?rev=4ed321d6943f75546e38bba80e14a59797aa29de)",
  "wasmtime",
  "wasmtime-wasi",
  "wit-bindgen-rust",
@@ -3689,7 +3690,7 @@ dependencies = [
  "url-escape",
  "wasi-cap-std-sync",
  "wasi-common",
- "wasi-experimental-http-wasmtime",
+ "wasi-experimental-http-wasmtime 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-wasi",
@@ -3806,6 +3807,25 @@ name = "wasi-experimental-http-wasmtime"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2611669cdde1adfb2433ed99a175298a26f7f496da296b8d9dc88f99bb1d3b30"
+dependencies = [
+ "anyhow",
+ "bytes 1.1.0",
+ "futures",
+ "http 0.2.6",
+ "reqwest",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url 2.2.2",
+ "wasi-common",
+ "wasmtime",
+ "wasmtime-wasi",
+]
+
+[[package]]
+name = "wasi-experimental-http-wasmtime"
+version = "0.9.0"
+source = "git+https://github.com/deislabs/wasi-experimental-http?rev=4ed321d6943f75546e38bba80e14a59797aa29de#4ed321d6943f75546e38bba80e14a59797aa29de"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -27,6 +27,7 @@ tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
 wasi-common = "0.34"
+wasi-experimental-http-wasmtime = { git = "https://github.com/deislabs/wasi-experimental-http", rev = "4ed321d6943f75546e38bba80e14a59797aa29de" }
 wasmtime = "0.34"
 wasmtime-wasi = "0.34"
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e9c7c0a3405845cecd3fe06f3c20ab413302fc73" }


### PR DESCRIPTION
close #45 
depends on https://github.com/deislabs/wasi-experimental-http/pull/86

This commit adds support for making outbound HTTP requests using
https://github.com/deislabs/wasi-experimental-http.

Using the outbound HTTP example fromhttps://github.com/deislabs/wagi/tree/main/examples, 
(that makes a GET request to https://api.brigade.sh), this can be configured in 
Spin using the following manifest:

```toml
apiVersion = "0.1.0"
authors = ["Fermyon Engineering <engineering@fermyon.com>"]
name = "spin-outbound-http"
trigger = {type = "http", base = "/"}
version = "1.0.0"

[[component]]
id = "success"
source = "http-example.wasm"
allowedHttpHosts = ["https://api.brigade.sh"]
[component.trigger]
route = "/success"
executor = { type = "wagi" }

[[component]]
id = "fail"
source = "http-example.wasm"
allowedHttpHosts = [""]
[component.trigger]
route = "/fail"
executor = { type = "wagi" }
```

Running this with Spin:

```
 ➜ curl -i localhost:3000/success         
HTTP/1.1 200 OK
content-type: text/plain
content-length: 123
date: Mon, 28 Feb 2022 17:27:17 GMT

api.brigade.sh is HEALTHY
The health check response had 4 header(s)
Its content type was: text/html
Its body content was: 

➜ curl -i localhost:3000/fail   
HTTP/1.1 500 Internal Server Error
content-length: 0
date: Mon, 28 Feb 2022 17:27:20 GMT
```

Signed-off-by: Radu Matei <radu.matei@fermyon.com>