### PR TITLE
docs(index.md): update example per unused var

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -31,7 +31,7 @@ This `hello_world` function written in Rust defines a component that takes an `h
 
 ```rust
 #[http_component]​
-fn hello_world(req: http::Request) -> Result<http::Response> {​
+fn hello_world(_req: http::Request) -> Result<http::Response> {​
     Ok(http::Response::builder()​
         .status(200)​
         .body(Some("Hello, Fermyon!".into()))?)​


### PR DESCRIPTION
Oops, this example would produce an unused var cargo compilation error as it was.

Alternatively, in other examples we `println` the `req`, so we could also do that here, if preferred.