### PR TITLE
license: add LLVM exception to Apache License Version 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,19 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.


### PR DESCRIPTION
Spin's current license is Apache License Version 2.0.
Spin is built on top of Wasmtime and the WIT bindgen projects, both of
which include the LLVM exceptions.

This commit updates the Spin license to include the LLVM exceptions from
https://spdx.org/licenses/LLVM-exception.html.


This is not a relicensing (the license is still Apache Version 2.0).

cc @lann, @itowlson, @michelleN, @fibonacci1729, @flynnduism, @vdice,
@adamreese, @technosophos, @carlsverre.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>