### PR TITLE
fix release upload process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,13 +101,23 @@ jobs:
           args: "--all-features --release ${{ matrix.config.extraArgs }}"
 
       - name: package release assets
+        if: runner.os != 'Windows'
+        run: |
+          mkdir _dist
+          cp readme.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
+          cd _dist
+          tar czf spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz readme.md LICENSE spin${{ matrix.config.extension }}
+          zip -r spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip readme.md LICENSE spin${{ matrix.config.extension }}
+
+      - name: package release assets
+        if: runner.os == 'Windows'
         shell: bash
         run: |
           mkdir _dist
           cp readme.md LICENSE ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} _dist/
           cd _dist
           tar czf spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz readme.md LICENSE spin${{ matrix.config.extension }}
-          shasum -a 256 *.tar.gz > checksums-${{ env.RELEASE_VERSION }}.txt
+          7z a -tzip spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip readme.md LICENSE spin${{ matrix.config.extension }}
 
       - name: upload binary as GitHub artifact
         uses: actions/upload-artifact@v3
@@ -115,7 +125,7 @@ jobs:
           name: spin
           path: |
             _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
-            _dist/checksums-${{ env.RELEASE_VERSION }}.txt
+            _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
 
       - name: upload binary to canary GitHub release
         uses: svenstaro/upload-release-action@2.2.1
@@ -124,6 +134,62 @@ jobs:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
           asset_name: spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.tar.gz
+          tag: canary
+          overwrite: true
+          prerelease: true
+          body: |
+            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
+            It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.
+
+      - name: upload binary to canary GitHub release
+        uses: svenstaro/upload-release-action@2.2.1
+        if: github.ref == 'refs/heads/main'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
+          asset_name: spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
+          tag: canary
+          overwrite: true
+          prerelease: true
+          body: |
+            This is a "canary" release of the most recent commits on our main branch. Canary is **not stable**.
+            It is only intended for developers wishing to try out the latest features in Spin, some of which may not be fully implemented.
+
+  checksums:
+    name: generate release checksums
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: set the release version (tag)
+        if: startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: echo "RELEASE_VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: set the release version (main)
+        if: github.ref == 'refs/heads/main'
+        shell: bash
+        run: echo "RELEASE_VERSION=canary" >> $GITHUB_ENV
+
+      - name: download release assets
+        uses: actions/download-artifact@v3
+        with:
+          name: spin
+
+      - name: generate checksums
+        run: sha256sum * > checksums-${{ env.RELEASE_VERSION }}.txt
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: spin
+          path: checksums-${{ env.RELEASE_VERSION }}.txt
+
+      - name: upload checksums to canary GitHub release
+        uses: svenstaro/upload-release-action@2.2.1
+        if: github.ref == 'refs/heads/main'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: checksums-${{ env.RELEASE_VERSION }}.txt
+          asset_name: checksums-${{ env.RELEASE_VERSION }}.txt
           tag: canary
           overwrite: true
           prerelease: true


### PR DESCRIPTION
It appears that v2.1.0 introduced multiple upload path support: https://github.com/actions/upload-artifact/releases/tag/2.1.0

Bumping to v3 should fix this.