### PR TITLE
Validate keys before persisting items in Azure CosmosDB key-value store

### DIFF
--- a/crates/key-value-azure/src/store.rs
+++ b/crates/key-value-azure/src/store.rs
@@ -158,7 +158,7 @@ impl Store for AzureCosmosStore {
 
         if key.contains(|c| illegal_chars.contains(&c)) {
             return Err(Error::Other(format!(
-                "Key contains an illegal character. Allowed characters do not include: {}",
+                "Key contains an illegal character. Keys must not include any of: {}",
                 illegal_chars.iter().collect::<String>()
             )));
         }

--- a/crates/key-value-azure/src/store.rs
+++ b/crates/key-value-azure/src/store.rs
@@ -154,6 +154,15 @@ impl Store for AzureCosmosStore {
     }
 
     async fn set(&self, key: &str, value: &[u8]) -> Result<(), Error> {
+        let illegal_chars = ['/', '\\', '?', '#'];
+
+        if key.contains(|c| illegal_chars.contains(&c)) {
+            return Err(Error::Other(format!(
+                "Key contains an illegal character. Allowed characters do not include: {}",
+                illegal_chars.iter().collect::<String>()
+            )));
+        }
+
         let pair = Pair {
             id: key.to_string(),
             value: value.to_vec(),


### PR DESCRIPTION
This PR updates the key-value store implementation for Azure CosmosDB only. 

When calling `set`, the specified `key` is validated according to the Azure SDK documentation (https://learn.microsoft.com/en-us/dotnet/api/microsoft.azure.documents.resource.id?view=azure-dotnet#remarks).

If the key contains an invalid char, the operation is terminated early and a corresponding error is returned.

- [x] passed `cargo build`
- [x] passed `cargo fmt`
- [x] passed `cargo clippy`
- [x] passed `make lint`
- [x] passed `make test`
