### PR TITLE
ref(.github): remove unused env config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
   build:
     name: Build Spin
     runs-on: ${{ matrix.config.os }}
-    env: ${{ matrix.config.env }}
     strategy:
       matrix:
         config:
@@ -27,7 +26,6 @@ jobs:
               extraArgs: "",
               target: "",
               targetDir: "target/release",
-              env: {},
               bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-linux-amd64.tar.gz",
               bindleBinary: "bindle-server",
               pathInBindleArchive: "bindle-server",
@@ -52,7 +50,6 @@ jobs:
               extraArgs: "",
               target: "",
               targetDir: "target/release",
-              env: {},
               bindleUrl: "https://bindle.blob.core.windows.net/releases/bindle-v0.8.0-windows-amd64.tar.gz",
               bindleBinary: "bindle-server.exe",
               pathInBindleArchive: "bindle-server.exe",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,6 @@ jobs:
   build:
     name: build release assets
     runs-on: ${{ matrix.config.os }}
-    env: ${{ matrix.config.env }}
     strategy:
       matrix:
         config:
@@ -23,7 +22,6 @@ jobs:
               extraArgs: "",
               target: "",
               targetDir: "target/release",
-              env: {},
             }
           - {
               os: "ubuntu-latest",
@@ -40,7 +38,6 @@ jobs:
               extraArgs: "",
               target: "",
               targetDir: "target/release",
-              env: {},
             }
           - {
               os: "macos-latest",
@@ -57,7 +54,6 @@ jobs:
               extraArgs: "",
               target: "",
               targetDir: "target/release",
-              env: {},
             }
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
It seems like the env config in build.yml and release.yml isn't being used and can be removed