### PR TITLE
If a component errors after starting the response, show that error

### DIFF
--- a/crates/trigger-http/src/wasi.rs
+++ b/crates/trigger-http/src/wasi.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal;
 use std::net::SocketAddr;
 
 use anyhow::{anyhow, Context, Result};
@@ -144,7 +145,11 @@ impl HttpExecutor for WasiHttpExecutor {
                         Ok(())
                     }
                     .map_err(|e: anyhow::Error| {
-                        tracing::warn!("component error after response: {e:?}");
+                        if std::io::stderr().is_terminal() {
+                            tracing::error!("Component error after response started. The response may not be fully sent: {e:?}");
+                        } else {
+                            terminal::warn!("Component error after response started: {e:?}");
+                        }
                     }),
                 );
 


### PR DESCRIPTION
Fixes #3035.

This makes little or no odds in non-streaming scenarios, where no guest code executes after the guest returns a response object (although SDK code may execute), and so any errors are likely to occur before the response is constructed let alone commenced.

However, in streaming scenarios, a guest may error (e.g. Rust panic) after the ResponseOutparam is set and its body taken, but before the response body is finished (or even started).  The default Spin logging settings turn this into a silent failure, which makes it hard to know where to start.  (In some cases a guest may be doing interesting things even after the response has completed, e.g. a Slack command handler doing work after the ack timeout, with intent to call back.)

This PR therefore bumps post-response guest errors to trace at Error level instead of Warning.
