### PR TITLE
fix(go): suppress CGO warnings in HTTP internals

### DIFF
--- a/sdk/go/http/http_internals.go
+++ b/sdk/go/http/http_internals.go
@@ -6,7 +6,7 @@
 
 package http
 
-// #cgo CFLAGS: -Wall
+// #cgo CFLAGS: -Wno-unused-parameter -Wno-switch-bool
 // #include "wasi-outbound-http.h"
 // #include<stdlib.h>
 import "C"


### PR DESCRIPTION
close #287 

This commit suppresses the CGO warnings from the generated outbound
HTTP C bindings.

Apparently, this only shows up during the first build, so we should make sure it
actually suppresses the warnings.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>