### PR TITLE
Revert expected test output for legacy apps

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -321,8 +321,8 @@ mod integration_tests {
                     )
                 };
 
-                test("golang", "Hello World!\n")?;
-                test("rust", "Hello World!")?;
+                test("golang", "Hello Fermyon!\n")?;
+                test("rust", "Hello, Fermyon")?;
                 test("javascript", "Hello from JS-SDK")?;
                 test("typescript", "Hello from TS-SDK")?;
                 Ok(())


### PR DESCRIPTION
Fixes #3044.

The context is that the apps being tested here predate the move into CNCF, and they cannot be changed because the explicit purpose is to test that _binaries built under very old tooling still work._

Therefore, although we aim to make the code as vendor-neutral as possible, in this case we need to retain an existing branded string because it is baked into our backward compatibility testing.
