### PR TITLE
Allow `self.alt` host for self-requests

### DIFF
--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -152,7 +152,12 @@ async fn send_request_impl(
     let host = request.uri().host().unwrap_or_default();
     let tls_client_config = component_tls_configs.get_client_config(host).clone();
 
-    if request.uri().authority().is_some() {
+    let is_self_request = request
+        .uri()
+        .authority()
+        .is_some_and(|a| a.host() == "self.alt");
+
+    if request.uri().authority().is_some() && !is_self_request {
         // Absolute URI
         let is_allowed = outbound_allowed_hosts
             .check_url(&request.uri().to_string(), "https")

--- a/crates/factor-outbound-networking/src/config.rs
+++ b/crates/factor-outbound-networking/src/config.rs
@@ -200,7 +200,7 @@ impl HostConfig {
             return Ok(Self::Any);
         }
 
-        if host == "self" {
+        if host == "self" || host == "self.alt" {
             return Ok(Self::ToSelf);
         }
 

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -719,6 +719,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+dependencies = [
+ "fastrand 2.1.1",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1686,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1696,9 +1705,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -1713,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1747,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1758,21 +1767,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3443,14 +3452,15 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.2"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e86f5670bd8b028edfb240f0616cad620705b31ec389d55e4f3da2c38dcd48"
+checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
 dependencies = [
  "arc-swap",
- "async-trait",
+ "backon",
  "bytes",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
  "native-tls",
@@ -4225,7 +4235,6 @@ name = "spin-factor-key-value"
 version = "3.2.0-pre0"
 dependencies = [
  "anyhow",
- "lru",
  "serde",
  "spin-core",
  "spin-factors",
@@ -4468,7 +4477,7 @@ name = "spin-key-value-redis"
 version = "3.2.0-pre0"
 dependencies = [
  "anyhow",
- "redis 0.27.2",
+ "redis 0.28.2",
  "serde",
  "spin-core",
  "spin-factor-key-value",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -372,6 +372,11 @@ mod integration_tests {
                     Request::new(Method::Get, "/outbound-allowed"),
                     Response::new_with_body(200, "Hello, Fermyon!\n"),
                 )?;
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/outbound-allowed-alt"),
+                    Response::new_with_body(200, "Hello, Fermyon!\n"),
+                )?;
 
                 assert_spin_request(
                     spin,

--- a/tests/test-components/components/outbound-http/src/lib.rs
+++ b/tests/test-components/components/outbound-http/src/lib.rs
@@ -7,6 +7,7 @@ use spin_sdk::{
 /// Send an HTTP request and return the response.
 #[http_component]
 async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
+    // Test self-request via relative URL
     let mut res: http::Response<String> = spin_sdk::http::send(
         http::Request::builder()
             .method("GET")
@@ -14,7 +15,21 @@ async fn send_outbound(_req: Request) -> Result<impl IntoResponse> {
             .body(())?,
     )
     .await?;
+
+    // Test self-request via self.alt
+    let res_alt: http::Response<String> = spin_sdk::http::send(
+        http::Request::builder()
+            .method("GET")
+            .uri("http://self.alt/hello")
+            .body(())?,
+    )
+    .await?;
+
+    assert_eq!(res.body(), res_alt.body());
+    assert_eq!(res.status(), res_alt.status());
+
     res.headers_mut()
         .insert("spin-component", "outbound-http-component".try_into()?);
+
     Ok(res)
 }

--- a/tests/testcases/outbound-http-to-same-app/spin.toml
+++ b/tests/testcases/outbound-http-to-same-app/spin.toml
@@ -19,6 +19,13 @@ allowed_http_hosts = ["self"]
 route = "/outbound-allowed/..."
 
 [[component]]
+id = "outbound-http-allowed-alt"
+source = "%{source=outbound-http}"
+allowed_http_hosts = ["self.alt"]
+[component.trigger]
+route = "/outbound-allowed-alt/..."
+
+[[component]]
 id = "outbound-http-not-allowed"
 source = "%{source=outbound-http}"
 [component.trigger]


### PR DESCRIPTION
This is a proposal to address https://github.com/fermyon/spin-js-sdk/issues/298.

The issue there is that JS guests use the inbuilt `fetch` function to make HTTP requests. If `fetch` sees a URL without a host, it helpfully prepends the host it thinks it's running on _before_ letting Spin see it.  So for a self-request such as `fetch("/back")`, Spin sees `http://localhost:3000/back` or whatever.  Which is not on the allow list so gets the banhammer.

This PR reluctantly compromises with `fetch` by allowing self-requests via the pseudo-host `self.alt`.  So if you do `fetch("http://self.alt/back")`, Spin will treat it as a self-request: it will validate permission using the self-request permission and route it as a self request.

The developer experience is, admittedly, not very lovely.  But it hopefully gives JS folks an escape hatch.

Notes for reviewers:

* Self-request permission is still given via `allowed_outbound_hosts = ["http://self"]`, _not_ `http://self.alt`.  Should we allow `self.alt` as another way of expressing the same permission?
* I implemented this only in wasi-http because that's what JS goes through.  Should I implement it in spin-http too?  It looked faffier there because of the way the types line up, but certainly do-able.
