### PR TITLE
trigger: Decouple Trigger from clap

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -38,7 +38,7 @@ pub(crate) type TriggerInstanceBuilder<'a, F> =
     spin_trigger::TriggerInstanceBuilder<'a, HttpTrigger, F>;
 
 #[derive(Args)]
-pub struct CliArgs {
+pub struct GlobalConfig {
     /// IP address and port to listen on
     #[clap(long = "listen", env = "SPIN_HTTP_LISTEN_ADDR", default_value = "127.0.0.1:3000", value_parser = parse_listen_addr)]
     pub address: SocketAddr,
@@ -52,7 +52,7 @@ pub struct CliArgs {
     pub tls_key: Option<PathBuf>,
 }
 
-impl CliArgs {
+impl GlobalConfig {
     fn into_tls_config(self) -> Option<TlsConfig> {
         match (self.tls_cert, self.tls_key) {
             (Some(cert_path), Some(key_path)) => Some(TlsConfig {
@@ -78,11 +78,11 @@ pub struct HttpTrigger {
 impl<F: RuntimeFactors> Trigger<F> for HttpTrigger {
     const TYPE: &'static str = "http";
 
-    type CliArgs = CliArgs;
+    type GlobalConfig = GlobalConfig;
     type InstanceState = ();
 
-    fn new(cli_args: Self::CliArgs, app: &spin_app::App) -> anyhow::Result<Self> {
-        Self::new(app, cli_args.address, cli_args.into_tls_config())
+    fn new(cfg: Self::GlobalConfig, app: &spin_app::App) -> anyhow::Result<Self> {
+        Self::new(app, cfg.address, cfg.into_tls_config())
     }
 
     async fn run(self, trigger_app: TriggerApp<F>) -> anyhow::Result<()> {

--- a/crates/trigger-redis/src/lib.rs
+++ b/crates/trigger-redis/src/lib.rs
@@ -6,7 +6,7 @@ use redis::{Client, Msg};
 use serde::Deserialize;
 use spin_factor_variables::VariablesFactor;
 use spin_factors::RuntimeFactors;
-use spin_trigger::{cli::NoCliArgs, App, Trigger, TriggerApp};
+use spin_trigger::{cli::NoGlobalConfig, App, Trigger, TriggerApp};
 use spin_world::exports::fermyon::spin::inbound_redis;
 use tracing::{instrument, Level};
 
@@ -34,11 +34,11 @@ struct TriggerConfig {
 impl<F: RuntimeFactors> Trigger<F> for RedisTrigger {
     const TYPE: &'static str = "redis";
 
-    type CliArgs = NoCliArgs;
+    type GlobalConfig = NoGlobalConfig;
 
     type InstanceState = ();
 
-    fn new(_cli_args: Self::CliArgs, _app: &App) -> anyhow::Result<Self> {
+    fn new(_cfg: Self::GlobalConfig, _app: &App) -> anyhow::Result<Self> {
         Ok(Self)
     }
 

--- a/crates/trigger/src/cli/launch_metadata.rs
+++ b/crates/trigger/src/cli/launch_metadata.rs
@@ -1,4 +1,4 @@
-use clap::CommandFactory;
+use clap::{Args, CommandFactory};
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 
@@ -29,7 +29,12 @@ struct LaunchFlag {
 }
 
 impl LaunchMetadata {
-    pub fn infer<T: Trigger<B::Factors>, B: RuntimeFactorsBuilder>() -> Self {
+    pub fn infer<T, B>() -> Self
+    where
+        T: Trigger<B::Factors>,
+        T::GlobalConfig: Args,
+        B: RuntimeFactorsBuilder,
+    {
         let all_flags: Vec<_> = FactorsTriggerCommand::<T, B>::command()
             .get_arguments()
             .map(LaunchFlag::infer)

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -4,10 +4,12 @@ pub mod loader;
 use std::future::Future;
 
 use clap::Args;
-use spin_core::Linker;
-use spin_factors::RuntimeFactors;
+pub use spin_core::Linker;
+pub use spin_factors::RuntimeFactors;
 use spin_factors_executor::{FactorsExecutorApp, FactorsInstanceBuilder};
 
+pub use anyhow;
+pub use clap::Parser;
 pub use spin_app::App;
 
 /// Type alias for a [`spin_factors_executor::FactorsExecutorApp`] specialized to a [`Trigger`].
@@ -21,7 +23,7 @@ pub type TriggerInstanceBuilder<'a, T, F> =
 pub type Store<T, F> = spin_core::Store<TriggerInstanceState<T, F>>;
 
 /// Type alias for [`spin_factors_executor::InstanceState`] specialized to a [`Trigger`].
-type TriggerInstanceState<T, F> = spin_factors_executor::InstanceState<
+pub type TriggerInstanceState<T, F> = spin_factors_executor::InstanceState<
     <F as RuntimeFactors>::InstanceState,
     <T as Trigger<F>>::InstanceState,
 >;

--- a/crates/trigger/src/lib.rs
+++ b/crates/trigger/src/lib.rs
@@ -3,13 +3,11 @@ pub mod loader;
 
 use std::future::Future;
 
-use clap::Args;
 pub use spin_core::Linker;
 pub use spin_factors::RuntimeFactors;
 use spin_factors_executor::{FactorsExecutorApp, FactorsInstanceBuilder};
 
 pub use anyhow;
-pub use clap::Parser;
 pub use spin_app::App;
 
 /// Type alias for a [`spin_factors_executor::FactorsExecutorApp`] specialized to a [`Trigger`].
@@ -33,14 +31,14 @@ pub trait Trigger<F: RuntimeFactors>: Sized + Send {
     /// A unique identifier for this trigger.
     const TYPE: &'static str;
 
-    /// The specific CLI arguments for this trigger.
-    type CliArgs: Args;
+    /// Global configuration used to construct this trigger.
+    type GlobalConfig;
 
-    /// The instance state for this trigger.
+    /// Extra state attached to each instance store for this trigger.
     type InstanceState: Send + 'static;
 
     /// Constructs a new trigger.
-    fn new(cli_args: Self::CliArgs, app: &App) -> anyhow::Result<Self>;
+    fn new(cfg: Self::GlobalConfig, app: &App) -> anyhow::Result<Self>;
 
     /// Update the [`spin_core::Config`] for this trigger.
     ///

--- a/examples/spin-timer/src/lib.rs
+++ b/examples/spin-timer/src/lib.rs
@@ -12,7 +12,7 @@ wasmtime::component::bindgen!({
 });
 
 #[derive(Args)]
-pub struct CliArgs {
+pub struct GlobalConfig {
     /// If true, run each component once and exit
     #[clap(long)]
     pub test: bool,
@@ -49,11 +49,11 @@ pub struct TimerTriggerConfig {
 impl<F: RuntimeFactors> Trigger<F> for TimerTrigger {
     const TYPE: &'static str = "timer";
 
-    type CliArgs = CliArgs;
+    type GlobalConfig = GlobalConfig;
 
     type InstanceState = ();
 
-    fn new(cli_args: Self::CliArgs, app: &App) -> anyhow::Result<Self> {
+    fn new(cfg: Self::GlobalConfig, app: &App) -> anyhow::Result<Self> {
         let trigger_type = <Self as Trigger<F>>::TYPE;
         let metadata = app
             .get_trigger_metadata::<TriggerMetadata>(trigger_type)?
@@ -67,7 +67,7 @@ impl<F: RuntimeFactors> Trigger<F> for TimerTrigger {
             .collect();
 
         Ok(Self {
-            test: cli_args.test,
+            test: cfg.test,
             speedup,
             component_timings,
         })

--- a/tests/testing-framework/src/runtimes/in_process_spin.rs
+++ b/tests/testing-framework/src/runtimes/in_process_spin.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use anyhow::Context as _;
-use spin_runtime_factors::{FactorsBuilder, TriggerAppArgs, TriggerFactors};
+use spin_runtime_factors::{FactorsBuilder, TriggerFactors, TriggerAppArgs};
 use spin_trigger::{cli::TriggerAppBuilder, loader::ComponentLoader};
 use spin_trigger_http::{HttpServer, HttpTrigger};
 use test_environment::{


### PR DESCRIPTION
- Rename `Trigger`'s associated `CliArgs` type to `GlobalConfig`
- Move that `clap::Args` bound into `FactorsTriggerCommand`
- Fix up related code

Also (the original PR):

- Re-export a few things to ease trigger development