### PR TITLE
Update otel dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -867,7 +867,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 1.0.1",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -5533,23 +5533,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3cebff57f7dbd1255b44d8bddc2cebeb0ea677dbaa2e25a3070a91b318f660"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.27.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5feffc321035ad94088a7e5333abb4d84a8726e54a802e736ce9dd7237e85b"
+checksum = "c513c7af3bec30113f3d4620134ff923295f1e9c580fda2b8abe0831f925ddc0"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -5559,22 +5559,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a8a7f5f6ba7c1b286c2fbca0454eaba116f63bbe69ed250b642d36fbb04d80"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
 dependencies = [
  "async-trait",
  "bytes",
  "http 1.1.0",
  "opentelemetry",
  "reqwest 0.12.9",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
 dependencies = [
  "async-trait",
  "futures-core",
@@ -5585,7 +5586,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.3",
  "reqwest 0.12.9",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tokio",
  "tonic",
  "tracing",
@@ -5593,9 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -5605,21 +5606,20 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b742c1cae4693792cc564e58d75a2a0ba29421a34a85b50da92efa89ecb2bc"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
  "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9366,14 +9366,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.1",
  "tower-layer",
  "tower-service",
 ]
@@ -9415,9 +9415,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9436,9 +9436,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,8 +127,8 @@ http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 itertools = "0.13"
-opentelemetry = { version = "0.27", features = ["metrics", "trace", "logs"] }
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
+opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
 rand = "0.8"
 regex = "1"
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
@@ -144,13 +144,13 @@ thiserror = "1"
 tokio = "1"
 toml = "0.8"
 tracing = { version = "0.1", features = ["log"] }
-tracing-opentelemetry = { version = "0.28", default-features = false, features = ["metrics"] }
+tracing-opentelemetry = { version = "0.29", default-features = false, features = ["metrics"] }
 url = "2"
 wasi-common-preview1 = { version = "25.0.0", package = "wasi-common", features = [
   "tokio",
 ] }
-wasm-pkg-common = "0.8"
 wasm-pkg-client = "0.8"
+wasm-pkg-common = "0.8"
 wasmtime = "29.0.1"
 wasmtime-wasi = "29.0.1"
 wasmtime-wasi-http = "29.0.1"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -10,7 +10,7 @@ http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
 opentelemetry = { workspace = true }
 opentelemetry-appender-tracing = "0.28"
-opentelemetry-otlp = { version = "0.28", features = ["http-proto", "http", "reqwest-client", "grpc-tonic"] }
+opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
 opentelemetry_sdk = { workspace = true }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -9,8 +9,8 @@ anyhow = { workspace = true }
 http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
 opentelemetry = { workspace = true }
-opentelemetry-appender-tracing = "0.27"
-opentelemetry-otlp = { version = "0.27", features = ["http-proto", "http", "reqwest-client"] }
+opentelemetry-appender-tracing = "0.28"
+opentelemetry-otlp = { version = "0.28", features = ["http-proto", "http", "reqwest-client", "grpc-tonic"] }
 opentelemetry_sdk = { workspace = true }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -47,7 +47,7 @@ pub use propagation::inject_trace_context;
 /// ```no_run
 /// spin_telemetry::metrics::monotonic_counter!(spin.metric_name = 1, metric_attribute = "value");
 /// ```
-pub fn init(spin_version: String) -> anyhow::Result<ShutdownGuard> {
+pub fn init(spin_version: String) -> anyhow::Result<()> {
     // This layer will print all tracing library log messages to stderr.
     let fmt_layer = fmt::layer()
         .with_writer(std::io::stderr)
@@ -91,18 +91,5 @@ pub fn init(spin_version: String) -> anyhow::Result<ShutdownGuard> {
         logs::init_otel_logging_backend(spin_version)?;
     }
 
-    Ok(ShutdownGuard)
-}
-
-/// An RAII implementation for connection to open telemetry services.
-///
-/// Shutdown of the open telemetry services will happen on `Drop`.
-#[must_use]
-pub struct ShutdownGuard;
-
-impl Drop for ShutdownGuard {
-    fn drop(&mut self) {
-        // Give tracer provider a chance to flush any pending traces.
-        opentelemetry::global::shutdown_tracer_provider();
-    }
+    Ok(())
 }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -1,5 +1,6 @@
 use std::io::IsTerminal;
 
+use anyhow::Context;
 use env::otel_logs_enabled;
 use env::otel_metrics_enabled;
 use env::otel_tracing_enabled;
@@ -65,13 +66,19 @@ pub fn init(spin_version: String) -> anyhow::Result<()> {
         );
 
     let otel_tracing_layer = if otel_tracing_enabled() {
-        Some(traces::otel_tracing_layer(spin_version.clone())?)
+        Some(
+            traces::otel_tracing_layer(spin_version.clone())
+                .context("failed to initialize otel tracing")?,
+        )
     } else {
         None
     };
 
     let otel_metrics_layer = if otel_metrics_enabled() {
-        Some(metrics::otel_metrics_layer(spin_version.clone())?)
+        Some(
+            metrics::otel_metrics_layer(spin_version.clone())
+                .context("failed to initialize otel metrics")?,
+        )
     } else {
         None
     };
@@ -88,7 +95,8 @@ pub fn init(spin_version: String) -> anyhow::Result<()> {
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
 
     if otel_logs_enabled() {
-        logs::init_otel_logging_backend(spin_version)?;
+        logs::init_otel_logging_backend(spin_version)
+            .context("failed to initialize otel logging")?;
     }
 
     Ok(())

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -42,8 +42,7 @@ async fn main() {
 }
 
 async fn _main() -> anyhow::Result<()> {
-    let _telemetry_guard =
-        spin_telemetry::init(VERSION.to_string()).context("Failed to initialize telemetry")?;
+    spin_telemetry::init(VERSION.to_string()).context("Failed to initialize telemetry")?;
 
     let plugin_help_entries = plugin_help_entries();
 


### PR DESCRIPTION
Updates to the 0.28 generation of otel dependencies. There is a newer generation of dependencies, but it's only 5 days old and has yet to be adopted by the ecosystem. Updating to that newer generation should be easy once we're confident the ecosystem has had enough time to adopt it. 