### PR TITLE
ci: Fix clippy not checking all crates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,21 +91,22 @@ jobs:
       #     ./Configure enable-rc5 zlib darwin64-arm64-cc no-asm --prefix=$OPENSSL_DIR --openssldir=$OPENSSL_DIR shared
       #     sudo make install
 
-      - name: Cargo Build
-        run: cargo build
-
-      - name: Cargo Test
-        run:
-          cargo test --all --all-features -- --nocapture
-        env:
-          RUST_LOG: spin=trace
-
-      - name: Cargo Clippy
-        run:
-          cargo clippy --all-targets --all-features -- -D warnings
       - name: Cargo Format
         run:
           cargo fmt --all -- --check
+
+      - name: Cargo Clippy
+        run:
+          cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+      - name: Cargo Build
+        run: cargo build --workspace --all-targets --all-features
+
+      - name: Cargo Test
+        run:
+          cargo test --workspace --all-targets --all-features -- --nocapture
+        env:
+          RUST_LOG: spin=trace
 
     # Cancel in-progress runs for PRs
     # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/examples/spin-timer-echo/src/lib.rs
+++ b/examples/spin-timer-echo/src/lib.rs
@@ -1,3 +1,6 @@
+// The wit_bindgen_wasmtime::import below is triggering this lint
+#![allow(clippy::needless_question_mark)]
+
 use anyhow::Result;
 use spin_config::{Configuration, CoreComponent};
 use spin_engine::{Builder, ExecutionContextConfiguration};


### PR DESCRIPTION
Missing `--workspace` meant clippy was only checking crates that were
dependents of the root spin-cli crate.

Updated other CI steps for consistent coverage.

Reordered CI steps so that lint/formatting errors will fail faster.