### PR TITLE
Use connection pooling when querying CosmosDB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8077,6 +8077,7 @@ dependencies = [
  "azure_data_cosmos",
  "azure_identity",
  "futures",
+ "reqwest 0.12.9",
  "serde",
  "spin-core",
  "spin-factor-key-value",

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -17,6 +17,12 @@ futures = { workspace = true }
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
+reqwest = { version = "0.12", default-features = false }
 
 [lints]
 workspace = true
+
+[features]
+# Enables reusing connections to the Azure Cosmos DB service.
+connection-pooling = []
+default = ["connection-pooling"]


### PR DESCRIPTION
I noticed that KV reads/writes had a really high latency with the CosmosDB provider. I crated some [simple test cases](https://github.com/kate-goldenring/cosmos-db-sdks-tests/tree/main) for interacting with CosmosDB and found that while the go SDK reuses connections between requests, the Rust SDK always created a new client. @lann discovered that the Azure Rust SDK disabled connection pooling because of this upstream issue: https://github.com/hyperium/hyper/issues/2312. The maintainers closed the issue deeming it to be irreproducible. I am getting latencies 3x higher without connection pooling (from 15ms reads to 60ms reads). I think it is worth enabling the pooling by creating our own reqwest client and passing it. 

I put it behind a feature flag in case we do hit the deadlock scenario that some have experienced.

~Marking this as draft for discussion~ Seems like this is a change we want