### PR TITLE
Spin Timer Tigger Loop Exit Feature

### DIFF
--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -3482,6 +3482,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin-key-value-redis"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "redis",
+ "spin-core",
+ "spin-key-value",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "spin-key-value-sqlite"
 version = "0.1.0"
 dependencies = [
@@ -3557,6 +3569,7 @@ dependencies = [
  "spin-config",
  "spin-core",
  "spin-key-value",
+ "spin-key-value-redis",
  "spin-key-value-sqlite",
  "spin-loader",
  "spin-manifest",

--- a/examples/spin-timer/app-example/src/lib.rs
+++ b/examples/spin-timer/app-example/src/lib.rs
@@ -6,9 +6,12 @@ wit_bindgen::generate!({
 struct MySpinTimer;
 
 impl SpinTimer for MySpinTimer {
-    fn handle_timer_request() {
+    fn handle_timer_request() -> ContinueTimer {
         let text = spin_sdk::config::get("message").unwrap();
         println!("{text}");
+
+        // Return ContinueTimer::True if you want to continue the timer loop calling this component/function subsequently.
+        ContinueTimer::True
     }
 }
 

--- a/examples/spin-timer/spin-timer.wit
+++ b/examples/spin-timer/spin-timer.wit
@@ -1,3 +1,10 @@
 default world spin-timer {
-  export handle-timer-request: func()
+  // Timer execution loop exit variant
+  variant continue-timer {      
+      true,
+      false
+  }
+
+  // Get the value of a key.
+  export handle-timer-request: func() -> continue-timer
 }


### PR DESCRIPTION
This change allow components triggered by timer trigger plugin to exit when they want to, effectively, inversing the control to exit the timer loop as per their business logic. This is useful if you are composing a service which consist of multiple components (some based on pub-sub and others are not) and not all components needs to run in infinite loop.
