### PR TITLE
Add shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -969,6 +969,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap 3.2.24",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5585,6 +5594,7 @@ dependencies = [
  "cargo-target-dep",
  "chrono",
  "clap 3.2.24",
+ "clap_complete",
  "clearscreen",
  "comfy-table",
  "command-group",
@@ -6845,7 +6855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bindle = { workspace = true }
 bytes = "1.1"
 chrono = "0.4"
 clap = { version = "3.2.24", features = ["derive", "env"] }
+clap_complete = "3.1.4"
 clearscreen = "2.0.1"
 command-group = "2.1"
 comfy-table = "5.0"

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -129,6 +129,8 @@ enum SpinApp {
     Plugins(PluginCommands),
     #[clap(subcommand, hide = true)]
     Trigger(TriggerCommands),
+    #[clap(hide = true, name = "generate-bash-completions")]
+    GenerateBashCompletions,
     #[clap(external_subcommand)]
     External(Vec<String>),
     Watch(WatchCommand),
@@ -162,6 +164,11 @@ impl SpinApp {
             Self::External(cmd) => execute_external_subcommand(cmd, app).await,
             Self::Watch(cmd) => cmd.run().await,
             Self::Doctor(cmd) => cmd.run().await,
+            Self::GenerateBashCompletions => {
+                let mut cmd: clap::Command = SpinApp::into_app();
+                print_completions(clap_complete::Shell::Bash, &mut cmd);
+                Ok(())
+            }
         }
     }
 }
@@ -219,4 +226,8 @@ fn installed_plugin_help_entries() -> Vec<PluginHelpEntry> {
 
 fn hide_plugin_in_help(plugin: &spin_plugins::manifest::PluginManifest) -> bool {
     plugin.name().starts_with("trigger-")
+}
+
+fn print_completions<G: clap_complete::Generator>(gen: G, cmd: &mut clap::Command) {
+    clap_complete::generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout())
 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -8,6 +8,8 @@ pub mod cloud;
 pub mod doctor;
 /// Commands for external subcommands (i.e. plugins)
 pub mod external;
+/// Command to generate shell completions
+pub mod generate_completions;
 /// Command for creating a new application.
 pub mod new;
 /// Command for adding a plugin to Spin

--- a/src/commands/generate_completions.rs
+++ b/src/commands/generate_completions.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use clap::Parser;
+
+/// Generate shell completions.
+#[derive(Parser, Debug)]
+#[clap(about = "Generate completions")]
+pub struct GenerateCompletionsCommand {
+    #[clap(value_parser = clap::value_parser!(clap_complete::Shell))]
+    pub shell: clap_complete::Shell,
+}
+
+impl GenerateCompletionsCommand {
+    pub async fn run(&self, mut cmd: clap::Command<'_>) -> Result<()> {
+        // let mut cmd: clap::Command = SpinApp::into_app();
+        print_completions(self.shell, &mut cmd);
+        Ok(())
+    }
+}
+
+fn print_completions<G: clap_complete::Generator>(gen: G, cmd: &mut clap::Command) {
+    clap_complete::generate(gen, cmd, cmd.get_name().to_string(), &mut std::io::stdout())
+}


### PR DESCRIPTION
I had a quick play with this to see what it could give us and there is good news and there is bad news.

The good news is that we can get completions for things like commands and options.  E.g. `spin de<TAB>` -> `spin deploy`, `spin new --va<TAB>` -> `--value  --values-file`.

The bad news is that nothing else really works - at least on bash.  (Maybe it would have worked better on zsh.)  All value completions seem to be "any path."  `clap_complete` supports a bunch of value hints but ignores all of them, or at least all the ones I tried.  For example, `ValueHint::FilePath`, `ValueHint::DirPath` and `ValueHint::Url` all resolve to `compgen -f` which is files and directories.  I don't know if this is fixed in more recent versions of `clap_complete`, but I did find an issue where people were asking for dynamic completions (e.g. `spin template new <TAB>` and it would give you a list of templates) and it wasn't happening.

In this draft, the user experience is bad news too.  You would run `spin generate-completions {bash|zsh|...} >spincomps`, then `chmod +x spincomps`, then add `source spincomps` to your `.bashrc` or user completions file or something like that.  Then you upgrade Spin and do the dance again.  If we think command and option completion is worth it, we can discuss a better UI, and whether to support other shells.

And right now the code is _also_ bad news, but I wanted to get opinions on whether we wanted this and if so what we wanted it to look like before I invested in niceing it up.

Signed-off-by: itowlson <ivan.towlson@fermyon.com>