### PR TITLE
handle connection errors on redis-trigger init

### DIFF
--- a/crates/trigger-redis/src/lib.rs
+++ b/crates/trigger-redis/src/lib.rs
@@ -99,10 +99,11 @@ impl TriggerExecutor for RedisTrigger {
             .collect();
 
         // wait for the first handle to be returned and drop the rest
-        let (_, _, rest) = futures::future::select_all(tasks).await;
+        let (result, _, rest) = futures::future::select_all(tasks).await;
+
         drop(rest);
 
-        Ok(())
+        result?
     }
 }
 


### PR DESCRIPTION
Handles the errors returned from the futures so that the user is informed as to the reason of why the trigger did not start. 

fixes #2347 