### PR TITLE
draft of single component rebuilds for spin watch

### DIFF
--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -105,7 +105,7 @@ impl WatchCommand {
             tokio::sync::watch::channel((Uuid::new_v4(), "artifact".to_owned()));
         let (pause_tx, pause_rx) = tokio::sync::mpsc::channel(1);
         let (source_code_tx, source_code_rx) =
-            tokio::sync::watch::channel((Uuid::new_v4(), "".to_owned()));
+            tokio::sync::watch::channel((Uuid::new_v4(), "THIS_IS_ THE-FIRST BUILD".to_owned()));
         let (manifest_tx, manifest_rx) =
             tokio::sync::watch::channel((Uuid::new_v4(), "manifest".to_owned()));
         let (stop_tx, stop_rx) = tokio::sync::watch::channel(Uuid::new_v4());

--- a/src/commands/watch/buildifier.rs
+++ b/src/commands/watch/buildifier.rs
@@ -88,7 +88,9 @@ impl Buildifier {
         loop {
             let mut cmd = tokio::process::Command::new(&self.spin_bin);
 
-            if component_paths.contains(&"THIS_IS_ THE-FIRST BUILD") {
+            if component_paths.contains(&"THIS_IS_ THE-FIRST BUILD")
+                || component_paths.contains(&self.manifest.to_str().unwrap())
+            {
                 cmd.arg("build").arg("-f").arg(&self.manifest);
             } else {
                 cmd.arg("build")

--- a/src/commands/watch/buildifier.rs
+++ b/src/commands/watch/buildifier.rs
@@ -3,13 +3,13 @@ use std::path::PathBuf;
 use uuid::Uuid;
 
 use super::uppificator::Pause;
-
+#[derive(Debug)]
 pub(crate) struct Buildifier {
     pub spin_bin: PathBuf,
     pub manifest: PathBuf,
     pub clear_screen: bool,
     pub has_ever_built: bool,
-    pub watched_changes: tokio::sync::watch::Receiver<Uuid>, // TODO: refine which component(s) a change affects
+    pub watched_changes: tokio::sync::watch::Receiver<(Uuid, String)>, // TODO: refine which component(s) a change affects
     pub uppificator_pauser: tokio::sync::mpsc::Sender<Pause>,
 }
 
@@ -28,9 +28,13 @@ impl Buildifier {
                 break;
             }
 
-            let build_result = self.build_once().await;
+            let (_, ref changed_paths) = self.watched_changes.borrow_and_update().clone();
+            tracing::debug!("Detected changes in: {}", changed_paths);
+
+            let build_component_result = self.build_component(changed_paths).await;
+
             if !self.has_ever_built {
-                self.has_ever_built = matches!(build_result, Ok(true));
+                self.has_ever_built = matches!(build_component_result, Ok(true));
             }
 
             if self.has_ever_built {
@@ -45,27 +49,53 @@ impl Buildifier {
         }
     }
 
-    pub(crate) async fn build_once(&mut self) -> std::io::Result<bool> {
+    pub(crate) async fn build_component(
+        &mut self,
+        mut component_path: &str,
+    ) -> std::io::Result<bool> {
+        let manifest = spin_manifest::manifest_from_file(&self.manifest).unwrap();
+        let inner_ids: Vec<&str> = manifest.components.keys().map(|key| key.as_ref()).collect();
+
+        if !inner_ids.iter().any(|id| component_path.contains(id)) && !component_path.is_empty() {
+            component_path = inner_ids.first().cloned().unwrap_or_default();
+        }
+
+        for inner_id in inner_ids {
+            if component_path.contains(inner_id) {
+                component_path = inner_id;
+                break;
+            }
+        }
+
         loop {
             let mut cmd = tokio::process::Command::new(&self.spin_bin);
-            cmd.arg("build").arg("-f").arg(&self.manifest);
+
+            if component_path.is_empty() {
+                cmd.arg("build").arg("-f").arg(&self.manifest);
+            } else {
+                cmd.arg("build")
+                    .arg("-c")
+                    .arg(component_path)
+                    .arg("-f")
+                    .arg(&self.manifest);
+            }
+
             let mut child = cmd.group_spawn()?;
 
             tokio::select! {
-                exit_status = child.wait() => {
-                    // It reports its own errors so we only care about success or failure (and then only for
-                    // the initial build).
-                    return Ok(exit_status?.success());
-                }
-                _ = self.watched_changes.changed() => {
-                    tracing::debug!("Cancelling build as there are new changes to process");
-                    child.kill()?;
-                    if self.clear_screen {
-                        _ = clearscreen::clear();
+                    exit_status = child.wait() => {
+                        // It reports its own errors so we only care about success or failure (and then only for
+                        // the initial build).
+                        return Ok(exit_status?.success());
                     }
-                    continue;
-                }
-
+                    _ = self.watched_changes.changed() => {
+                        tracing::debug!("Cancelling build as there are new changes to process");
+                        child.kill()?;
+                        if self.clear_screen {
+                            _ = clearscreen::clear();
+                        }
+                        continue;
+                    }
             }
         }
     }

--- a/src/commands/watch/reconfiguriser.rs
+++ b/src/commands/watch/reconfiguriser.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 
 pub(crate) struct Reconfiguriser {
-    pub manifest_changes: tokio::sync::watch::Receiver<Uuid>,
+    pub manifest_changes: tokio::sync::watch::Receiver<(Uuid, String)>,
     pub artifact_watcher: super::ReconfigurableWatcher,
     pub build_watcher: super::ReconfigurableWatcher,
 }

--- a/src/commands/watch/uppificator.rs
+++ b/src/commands/watch/uppificator.rs
@@ -7,7 +7,7 @@ pub(crate) struct Uppificator {
     pub up_args: Vec<String>,
     pub manifest: PathBuf,
     pub clear_screen: bool,
-    pub watched_changes: tokio::sync::watch::Receiver<Uuid>,
+    pub watched_changes: tokio::sync::watch::Receiver<(Uuid, String)>,
     pub pause_feed: tokio::sync::mpsc::Receiver<Pause>,
     pub stopper: tokio::sync::watch::Receiver<Uuid>,
 }


### PR DESCRIPTION
I'm still new to larger projects and Rust in general, so hopefully this isn't too janky.

This potentially closes #1417. 

What this draft does is make the `watched_changes` receiver a tuple with a `Uuid` and a `String`. This allows paths for where the file change originated to be passed into the `build_components` function in the buildifier. The logic in `build_components` is effective for what projects I have up and running, but could use a test or inspection. Essentially if there is an empty string in the receiver tuple, it does a full build since it's the first execution. Any changes after that are matched to component IDs and selectively built with `-c`.

Unfortunately, since `spawn_watchexec` contains the notifier, the tuples have to be added to artifact and manifest senders and receivers as well. I tried to make the `String` an `Option<String>` but that seemed to overly complicate things. That could be because I'm not as familiar with idiomatic Rust. 

Another small thing I noticed was that the debounce value is a `u64`. That could be set _very_ high and never rebuild. I don't know if it's worth changing that to a `u16` and then pass it to `Duration::from_millis` as a `u64`? If the user enters too large of a value, clap will emit an error.

Also, if the debounce value is high--anything over a few seconds--then there is potential for multiple components to be rebuilt. In this case `Vec<String>` or some other similar structure is better suited and would need to be refactored.

One last thing--I tried making changes within the manifest but never got it to rebuild automatically in response. That doesn't appear to be the intent though. I'm guessing that stems from `ManifestFilterFactory`.