### PR TITLE
fix: make temp an option for `spin up` and not mark copied assets as readonly

### DIFF
--- a/crates/loader/src/local/assets.rs
+++ b/crates/loader/src/local/assets.rs
@@ -210,8 +210,8 @@ async fn copy(file: &FileMount, dir: impl AsRef<Path>) -> Result<()> {
         .await
         .with_context(|| anyhow!("Error copying asset file  '{}'", from.display()))?;
 
-    let mut perms = tokio::fs::metadata(&to).await?.permissions();
-    perms.set_readonly(true);
+    let perms = tokio::fs::metadata(&to).await?.permissions();
+    // perms.set_readonly(true);
     tokio::fs::set_permissions(&to, perms).await?;
 
     Ok(())

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -51,8 +51,8 @@ pub struct UpCommand {
         env = BINDLE_URL_ENV,
     )]
     pub server: Option<String>,
-    /// Temorary directory for the static assets of the components.
-    #[structopt()]
+    /// Temporary directory for the static assets of the components.
+    #[structopt(long = "temp")]
     pub tmp: Option<PathBuf>,
     /// Pass an environment variable (key=value) to all components of the application.
     #[structopt(long = "env", short = "e", parse(try_from_str = parse_env_var))]


### PR DESCRIPTION
This commit fixes running `spin up ... --temp <some-dir>`, which was
broken for two reasons:

- the path was a positional argument rather than a named option
- because assets were copied as read-only, files could not get updated,
consecutive runs resulting in errors.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>