### PR TITLE
Refactor trigger configuration

### DIFF
--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -34,7 +34,7 @@ impl Router {
             .components
             .iter()
             .map(|c| {
-                let trigger = c.trigger.as_http().unwrap();
+                let trigger = app.component_triggers.get(c).unwrap().as_http().unwrap();
                 (
                     RoutePattern::from(&app_trigger.base, &trigger.route),
                     c.clone(),
@@ -334,10 +334,6 @@ mod route_tests {
         CoreComponent {
             id: id.to_string(),
             source: spin_config::ModuleSource::FileReference("FAKE".into()),
-            trigger: spin_config::TriggerConfig::Http(spin_config::HttpConfig {
-                route: "/test".to_string(),
-                executor: Some(spin_config::HttpExecutor::Spin),
-            }),
             wasm: spin_config::WasmConfig::default(),
         }
     }

--- a/crates/loader/src/bindle/mod.rs
+++ b/crates/loader/src/bindle/mod.rs
@@ -65,6 +65,11 @@ async fn prepare(
 
     let info = info(&raw, &invoice, url);
     log::trace!("Application information from bindle: {:?}", info);
+    let component_triggers = raw
+        .components
+        .iter()
+        .map(|c| (c.id.clone(), c.trigger.clone()))
+        .collect();
     let components = future::join_all(
         raw.components
             .into_iter()
@@ -76,7 +81,11 @@ async fn prepare(
     .map(|x| x.expect("Cannot prepare component"))
     .collect::<Vec<_>>();
 
-    Ok(Application { info, components })
+    Ok(Application {
+        info,
+        components,
+        component_triggers,
+    })
 }
 
 /// Given a raw component manifest, prepare its assets and return a fully formed core component.
@@ -113,14 +122,7 @@ async fn core(
         mounts,
         allowed_http_hosts,
     };
-    let trigger = raw.trigger;
-
-    Ok(CoreComponent {
-        source,
-        id,
-        wasm,
-        trigger,
-    })
+    Ok(CoreComponent { source, id, wasm })
 }
 
 /// Converts the raw application manifest from the bindle invoice into the

--- a/crates/loader/src/local/mod.rs
+++ b/crates/loader/src/local/mod.rs
@@ -71,6 +71,11 @@ async fn prepare(
 ) -> Result<Application<CoreComponent>> {
     let info = info(raw.info, &src);
 
+    let component_triggers = raw
+        .components
+        .iter()
+        .map(|c| (c.id.clone(), c.trigger.clone()))
+        .collect();
     let components = future::join_all(
         raw.components
             .into_iter()
@@ -82,7 +87,11 @@ async fn prepare(
     .collect::<Result<Vec<_>>>()
     .context("Failed to prepare configuration")?;
 
-    Ok(Application { info, components })
+    Ok(Application {
+        info,
+        components,
+        component_triggers,
+    })
 }
 
 /// Given a raw component manifest, prepare its assets and return a fully formed core component.
@@ -121,14 +130,7 @@ async fn core(
         mounts,
         allowed_http_hosts,
     };
-    let trigger = raw.trigger;
-
-    Ok(CoreComponent {
-        source,
-        id,
-        wasm,
-        trigger,
-    })
+    Ok(CoreComponent { source, id, wasm })
 }
 
 /// Converts the raw application information from the spin.toml manifest to the standard configuration.

--- a/crates/redis/src/tests.rs
+++ b/crates/redis/src/tests.rs
@@ -28,7 +28,7 @@ async fn test_pubsub() -> Result<()> {
         })
         .build_configuration();
 
-    let trigger = RedisTrigger::new(cfg, None, None).await?;
+    let trigger = RedisTrigger::new(cfg, None).await?;
 
     // TODO
     // use redis::{FromRedisValue, Msg, Value};

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -75,10 +75,6 @@ impl TestConfig {
         CoreComponent {
             source: ModuleSource::FileReference(module_path),
             id: "test-component".to_string(),
-            trigger: self
-                .trigger_config
-                .clone()
-                .expect("http_trigger or redis_trigger required"),
             wasm: Default::default(),
         }
     }
@@ -87,11 +83,19 @@ impl TestConfig {
         Application {
             info: self.build_application_information(),
             components: vec![self.build_component()],
+            component_triggers: [(
+                "test-component".to_string(),
+                self.trigger_config
+                    .clone()
+                    .expect("http_trigger or redis_trigger required"),
+            )]
+            .into_iter()
+            .collect(),
         }
     }
 
     pub async fn build_http_trigger(&self) -> HttpTrigger {
-        HttpTrigger::new("".to_string(), self.build_configuration(), None, None, None)
+        HttpTrigger::new("".to_string(), self.build_configuration(), None, None)
             .await
             .expect("failed to build HttpTrigger")
     }

--- a/docs/content/extending-and-embedding.md
+++ b/docs/content/extending-and-embedding.md
@@ -56,14 +56,11 @@ Let's have a look at building the timer trigger:
 wit_bindgen_wasmtime::import!("spin-timer.wit");
 type ExecutionContext = spin_engine::ExecutionContext<spin_timer::SpinTimerData>;
 
-/// A custom timer trigger that executes the
-/// first component of an application on every interval.
+/// A custom timer trigger that executes a component on every interval.
 #[derive(Clone)]
 pub struct TimerTrigger {
     /// The interval at which the component is executed.
     pub interval: Duration,
-    /// The application configuration.
-    app: Application<CoreComponent>,
     /// The Spin execution context.
     engine: Arc<ExecutionContext>,
 }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -130,11 +130,11 @@ impl UpCommand {
 
         match &app.info.trigger {
             ApplicationTrigger::Http(_) => {
-                let trigger = HttpTrigger::new(self.address, app, None, tls, self.log).await?;
+                let trigger = HttpTrigger::new(self.address, app, tls, self.log).await?;
                 trigger.run().await?;
             }
             ApplicationTrigger::Redis(_) => {
-                let trigger = RedisTrigger::new(app, None, self.log).await?;
+                let trigger = RedisTrigger::new(app, self.log).await?;
                 trigger.run().await?;
             }
         }


### PR DESCRIPTION
The main goal is to remove trigger config from engine code (fixes #229),
but there were some collatoral changes:

- Moved TriggerConfig from CoreComponent to
  Application.component_triggers

- Pulled just the necessary fields from Application into
  ExecutionContextConfiguration

- Removed unused `wasmtime::Config` field from
  ExecutionContextConfiguration

- Made engine::Builder more buildery