### PR TITLE
chore: move verbose logs to tracing

### DIFF
--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -141,7 +141,7 @@ impl<T: Default> Builder<T> {
             };
 
             let pre = Arc::new(self.linker.instantiate_pre(&mut self.store, &module)?);
-            log::debug!("Created pre-instance from module for component {}.", &c.id);
+            log::trace!("Created pre-instance from module for component {}.", &c.id);
 
             components.insert(c.id.clone(), Component { core, pre });
         }
@@ -201,7 +201,7 @@ impl<T: Default> ExecutionContext<T> {
         env: Option<HashMap<String, String>>,
         args: Option<Vec<String>>,
     ) -> Result<(Store<RuntimeContext<T>>, Instance)> {
-        log::debug!("Preparing component {}", component);
+        log::trace!("Preparing component {}", component);
         let component = match self.components.get(component) {
             Some(c) => c,
             None => bail!("Cannot find component {}", component),
@@ -244,7 +244,7 @@ impl<T: Default> ExecutionContext<T> {
 
         std::fs::create_dir_all(&log_dir)?;
 
-        log::debug!("Saving logs to {:?} {:?}", stdout_filename, stderr_filename);
+        log::trace!("Saving logs to {:?} {:?}", stdout_filename, stderr_filename);
 
         if save_stdout {
             let mut file = std::fs::OpenOptions::new()
@@ -277,7 +277,7 @@ impl<T: Default> ExecutionContext<T> {
         env: Option<HashMap<String, String>>,
         args: Option<Vec<String>>,
     ) -> Result<Store<RuntimeContext<T>>> {
-        log::debug!("Creating store.");
+        log::trace!("Creating store.");
         let (env, dirs) = Self::wasi_config(component, env)?;
         let mut ctx = RuntimeContext::default();
         let mut wasi_ctx = WasiCtxBuilder::new()

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -76,7 +76,7 @@ impl HttpTrigger {
 
         let engine = Arc::new(Builder::build_default(config).await?);
         let router = Router::build(&app)?;
-        log::debug!("Created new HTTP trigger.");
+        log::trace!("Created new HTTP trigger.");
 
         Ok(Self {
             address,

--- a/crates/http/src/wagi.rs
+++ b/crates/http/src/wagi.rs
@@ -99,7 +99,7 @@ impl HttpExecutor for WagiHttpExecutor {
             })?;
         tracing::trace!("Calling Wasm entry point");
         let guest_result = spawn_blocking(move || start.call(&mut store, &[], &mut [])).await;
-        tracing::trace!("Module execution complete");
+        tracing::info!("Module execution complete");
 
         let log_result = engine.save_output_to_logs(iostream.clone(), component, false, true);
 

--- a/crates/loader/src/local/assets.rs
+++ b/crates/loader/src/local/assets.rs
@@ -165,7 +165,7 @@ fn collect_placement(
 /// Generate a vector of file mounts given a file pattern.
 fn collect_pattern(pattern: &str, rel: impl AsRef<Path>) -> Result<Vec<FileMount>> {
     let abs = rel.as_ref().join(pattern);
-    log::debug!("Resolving asset file pattern '{:?}'", abs);
+    log::trace!("Resolving asset file pattern '{:?}'", abs);
 
     let matches = glob::glob(&abs.to_string_lossy())?;
     let specifiers = matches

--- a/crates/redis/src/lib.rs
+++ b/crates/redis/src/lib.rs
@@ -45,7 +45,7 @@ impl RedisTrigger {
             config.wasmtime = wasmtime;
         };
         let engine = Arc::new(Builder::build_default(config).await?);
-        log::debug!("Created new Redis trigger.");
+        log::trace!("Created new Redis trigger.");
 
         let subscriptions =
             app.components
@@ -90,7 +90,7 @@ impl RedisTrigger {
         loop {
             match stream.next().await {
                 Some(msg) => drop(self.handle(msg).await),
-                None => log::debug!("Empty message"),
+                None => log::trace!("Empty message"),
             };
         }
     }

--- a/crates/templates/src/lib.rs
+++ b/crates/templates/src/lib.rs
@@ -64,7 +64,7 @@ impl TemplatesManager {
     /// Adds the given templates repository locally and offline by cloning it.
     pub fn add_repo(&self, name: &str, url: &str, branch: Option<&str>) -> Result<()> {
         let dst = &self.root.join(TEMPLATES_DIR).join(name);
-        log::debug!("adding repository {} to {:?}", url, dst);
+        log::trace!("adding repository {} to {:?}", url, dst);
 
         match branch {
             Some(b) => RepoBuilder::new().branch(b).clone(url, dst)?,
@@ -83,7 +83,7 @@ impl TemplatesManager {
             .join(LOCAL_TEMPLATES)
             .join(TEMPLATES_DIR)
             .join(name);
-        log::debug!("adding local template from {:?} to {:?}", src, dst);
+        log::trace!("adding local template from {:?} to {:?}", src, dst);
 
         symlink::symlink_dir(src, dst)?;
         Ok(())
@@ -161,7 +161,7 @@ impl TemplatesManager {
     /// Ensure the root directory exists, or else create it.
     async fn ensure(root: &Path) -> Result<()> {
         if !root.exists() {
-            log::debug!("creating cache root directory `{}`", root.display());
+            log::trace!("Creating cache root directory `{}`", root.display());
             fs::create_dir_all(root).await.with_context(|| {
                 format!("failed to create cache root directory `{}`", root.display())
             })?;
@@ -171,7 +171,7 @@ impl TemplatesManager {
                 root.display()
             );
         } else {
-            log::debug!("using existing cache root directory `{}`", root.display());
+            log::trace!("Using existing cache root directory `{}`", root.display());
         }
 
         Ok(())

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
     "sass": "^1.49.9"
   },
   "scripts": {
-    "spin": "nodemon --watch content --watch static --watch templates --ext md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'RUST_LOG=spin=trace spin up --file spin.toml'",
+    "spin": "nodemon --watch content --watch static --watch templates --ext md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'spin up --file spin.toml'",
     "styles": "npx parcel build static/sass/styles.scss --dist-dir static/css --no-optimize"
   }
 }


### PR DESCRIPTION
This commit updates a few logs that polluted the log files from debug
to tracing.

This means there are exactly two info / debug log lines per request
instead of dumping the request headers every time:

```
$ spin up --file spin.toml
INFO spin_loader::local::assets: Mounting files from X  to Y
INFO spin_loader::local::assets: Mounting files from X to Y
INFO spin_http_engine: Serving HTTP on address 127.0.0.1:3000

INFO spin_http_engine: Processing request for application spin-docs on URI https://localhost:3000/
INFO spin_http_engine::wagi: Module execution complete
```

Signed-off-by: Radu Matei <radu.matei@fermyon.com>