### PR TITLE
Update `wagi` dep to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,8 +3942,8 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wagi"
-version = "0.7.0"
-source = "git+https://github.com/deislabs/wagi?rev=a5b3e7b9e94f86bcb753d7a009d51fd016a41f4e#a5b3e7b9e94f86bcb753d7a009d51fd016a41f4e"
+version = "0.8.1"
+source = "git+https://github.com/deislabs/wagi?tag=v0.8.1#ff730bafb4fbc223be4a6281674e5ec4c3d46e87"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -34,7 +34,7 @@ tracing = { version = "0.1", features = ["log"] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3.7", features = ["env-filter"] }
 url = "2.2"
-wagi = { git = "https://github.com/deislabs/wagi", rev = "a5b3e7b9e94f86bcb753d7a009d51fd016a41f4e" }
+wagi = { git = "https://github.com/deislabs/wagi", tag = "v0.8.1" }
 wasi-cap-std-sync = "0.34"
 wasi-common = "0.34"
 wasmtime = "0.34"


### PR DESCRIPTION
Fixes an issue where bytes could be incorrectly removed from response bodies.