### PR TITLE
Check allowed hosts before checking the `request_interceptor`

### DIFF
--- a/tests/test-components/helper/src/lib.rs
+++ b/tests/test-components/helper/src/lib.rs
@@ -159,11 +159,17 @@ macro_rules! ensure_matches {
 
 #[macro_export]
 macro_rules! ensure_eq {
-    ($expr1:expr, $expr2:expr) => {
-        if $expr1 != $expr2 {
-            $crate::bail!("`{}` != `{}`", stringify!($expr1), stringify!($expr2));
+    ($expr1:expr, $expr2:expr) => {{
+        let a = $expr1;
+        let b = $expr2;
+        if a != b {
+            $crate::bail!(
+                "`{}` != `{}`\n{a:?} != {b:?}",
+                stringify!($expr1),
+                stringify!($expr2),
+            );
         }
-    };
+    }};
 }
 
 #[macro_export]


### PR DESCRIPTION
This commit updates the `request_interceptor` implementation of outbound HTTP requests to check the set of allowed hosts before calling the `request_interceptor`. This fixes behavior in Spin where service-chained requests were allowed regardless of configuration of `allowed_outbound_hosts` in `spin.toml`. A new test is added to ensure that a request to the "back" component is disallowed.