### PR TITLE
docs: mention how `spin templates install` works

### DIFF
--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -16,6 +16,9 @@ const INSTALL_FROM_GIT_OPT: &str = "FROM_GIT";
 #[derive(Subcommand, Debug)]
 pub enum TemplateCommands {
     /// Install templates from a Git repository or local directory.
+    ///
+    /// The files of the templates are copied to the local template store: a
+    /// directory in your data or home directory.
     Install(Install),
 
     /// Remove a template from your installation.


### PR DESCRIPTION
Looking into `spin templates install`, I wondered what it actually means to
install templates. Finding out required digging into the code. If others might
ask themselves the same, it could be helpful to extend the command's description
a bit.

This extra info would have been helpful to me. However, feel free to just
discard this PR if help texts should stay short or this is simply not needed.

Before:

```
spin templates install --help

Install templates from a Git repository or local directory
```

After:

```
spin templates install --help

Install templates from a Git repository or local directory.

The files of the templates are copied to the local template store: a directory
in your data or home directory.
```

Signed-off-by: Moritz <moritz.zielke@gmail.com>