### PR TITLE
chore(*): v0.4.0 pre-release bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "spin-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes 1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spin-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = [ "Fermyon Engineering <engineering@fermyon.com>" ]
 

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -16,15 +16,15 @@ You can download the [latest release](https://github.com/fermyon/spin/releases).
 For example, for an Apple silicon macOS machine:
 
 ```
-$ wget https://github.com/fermyon/spin/releases/download/v0.3.0/spin-v0.3.0-macos-aarch64.tar.gz
-$ tar xfv spin-v0.3.0-macos-aarch64.tar.gz
+$ wget https://github.com/fermyon/spin/releases/download/v0.4.0/spin-v0.4.0-macos-aarch64.tar.gz
+$ tar xfv spin-v0.4.0-macos-aarch64.tar.gz
 $ ./spin --help
 ```
 
 If you have [`cargo`](https://doc.rust-lang.org/cargo/getting-started/installation.html), you can clone the repo and install it to your path:
 
 ```bash
-$ git clone https://github.com/fermyon/spin -b v0.3.0
+$ git clone https://github.com/fermyon/spin -b v0.4.0
 $ cd spin
 $ rustup target add wasm32-wasi
 $ cargo install --path .

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "spin-sdk"
-version = "0.3.0"
+version = "0.4.0"
 
 [lib]
 name = "spin_sdk"

--- a/tests/http/simple-spin-rust/Cargo.lock
+++ b/tests/http/simple-spin-rust/Cargo.lock
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "spin-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytes",


### PR DESCRIPTION
Step 1 from https://github.com/fermyon/spin/blob/main/docs/content/release-process.md