### PR TITLE
Allow "choose from list" parameters in templates

### DIFF
--- a/crates/templates/src/constraints.rs
+++ b/crates/templates/src/constraints.rs
@@ -3,6 +3,7 @@ use regex::Regex;
 #[derive(Clone, Debug)]
 pub(crate) struct StringConstraints {
     pub regex: Option<Regex>,
+    pub allowed_values: Option<Vec<String>>,
 }
 
 impl StringConstraints {
@@ -10,6 +11,15 @@ impl StringConstraints {
         if let Some(regex) = self.regex.as_ref() {
             if !regex.is_match(&text) {
                 anyhow::bail!("Input '{}' does not match pattern '{}'", text, regex);
+            }
+        }
+        if let Some(allowed_values) = self.allowed_values.as_ref() {
+            if !allowed_values.contains(&text) {
+                anyhow::bail!(
+                    "Input '{}' is not one of the allowed values ({})",
+                    text,
+                    allowed_values.join(", ")
+                );
             }
         }
         Ok(text)

--- a/crates/templates/src/reader.rs
+++ b/crates/templates/src/reader.rs
@@ -86,6 +86,7 @@ pub(crate) struct RawParameter {
     #[serde(rename = "default")]
     pub default_value: Option<String>,
     pub pattern: Option<String>,
+    pub allowed_values: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -617,7 +617,10 @@ impl Condition {
 fn parse_string_constraints(raw: &RawParameter) -> anyhow::Result<StringConstraints> {
     let regex = raw.pattern.as_ref().map(|re| Regex::new(re)).transpose()?;
 
-    Ok(StringConstraints { regex })
+    Ok(StringConstraints {
+        regex,
+        allowed_values: raw.allowed_values.clone(),
+    })
 }
 
 fn read_install_record(layout: &TemplateLayout) -> InstalledFrom {


### PR DESCRIPTION
The UI is the usual dialoguer one:

```
$ spin new http-rust tplchoicetest
CUTLERY ME!:
  spork
> another spork
```

Activated by setting `allowed_values = [...]` on the parameter.

We don't need this for any templates in this repo, but https://github.com/spinframework/spin-js-sdk/pull/356 muses about offering a choice of router rather than separate templates.  (Although that idea has gnarlier woes than this!)  Low priority unless JS SDK decides they want to go down that route.
