### PR TITLE
Mount directory at path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,6 +2987,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber 0.3.8",
+ "walkdir",
 ]
 
 [[package]]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -26,3 +26,4 @@ toml = "0.5"
 tracing = { version = "0.1", features = [ "log" ] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = [ "env-filter" ] }
+walkdir = "2.3.2"

--- a/crates/loader/src/local/assets.rs
+++ b/crates/loader/src/local/assets.rs
@@ -6,31 +6,34 @@ use futures::future;
 use spin_config::DirectoryMount;
 use std::path::{Path, PathBuf};
 use tracing::log;
+use walkdir::WalkDir;
+
+use super::config::{RawDirectoryPlacement, RawFileMount};
 
 /// Prepare all local assets given a component ID and its file patterns.
 /// This file will copy all assets into a temporary directory as read-only.
 pub(crate) async fn prepare_component(
-    patterns: &[String],
+    raw_mounts: &[RawFileMount],
     src: impl AsRef<Path>,
     base_dst: impl AsRef<Path>,
     id: &str,
-) -> Result<DirectoryMount> {
+) -> Result<Vec<DirectoryMount>> {
     log::info!(
         "Mounting files from '{}' to '{}'",
         src.as_ref().display(),
         base_dst.as_ref().display()
     );
 
-    let files = collect(patterns, src)?;
+    let files = collect(raw_mounts, src)?;
     let host = create_dir(&base_dst, id).await?;
     let guest = "/".to_string();
     copy_all(&files, &host).await?;
 
-    Ok(DirectoryMount { guest, host })
+    Ok(vec![DirectoryMount { guest, host }])
 }
 
 /// A file that a component requires to be present at runtime.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FileMount {
     /// The source
     pub src: PathBuf,
@@ -41,17 +44,52 @@ pub struct FileMount {
 impl FileMount {
     fn from(
         src: Result<impl AsRef<Path>, glob::GlobError>,
-        relative_dst: impl AsRef<Path>,
+        relative_to: impl AsRef<Path>,
     ) -> Result<Self> {
         let src = src?;
-        let relative_dst = to_relative(&src, &relative_dst)?;
+        let relative_dst = to_relative(&src, &relative_to)?;
         let src = src.as_ref().to_path_buf();
+        Ok(Self { src, relative_dst })
+    }
+
+    fn from_exact(src: impl AsRef<Path>, dest: impl AsRef<Path>) -> Result<Self> {
+        let src = src.as_ref().to_path_buf();
+        let relative_dst = dest.as_ref().to_string_lossy().to_string();
         Ok(Self { src, relative_dst })
     }
 }
 
 /// Generate a vector of file mounts for a component given all its file patterns.
-pub fn collect(patterns: &[String], rel: impl AsRef<Path>) -> Result<Vec<FileMount>> {
+pub fn collect(raw_mounts: &[RawFileMount], rel: impl AsRef<Path>) -> Result<Vec<FileMount>> {
+    let (patterns, placements) = uncase(raw_mounts);
+
+    let pattern_files = collect_patterns(&patterns, &rel)?;
+    let placement_files = collect_placements(&placements, &rel)?;
+    let all_files = [pattern_files, placement_files].concat();
+    Ok(all_files)
+}
+
+fn collect_placements(
+    placements: &[RawDirectoryPlacement],
+    rel: impl AsRef<Path>,
+) -> Result<Vec<FileMount>, anyhow::Error> {
+    let results = placements.iter().map(|placement| {
+        collect_placement(placement, &rel).with_context(|| {
+            format!(
+                "Failed to collect file mounts for {}",
+                placement.source.display()
+            )
+        })
+    });
+    let collections = results.collect::<Result<Vec<_>>>()?;
+    let collection = collections.into_iter().flatten().collect();
+    Ok(collection)
+}
+
+fn collect_patterns(
+    patterns: &[String],
+    rel: impl AsRef<Path>,
+) -> Result<Vec<FileMount>, anyhow::Error> {
     let results = patterns.iter().map(|pattern| {
         collect_pattern(pattern, &rel)
             .with_context(|| format!("Failed to collect file mounts for {}", pattern))
@@ -59,6 +97,69 @@ pub fn collect(patterns: &[String], rel: impl AsRef<Path>) -> Result<Vec<FileMou
     let collections = results.collect::<Result<Vec<_>>>()?;
     let collection = collections.into_iter().flatten().collect();
     Ok(collection)
+}
+
+fn collect_placement(
+    placement: &RawDirectoryPlacement,
+    rel: impl AsRef<Path>,
+) -> Result<Vec<FileMount>> {
+    let source = &placement.source;
+    let guest_path = &placement.destination;
+
+    if !source.is_relative() {
+        bail!(
+            "Cannot place {}: source paths must be relative",
+            source.display()
+        );
+    }
+    // TODO: check if this works if the host is Windows
+    if !guest_path.is_absolute() {
+        bail!(
+            "Cannot place {}: guest paths must be absolute",
+            guest_path.display()
+        );
+    }
+    // TODO: okay to assume that absolute guest paths start with '/'?
+    let relative_guest_path = guest_path.strip_prefix("/")?;
+
+    let abs = rel.as_ref().join(source);
+    if !abs.is_dir() {
+        bail!("Cannot place {}: source must be a directory", abs.display());
+    }
+
+    let walker = WalkDir::new(&abs);
+    let files = walker
+        .into_iter()
+        .filter_map(|de| match de {
+            Err(e) => Some(
+                Err(e).with_context(|| format!("Failed to walk directory under {}", abs.display())),
+            ),
+            Ok(dir_entry) => {
+                if dir_entry.file_type().is_file() {
+                    let match_path = dir_entry.path();
+                    match to_relative(match_path, &abs) {
+                        Ok(relative_to_match_root_dst) => {
+                            let guest_dst = relative_guest_path.join(relative_to_match_root_dst);
+                            Some(FileMount::from_exact(match_path, &guest_dst))
+                        }
+                        Err(e) => {
+                            let err = Err(e).with_context(|| {
+                                format!(
+                                    "Failed to establish relative path for '{}'",
+                                    match_path.display()
+                                )
+                            });
+                            Some(err)
+                        }
+                    }
+                } else {
+                    None
+                }
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(files)
 }
 
 /// Generate a vector of file mounts given a file pattern.
@@ -114,4 +215,24 @@ async fn copy(file: &FileMount, dir: impl AsRef<Path>) -> Result<()> {
     tokio::fs::set_permissions(&to, perms).await?;
 
     Ok(())
+}
+
+fn uncase(raw_mounts: &[RawFileMount]) -> (Vec<String>, Vec<RawDirectoryPlacement>) {
+    (
+        raw_mounts.iter().filter_map(as_pattern).collect(),
+        raw_mounts.iter().filter_map(as_placement).collect(),
+    )
+}
+
+fn as_pattern(fm: &RawFileMount) -> Option<String> {
+    match fm {
+        RawFileMount::Pattern(p) => Some(p.to_owned()),
+        _ => None,
+    }
+}
+fn as_placement(fm: &RawFileMount) -> Option<RawDirectoryPlacement> {
+    match fm {
+        RawFileMount::Placement(p) => Some(p.clone()),
+        _ => None,
+    }
 }

--- a/crates/loader/src/local/config.rs
+++ b/crates/loader/src/local/config.rs
@@ -73,11 +73,34 @@ pub struct RawWasmConfig {
     pub environment: Option<HashMap<String, String>>,
     /// Files to be mapped inside the Wasm module at runtime.
     ///
-    /// In the local configuration file, this is a vector or file paths or
-    /// globs relative to the spin.toml file.
-    pub files: Option<Vec<String>>,
+    /// In the local configuration file, this is a vector, each element of which
+    /// is either a file paths or glob relative to the spin.toml file, or a
+    /// mapping of a source path to an absolute mount path in the guest.
+    pub files: Option<Vec<RawFileMount>>,
     /// Optional list of HTTP hosts the component is allowed to connect.
     pub allowed_http_hosts: Option<Vec<String>>,
+}
+
+/// An entry in the `files` list mapping a source path to an absolute
+/// mount path in the guest.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct RawDirectoryPlacement {
+    /// The source to mount.
+    pub source: PathBuf,
+    /// Where to mount the directory specified in `source`.
+    pub destination: PathBuf,
+}
+
+/// A specification for a file or set of files to mount in the
+/// Wasm module.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase", untagged)]
+pub enum RawFileMount {
+    /// Mount a specified directory at a specified location.
+    Placement(RawDirectoryPlacement),
+    /// Mount a file or set of files at their relative path.
+    Pattern(String),
 }
 
 /// Source for the module.

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -81,8 +81,8 @@ async fn prepare(
     )
     .await
     .into_iter()
-    .map(|x| x.expect("Cannot prepare component."))
-    .collect::<Vec<_>>();
+    .collect::<Result<Vec<_>>>()
+    .context("Failed to prepare configuration")?;
 
     Ok(Configuration { info, components })
 }
@@ -113,7 +113,7 @@ async fn core(
 
     let id = raw.id;
     let mounts = match raw.wasm.files {
-        Some(f) => vec![assets::prepare_component(&f, src, &base_dst, &id).await?],
+        Some(f) => assets::prepare_component(&f, src, &base_dst, &id).await?,
         None => vec![],
     };
     let environment = raw.wasm.environment.unwrap_or_default();

--- a/crates/loader/src/local/tests.rs
+++ b/crates/loader/src/local/tests.rs
@@ -1,4 +1,4 @@
-use crate::local::config::RawModuleSource;
+use crate::local::config::{RawDirectoryPlacement, RawFileMount, RawModuleSource};
 
 use super::*;
 use anyhow::Result;
@@ -67,9 +67,19 @@ fn test_manifest() -> Result<()> {
     assert_eq!(test_env.get("env2").unwrap(), "second");
 
     let test_files = &test_component.wasm.files.as_ref().unwrap();
-    assert_eq!(test_files.len(), 2);
-    assert_eq!(test_files[0], "file.txt");
-    assert_eq!(test_files[1], "subdir/another.txt");
+    assert_eq!(test_files.len(), 3);
+    assert_eq!(test_files[0], RawFileMount::Pattern("file.txt".to_owned()));
+    assert_eq!(
+        test_files[1],
+        RawFileMount::Placement(RawDirectoryPlacement {
+            source: PathBuf::from("valid-with-files"),
+            destination: PathBuf::from("/vwf"),
+        })
+    );
+    assert_eq!(
+        test_files[2],
+        RawFileMount::Pattern("subdir/another.txt".to_owned())
+    );
 
     let b = match cfg.components[1].source.clone() {
         RawModuleSource::Bindle(b) => b,

--- a/crates/loader/tests/valid-manifest.toml
+++ b/crates/loader/tests/valid-manifest.toml
@@ -6,7 +6,7 @@ trigger = {type = "http", base = "/"}
 version = "6.11.2"
 
 [[component]]
-files = ["file.txt", "subdir/another.txt"]
+files = ["file.txt", { source = "valid-with-files", destination = "/vwf" }, "subdir/another.txt"]
 id = "four-lights"
 source = "path/to/wasm/file.wasm"
 [component.trigger]

--- a/crates/publish/src/bindle_writer.rs
+++ b/crates/publish/src/bindle_writer.rs
@@ -89,7 +89,7 @@ impl BindleWriter {
 }
 
 #[derive(Debug, Clone)]
-struct ParcelSource {
+pub struct ParcelSource {
     digest: String,
     source_path: PathBuf,
 }
@@ -115,6 +115,17 @@ impl ParcelSources {
         Self {
             sources: vec![parcel_source],
         }
+    }
+
+    pub fn from_iter(paths: impl Iterator<Item = (String, impl AsRef<Path>)>) -> Self {
+        let sources = paths
+            .map(|(digest, path)| ParcelSource {
+                digest,
+                source_path: path.as_ref().to_owned(),
+            })
+            .collect();
+
+        Self { sources }
     }
 }
 


### PR DESCRIPTION
Fixes #106.

This proposes a new syntax in the `spin.toml` `files` field:

```
[[component]]
files = [{ source = "img", guestPath = "/assets/images" }]
```

The `source` property must be directory.

This 'placement' syntax can be mixed with the existing pattern syntax.


```
[[component]]
files = ["common/common.css", { source = "dist/css", guestPath = "/styles" }]
```

Note that the behaviour is still that the files are _snapshot copied_ to the component asset folder: the directory is _not_ mounted directly.  This is to ensure consistency with bindle deployments, where only snapshots will be available and there will be no access to a shared host directory.

cc @adamreese @technosophos - is this going to meet your needs?  (I did post about it on the issue you raised but not sure what you felt.)

@radu-matei the code feels rather hamfisted to me, but I am in a fog and can't see why, so would welcome any thoughts on structuring it better - thanks!