### PR TITLE
Use `spin.alt` domain for service chaining

### DIFF
--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -12,7 +12,7 @@ use spin_locked_app::{
     values::{ValuesMap, ValuesMapBuilder},
 };
 use spin_manifest::schema::v2::{self, AppManifest, KebabId, WasiFilesMount};
-use spin_outbound_networking::SERVICE_CHAINING_DOMAIN_SUFFIX;
+use spin_outbound_networking::SERVICE_CHAINING_DOMAIN_SUFFIXES;
 use tokio::{io::AsyncWriteExt, sync::Semaphore};
 
 use crate::{cache::Cache, FilesMountStrategy};
@@ -661,10 +661,16 @@ fn is_chaining_host(pattern: &str) -> bool {
     match allowed.host() {
         HostConfig::List(hosts) => hosts
             .iter()
-            .any(|h| h.ends_with(SERVICE_CHAINING_DOMAIN_SUFFIX)),
-        HostConfig::AnySubdomain(domain) => domain == SERVICE_CHAINING_DOMAIN_SUFFIX,
+            .any(|h| ends_with_any(h, SERVICE_CHAINING_DOMAIN_SUFFIXES)),
+        HostConfig::AnySubdomain(domain) => {
+            SERVICE_CHAINING_DOMAIN_SUFFIXES.contains(&domain.as_str())
+        }
         _ => false,
     }
+}
+
+fn ends_with_any(host: &str, suffixes: &[&str]) -> bool {
+    suffixes.iter().any(|suffix| host.ends_with(suffix))
 }
 
 const SLOTH_WARNING_DELAY_MILLIS: u64 = 1250;

--- a/crates/loader/tests/ui/service-chaining.lock
+++ b/crates/loader/tests/ui/service-chaining.lock
@@ -55,7 +55,7 @@
       "id": "four-lights",
       "metadata": {
         "allowed_outbound_hosts": [
-          "http://old-test.spin.internal"
+          "http://old-test.spin.alt"
         ]
       },
       "source": {

--- a/crates/loader/tests/ui/service-chaining.toml
+++ b/crates/loader/tests/ui/service-chaining.toml
@@ -21,7 +21,7 @@ component = "web"
 
 [component.four-lights]
 source = "wasm/dummy.wasm"
-allowed_outbound_hosts = ["http://old-test.spin.internal"]
+allowed_outbound_hosts = ["http://old-test.spin.alt"]
 [component.four-lights.environment]
 env1 = "first"
 env2 = "second"

--- a/crates/locked-app/src/locked.rs
+++ b/crates/locked-app/src/locked.rs
@@ -15,7 +15,8 @@ use crate::{
 pub type LockedMap<T> = std::collections::BTreeMap<String, T>;
 
 /// If present and required in `host_requirements`, the host must support
-/// local service chaining (*.spin.internal) or reject the app.
+/// local service chaining (via *.spin.alt, and, for backward compatibility,
+/// *.spin.internal) or reject the app.
 pub const SERVICE_CHAINING_KEY: &str = "local_service_chaining";
 
 /// Indicates that a host feature is optional. This is the default and is

--- a/crates/outbound-networking/src/lib.rs
+++ b/crates/outbound-networking/src/lib.rs
@@ -5,8 +5,8 @@ use spin_locked_app::MetadataKey;
 
 pub const ALLOWED_HOSTS_KEY: MetadataKey<Vec<String>> = MetadataKey::new("allowed_outbound_hosts");
 
-pub const SERVICE_CHAINING_DOMAIN: &str = "spin.internal";
-pub const SERVICE_CHAINING_DOMAIN_SUFFIX: &str = ".spin.internal";
+pub const SERVICE_CHAINING_DOMAINS: &[&str] = &["spin.alt", "spin.internal"];
+pub const SERVICE_CHAINING_DOMAIN_SUFFIXES: &[&str] = &[".spin.alt", ".spin.internal"];
 
 /// Checks address against allowed hosts
 ///
@@ -453,7 +453,7 @@ fn parse_service_chaining_host(host: &str) -> Option<String> {
 
     let (first, rest) = host.split_once('.')?;
 
-    if rest == SERVICE_CHAINING_DOMAIN {
+    if SERVICE_CHAINING_DOMAINS.contains(&rest) {
         Some(first.to_owned())
     } else {
         None

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -1201,8 +1201,8 @@ mod tests {
 
     #[test]
     fn forbidden_headers_are_removed() {
-        let mut req = Request::get("http://test.spin.internal")
-            .header("Host", "test.spin.internal")
+        let mut req = Request::get("http://test.spin.alt")
+            .header("Host", "test.spin.alt")
             .header("accept", "text/plain")
             .body(Default::default())
             .unwrap();

--- a/tests/runtime-tests/tests/internal-http-streaming/spin.toml
+++ b/tests/runtime-tests/tests/internal-http-streaming/spin.toml
@@ -11,7 +11,7 @@ component = "front-streaming"
 
 [component.front-streaming]
 source = "%{source=internal-http-streaming-front}"
-allowed_outbound_hosts = ["http://*.spin.internal"]
+allowed_outbound_hosts = ["http://*.spin.alt"]
 
 [[trigger.http]]
 route = "/back/..."

--- a/tests/runtime-tests/tests/internal-http/spin.toml
+++ b/tests/runtime-tests/tests/internal-http/spin.toml
@@ -11,7 +11,7 @@ component = "front"
 
 [component.front]
 source = "%{source=internal-http-front}"
-allowed_outbound_hosts = ["http://middle.spin.internal"]
+allowed_outbound_hosts = ["http://middle.spin.alt"]
 
 [[trigger.http]]
 route = { private = true }

--- a/tests/test-components/components/internal-http-front/src/lib.rs
+++ b/tests/test-components/components/internal-http-front/src/lib.rs
@@ -15,7 +15,7 @@ async fn handle_front_impl(_req: Request) -> Result<impl IntoResponse, String> {
     let mut res: http::Response<String> = ensure_ok!(spin_sdk::http::send(
         spin_sdk::http::Request::new(
             spin_sdk::http::Method::Get,
-            "http://middle.spin.internal/hello/from/front"
+            "http://middle.spin.alt/hello/from/front"
         )
     )
     .await);

--- a/tests/test-components/components/internal-http-streaming-front/src/lib.rs
+++ b/tests/test-components/components/internal-http-streaming-front/src/lib.rs
@@ -17,7 +17,7 @@ async fn handle_front_impl(_req: Request) -> Result<impl IntoResponse, String> {
         spin_sdk::http::Fields::new()
     );
     out_req.set_method(&spin_sdk::http::Method::Post).unwrap();
-    out_req.set_authority(Some("back-streaming.spin.internal")).unwrap();
+    out_req.set_authority(Some("back-streaming.spin.alt")).unwrap();
     out_req.set_scheme(Some(&spin_sdk::http::Scheme::Http)).unwrap();
     out_req.set_path_with_query(Some("/")).unwrap();
 


### PR DESCRIPTION
Fixes #2731 