### PR TITLE
chore(*): v0.3.0 pre-release bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-cli"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -16,8 +16,8 @@ You can download the [latest release](https://github.com/fermyon/spin/releases).
 For example, for an Apple silicon macOS machine:
 
 ```
-$ wget https://github.com/fermyon/spin/releases/download/v0.2.0/spin-v0.2.0-macos-aarch64.tar.gz
-$ tar xfv spin-v0.2.0-macos-aarch64.tar.gz
+$ wget https://github.com/fermyon/spin/releases/download/v0.3.0/spin-v0.3.0-macos-aarch64.tar.gz
+$ tar xfv spin-v0.3.0-macos-aarch64.tar.gz
 $ ./spin --help
 ```
 

--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.2.0
+require github.com/fermyon/spin/sdk/go v0.3.0

--- a/templates/http-rust/content/Cargo.toml
+++ b/templates/http-rust/content/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 # General-purpose crate with common HTTP types.
 http = "0.2"
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.2.0" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.3.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e9c7c0a3405845cecd3fe06f3c20ab413302fc73" }
 

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.17
 
-require github.com/fermyon/spin/sdk/go v0.2.0
+require github.com/fermyon/spin/sdk/go v0.3.0

--- a/templates/redis-rust/content/Cargo.toml
+++ b/templates/redis-rust/content/Cargo.toml
@@ -16,7 +16,7 @@ bytes = "1"
 # Logging
 log = { version = "0.4", default-features = false }
 # The Spin SDK.
-spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.2.0" }
+spin-sdk = { git = "https://github.com/fermyon/spin", tag = "v0.3.0" }
 # Crate that generates Rust Wasm bindings from a WebAssembly interface.
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", rev = "e9c7c0a3405845cecd3fe06f3c20ab413302fc73" }
 


### PR DESCRIPTION
Following the [release process doc](https://github.com/fermyon/spin/blob/main/docs/content/release-process.md), I see that we'll want to merge this PR (or similar) before tagging v0.3.0.
