### PR TITLE
fix: update release URL for Bindle in GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: engineerd/configurator@v0.0.8
         with:
           name: "bindle-server"
-          url: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-linux-amd64.tar.gz"
+          url: "https://github.com/deislabs/bindle/releases/download/v0.8.0/bindle-v0.8.0-linux-amd64.tar.gz"
           pathInArchive: "bindle-server"
 
       - name: Build


### PR DESCRIPTION
This commit updates the download URL for the Bindle server to mitigate
the missing blobs from the Bindle releases in Azure Storage.
Ideally, the referenced blob should be restored, but in the meantime,
this fixes the failing builds.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>