### PR TITLE
ref(crates/engine): sanitize log file paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,6 +2603,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanitize-filename"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf18934a12018228c5b55a6dae9df5d0641e3566b3630cb46cc55564068e7c2f"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +2970,7 @@ dependencies = [
  "anyhow",
  "bytes 1.1.0",
  "dirs 4.0.0",
+ "sanitize-filename",
  "spin-config",
  "tempfile",
  "tokio",

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Fermyon Engineering <engineering@fermyon.com>"]
 anyhow = "1.0.44"
 bytes = "1.1.0"
 dirs = "4.0"
+sanitize-filename = "0.3.0"
 spin-config = { path = "../config" }
 tempfile = "3.3.0"
 tokio = { version = "1.10.0", features = [ "fs" ] }


### PR DESCRIPTION
This commit adds logic that sanitizes the log file path.
Two log files are created for every component (one for
stderr, one for stdout) and the default path for these
files is generated using the app name and the component id.
Both the app name and the component id are sanitized before
being added to any paths. This helps us bypass issues related
to a user inputing app names and component ids which may contain
unsafe characters or characters that will have unintended
consequences if used as part of a path.

resolves #163

Signed-off-by: Michelle Dhanani <michelle@fermyon.com>