### PR TITLE
Run unit tests even if integration tests fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
 name: Rust
 on:
   push:
@@ -104,7 +106,7 @@ jobs:
 
       - name: Cargo Test
         run:
-          cargo test --workspace --all-targets --all-features -- --nocapture
+          cargo test --workspace --all-targets --all-features --no-fail-fast -- --nocapture
         env:
           RUST_LOG: spin=trace
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ build:
 
 .PHONY: test
 test:
-	RUST_LOG=$(LOG_LEVEL) cargo test --all -- --nocapture
+	RUST_LOG=$(LOG_LEVEL) cargo test --all --no-fail-fast -- --nocapture
 	cargo clippy --all-targets --all-features -- -D warnings
 	cargo fmt --all -- --check
 


### PR DESCRIPTION
Because they often do on local dev boxes where we are not bindled.