### PR TITLE
fix: support empty files directories

### DIFF
--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -549,6 +549,15 @@ impl LocalLoader {
             })
             .collect::<Result<Vec<_>>>()?;
 
+        crate::fs::create_dir_all(dest_root)
+            .await
+            .with_context(|| {
+                format!(
+                    "Failed to create parent directory {}",
+                    quoted_path(&dest_root)
+                )
+            })?;
+
         for path_res in paths {
             let src = path_res?;
             if !src.is_file() {


### PR DESCRIPTION
fixes https://github.com/spinframework/spin/issues/3019

Note, when directly mounting the fs with `--direct-mounts` this error is not encountered. Related https://github.com/spinframework/spin/issues/3018#issuecomment-2675096223