### PR TITLE
chore: add GitHub Action for Rust compilation cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,9 @@ jobs:
           url: "https://github.com/deislabs/bindle/releases/download/v0.8.0/bindle-v0.8.0-linux-amd64.tar.gz"
           pathInArchive: "bindle-server"
 
-      - name: Build
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Cargo Build
         run: cargo build
       - name: Cargo Test
         run:


### PR DESCRIPTION
This PR attempts to add a GitHub Action that caches the Rust compilation 
for the dependencies.
Theoretically, this should improve CI times.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>