### PR TITLE
Change Homebrew data dir from fermyon-spin to spinframework-spin

### DIFF
--- a/crates/common/src/data_dir.rs
+++ b/crates/common/src/data_dir.rs
@@ -25,7 +25,9 @@ fn package_manager_data_dir() -> Option<PathBuf> {
             .map(|p| p.starts_with(&brew_prefix))
             .unwrap_or(false)
         {
-            let data_dir = Path::new(&brew_prefix).join("etc").join("fermyon-spin");
+            let data_dir = Path::new(&brew_prefix)
+                .join("etc")
+                .join("spinframework-spin");
             return Some(data_dir);
         }
     }


### PR DESCRIPTION
Updates data directory for Homebrew to not be Fermyon specific as the homebrew tap has moved to the spinframework org: https://github.com/spinframework/homebrew-tap

I need to double check how homebrew autodetects this cleanup. I think it is naming based in which case this should change the cleanup from
```sh
 » brew uninstall spin
Uninstalling /opt/homebrew/Cellar/spin/3.1.2... (6 files, 88.3MB)

Warning: The following may be spin configuration files and have not been removed!
If desired, remove them manually with `rm -rf`:
  /opt/homebrew/etc/fermyon-spin
```
To
```sh
» brew uninstall spin
Uninstalling /opt/homebrew/Cellar/spin/3.1.2... (6 files, 88.3MB)

Warning: The following may be spin configuration files and have not been removed!
If desired, remove them manually with `rm -rf`:
  /opt/homebrew/etc/spinframework-spin
```