### PR TITLE
Generate schema for v2 manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
               extraArgs: "--features openssl/vendored",
               target: "",
               targetDir: "target/release",
+              generateManifestSchema: true,
             }
           - {
               os: "ubuntu-22.04",
@@ -132,6 +133,10 @@ jobs:
             --output-signature spin.sig \
             ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }}
 
+      - name: Generate manifest schema
+        if: matrix.config.generateManifestSchema
+        run: ${{ matrix.config.targetDir }}/spin${{ matrix.config.extension }} maintenance generate-manifest-schema -o manifest.schema.json
+
       - name: package release assets
         if: runner.os != 'Windows'
         shell: bash
@@ -167,6 +172,13 @@ jobs:
         with:
           name: spin-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}
           path: _dist/spin-${{ env.RELEASE_VERSION }}-${{ env.RUNNER_OS }}-${{ matrix.config.arch }}.zip
+      
+      - name: Upload schema as GitHub artifact
+        if: matrix.config.generateManifestSchema
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest.schema.json
+          path: manifest.schema.json
 
   checksums:
     name: generate release checksums
@@ -206,10 +218,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: download release assets
+      - name: download binaries for release assets
         uses: actions/download-artifact@v4
         with:
           pattern: spin-*
+          path: _dist
+          merge-multiple: true
+
+      - name: download schema for release assets
+        uses: actions/download-artifact@v4
+        with:
+          pattern: manifest.schema.json
           path: _dist
           merge-multiple: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7358,6 +7358,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "indexmap 2.7.1",
+ "schemars_derive",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7491,6 +7517,17 @@ name = "serde_derive"
 version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7885,6 +7922,7 @@ dependencies = [
  "reqwest 0.12.9",
  "rpassword",
  "runtime-tests",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -8440,6 +8478,7 @@ dependencies = [
  "anyhow",
  "glob",
  "indexmap 2.7.1",
+ "schemars",
  "semver",
  "serde",
  "serde_json",
@@ -8576,6 +8615,7 @@ version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "schemars",
  "semver",
  "serde",
  "wasm-pkg-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ pretty_assertions = "1.3"
 regex = { workspace = true }
 reqwest = { workspace = true }
 rpassword = "7"
+schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
 semver = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { workspace = true }

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
+schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 spin-serde = { path = "../serde" }

--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -60,6 +60,7 @@ pub fn v1_to_v2_app(manifest: v1::AppManifestV1) -> Result<v2::AppManifest, Erro
         };
         components.insert(
             component_id.clone(),
+            #[allow(deprecated)]
             v2::Component {
                 source: component.source,
                 description: component.description,

--- a/crates/manifest/src/schema/common.rs
+++ b/crates/manifest/src/schema/common.rs
@@ -1,11 +1,12 @@
 use std::fmt::Display;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use wasm_pkg_common::{package::PackageRef, registry::Registry};
 
 /// Variable definition
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Variable {
     /// `required = true`
@@ -20,7 +21,7 @@ pub struct Variable {
 }
 
 /// Component source
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, untagged)]
 pub enum ComponentSource {
     /// `"local.wasm"`
@@ -35,8 +36,10 @@ pub enum ComponentSource {
     /// `{ ... }`
     Registry {
         /// `registry = "example.com"`
+        #[schemars(with = "Option<String>")]
         registry: Option<Registry>,
         /// `package = "example:component"`
+        #[schemars(with = "String")]
         package: PackageRef,
         /// `version = "1.2.3"`
         version: String,
@@ -64,7 +67,7 @@ impl Display for ComponentSource {
 }
 
 /// WASI files mount
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, untagged)]
 pub enum WasiFilesMount {
     /// `"images/*.png"`
@@ -79,7 +82,7 @@ pub enum WasiFilesMount {
 }
 
 /// Component build configuration
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ComponentBuildConfig {
     /// `command = "cargo build"`
@@ -104,7 +107,7 @@ impl ComponentBuildConfig {
 }
 
 /// Component build command or commands
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum Commands {
     /// `command = "cargo build"`

--- a/crates/manifest/src/schema/json_schema.rs
+++ b/crates/manifest/src/schema/json_schema.rs
@@ -1,0 +1,107 @@
+use crate::schema::v2::{ComponentSpec, Map, OneOrManyComponentSpecs};
+use schemars::JsonSchema;
+
+// The structs here allow dead code because they exist only
+// to represent JSON schemas, and are never instantiated.
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+pub struct TriggerSchema {
+    /// HTTP triggers
+    #[schemars(default)]
+    http: Vec<HttpTriggerSchema>,
+    /// Redis triggers
+    #[schemars(default)]
+    redis: Vec<RedisTriggerSchema>,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct HttpTriggerSchema {
+    /// `id = "trigger-id"`
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub id: String,
+    /// `component = ...`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component: Option<ComponentSpec>,
+    /// `components = { ... }`
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub components: Map<String, OneOrManyComponentSpecs>,
+    /// `route = "/user/:name/..."`
+    route: HttpRouteSchema,
+    /// `executor = { type = "wagi" }
+    #[schemars(default, schema_with = "toml_table")]
+    executor: Option<toml::Table>,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(untagged)]
+pub enum HttpRouteSchema {
+    /// `route = "/user/:name/..."`
+    Route(String),
+    /// `route = { private = true }`
+    Private(HttpPrivateEndpoint),
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct HttpPrivateEndpoint {
+    /// Whether the private endpoint is private. This must be true.
+    pub private: bool,
+}
+
+#[allow(dead_code)]
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct RedisTriggerSchema {
+    /// `id = "trigger-id"`
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub id: String,
+    /// `component = ...`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub component: Option<ComponentSpec>,
+    /// `components = { ... }`
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub components: Map<String, OneOrManyComponentSpecs>,
+    /// `channel = "my-messages"`
+    channel: String,
+    /// `address = "redis://redis.example.com:6379"`
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    address: Option<String>,
+}
+
+pub fn toml_table(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+        instance_type: Some(schemars::schema::SingleOrVec::Single(Box::new(
+            schemars::schema::InstanceType::Object,
+        ))),
+        ..Default::default()
+    })
+}
+
+pub fn map_of_toml_tables(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+        instance_type: Some(schemars::schema::SingleOrVec::Single(Box::new(
+            schemars::schema::InstanceType::Object,
+        ))),
+        ..Default::default()
+    })
+}
+
+pub fn one_or_many<T: schemars::JsonSchema>(
+    gen: &mut schemars::gen::SchemaGenerator,
+) -> schemars::schema::Schema {
+    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
+        subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
+            one_of: Some(vec![
+                gen.subschema_for::<T>(),
+                gen.subschema_for::<Vec<T>>(),
+            ]),
+            ..Default::default()
+        })),
+        ..Default::default()
+    })
+}

--- a/crates/manifest/src/schema/mod.rs
+++ b/crates/manifest/src/schema/mod.rs
@@ -10,6 +10,7 @@ pub mod v2;
 // Types common between manifest versions. Re-exported from versioned modules
 // to make them easier to split if necessary.
 pub(crate) mod common;
+mod json_schema;
 
 #[derive(Deserialize)]
 pub(crate) struct VersionProbe {

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
+schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 wasm-pkg-common = { workspace = true }

--- a/crates/serde/src/id.rs
+++ b/crates/serde/src/id.rs
@@ -1,10 +1,13 @@
 //! ID (de)serialization
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// An ID is a non-empty string containing one or more component model
 /// `word`s separated by a delimiter char.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd, Serialize, Deserialize, JsonSchema,
+)]
 #[serde(into = "String", try_from = "String")]
 pub struct Id<const DELIM: char, const LOWER: bool>(String);
 

--- a/crates/serde/src/version.rs
+++ b/crates/serde/src/version.rs
@@ -1,8 +1,10 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// FixedVersion represents a version integer field with a const value.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(into = "usize", try_from = "usize")]
+#[schemars(with = "usize", range = (min = V, max = V))]
 pub struct FixedVersion<const V: usize>;
 
 impl<const V: usize> From<FixedVersion<V>> for usize {
@@ -24,8 +26,9 @@ impl<const V: usize> TryFrom<usize> for FixedVersion<V> {
 
 /// FixedVersion represents a version integer field with a const value,
 /// but accepts lower versions during deserialisation.
-#[derive(Clone, Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
 #[serde(into = "usize", try_from = "usize")]
+#[schemars(with = "usize", range = (min = 1, max = V))]
 pub struct FixedVersionBackwardCompatible<const V: usize>;
 
 impl<const V: usize> From<FixedVersionBackwardCompatible<V>> for usize {

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -7,12 +7,15 @@ use clap::{Parser, Subcommand};
 pub enum MaintenanceCommands {
     /// Generate CLI reference docs in Markdown format.
     GenerateReference(GenerateReference),
+    /// Generate JSON schema for application manifest.
+    GenerateManifestSchema(GenerateSchema),
 }
 
 impl MaintenanceCommands {
     pub async fn run(&self, app: clap::Command<'_>) -> anyhow::Result<()> {
         match self {
-            MaintenanceCommands::GenerateReference(g) => g.run(app).await,
+            MaintenanceCommands::GenerateReference(cmd) => cmd.run(app).await,
+            MaintenanceCommands::GenerateManifestSchema(cmd) => cmd.run().await,
         }
     }
 }
@@ -27,10 +30,31 @@ pub struct GenerateReference {
 impl GenerateReference {
     pub async fn run(&self, app: clap::Command<'_>) -> anyhow::Result<()> {
         let markdown = crate::clap_markdown::help_markdown_command(&app);
-        match &self.output {
-            Some(path) => std::fs::write(path, markdown)?,
-            None => println!("{markdown}"),
-        }
+        write(&self.output, &markdown)?;
         Ok(())
     }
+}
+
+#[derive(Parser, Debug)]
+pub struct GenerateSchema {
+    /// The file to which to generate the JSON schema. If omitted, it is generated to stdout.
+    #[clap(short = 'o')]
+    pub output: Option<PathBuf>,
+}
+
+impl GenerateSchema {
+    async fn run(&self) -> anyhow::Result<()> {
+        let schema = schemars::schema_for!(spin_manifest::schema::v2::AppManifest);
+        let schema_json = serde_json::to_string_pretty(&schema)?;
+        write(&self.output, &schema_json)?;
+        Ok(())
+    }
+}
+
+fn write(output: &Option<PathBuf>, text: &str) -> anyhow::Result<()> {
+    match output {
+        Some(path) => std::fs::write(path, text)?,
+        None => println!("{text}"),
+    }
+    Ok(())
 }


### PR DESCRIPTION
Attempts #930.

This is for discussion right now.  Some questions:

* Does this provide enough value to invest further time making it wholesome?  E.g. trigger properties are not autosuggested (but they are validated).  You can test the current output by installing Even Better TOML or Taplo and adding the `#:schema https://gist.githubusercontent.com/itowlson/080922335ea080a185b77a17b9f1eb03/raw/3c24973fbeec3f3c78a1adc34284c235eba6df23/manifest.v2.triggy.json` at the top of a spin.toml file.
* Which triggers should we bake in schemas for?  I've done HTTP and Redis, but should we do cron, command, MQTT, SQS, etc. too?  (Currently they are not validated but do not cause an error either.)
* How do we want to expose generation?  For now I have it as a `spin schema` command but there's no reason anyone except people updating the manifest format should ever need to run it.
* How do we want to publish/distribute the schema?  E.g. asset URL in a GH release, S3 bucket, VS Code extension, BitTorrent...  Even Better TOML is happy with HTTP URLs via the `#:schema` directive, which we could add to templates.

If we decide to press ahead, the main remaining work is:

* Agree design and review implementation
* Update the descriptions/doc comments (which are currently examples rather than explanations)
* Implement publishing / distribution.

Docs are probably a few hours, and I can do them; distribution would depend on how we want to do it.
