### PR TITLE
Log guest output before returning a failure

### DIFF
--- a/crates/http/src/spin.rs
+++ b/crates/http/src/spin.rs
@@ -42,15 +42,22 @@ impl HttpExecutor for SpinHttpExecutor {
         let (store, instance) =
             engine.prepare_component(component, None, Some(io_redirects.clone()), None, None)?;
 
-        let res = Self::execute_impl(store, instance, base, raw_route, req).await?;
+        let resp_result = Self::execute_impl(store, instance, base, raw_route, req).await;
 
-        engine.save_output_to_logs(io_redirects, component, true, true)?;
+        let log_result = engine.save_output_to_logs(io_redirects, component, true, true);
+
+        // Defer checking for failures until here so that the logging runs
+        // even if the guest code fails. (And when checking, check the guest
+        // result first, so that guest failures are returned in preference to
+        // log failures.)
+        let resp = resp_result?;
+        log_result?;
 
         log::info!(
             "Request finished, sending response with status code {}",
-            res.status()
+            resp.status()
         );
-        Ok(res)
+        Ok(resp)
     }
 }
 


### PR DESCRIPTION
Fixes #161.

Note this does not address the panic scenario.  We can probably get away without this in the WAGI case because the `call` method only panics under specific circumstances which we should never encounter.  This isn't _quite_ so clear in the Spin case, so it would be nice to address that; however, there are structures in play that make it hard to put a `catch_unwind` around the guest call.  So we'll need to discuss whether that's an acceptable compromise for now.