### PR TITLE
fix(registry): use rpassword when taking registry password from stdin

### DIFF
--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use indicatif::{ProgressBar, ProgressStyle};
 use spin_oci::Client;
-use std::{io::Read, path::PathBuf, time::Duration};
+use std::{path::PathBuf, time::Duration};
 
 /// Commands for working with OCI registries to distribute applications.
 #[derive(Subcommand, Debug)]
@@ -149,10 +149,8 @@ impl Login {
         // Otherwise, if the --password flag was passed with a value, use that value. Finally, if
         // neither was passed, prompt the user to input the password.
         let password = if self.password_stdin {
-            let mut buf = String::new();
             let mut stdin = std::io::stdin().lock();
-            stdin.read_to_string(&mut buf)?;
-            buf
+            rpassword::read_password_from_bufread(&mut stdin)?
         } else {
             match self.password {
                 Some(p) => p,


### PR DESCRIPTION
cc @michelleN 