### PR TITLE
fixed the content-type requirement

### DIFF
--- a/examples/http-tinygo/main.go
+++ b/examples/http-tinygo/main.go
@@ -9,6 +9,10 @@ import (
 
 func main() {
 	spin_http.HandleRequest(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprintln(w, "Hello, Fermyon!")
+		header := w.Header()
+		header.Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintf(w, "\n")
+
+		fmt.Fprintln(w, "Hello, world!")
 	})
 }


### PR DESCRIPTION
Signed-off-by: ralph squillace <ralph@squillace.com>

just fixing up the sample. throws 500 errors without the content-type header attached in WSL2, ubuntu 20.04.