### PR TITLE
(Discussion): allow multi trigger to continue if a trigger exits successfully

### DIFF
--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -210,7 +210,7 @@ impl UpCommand {
 
         set_kill_on_ctrl_c(&pids)?;
 
-        let trigger_tasks = trigger_processes
+        let mut trigger_tasks = trigger_processes
             .into_iter()
             .map(|mut ch| tokio::task::spawn(async move { ch.wait().await }))
             .collect::<Vec<_>>();
@@ -219,16 +219,24 @@ impl UpCommand {
             tokio::time::sleep(MULTI_TRIGGER_LET_ALL_START).await;
         }
 
-        let (first_to_finish, _index, _rest) = futures::future::select_all(trigger_tasks).await;
+        loop {
+            let (first_to_finish, _index, rest) = futures::future::select_all(trigger_tasks).await;
 
-        if let Ok(process_result) = first_to_finish {
-            let status = process_result?;
-            if !status.success() {
-                if is_multi {
-                    println!("A trigger exited unexpectedly. Terminating.");
-                    kill_child_processes(&pids);
+            if let Ok(process_result) = first_to_finish {
+                let status = process_result?;
+                if !status.success() {
+                    if is_multi {
+                        println!("A trigger exited unexpectedly. Terminating.");
+                        kill_child_processes(&pids);
+                    }
+                    return Err(crate::subprocess::ExitStatusError::new(status).into());
                 }
-                return Err(crate::subprocess::ExitStatusError::new(status).into());
+            }
+
+            if rest.is_empty() {
+                break;
+            } else {
+                trigger_tasks = rest;
             }
         }
 


### PR DESCRIPTION
To enable running other triggers along with the `command` trigger as per https://github.com/fermyon/spin-trigger-command/issues/7

This PR just focuses on enabling the ability for multi-triggers to continue if one of them exits successfully. 