### PR TITLE
Optimize per-request work dispatching to wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8117,9 +8117,11 @@ dependencies = [
  "routefinder",
  "serde",
  "spin-app",
+ "spin-factor-outbound-http",
  "toml",
  "tracing",
  "wasmtime",
+ "wasmtime-wasi",
  "wasmtime-wasi-http",
 ]
 

--- a/crates/factor-outbound-http/src/wasi_2023_10_18.rs
+++ b/crates/factor-outbound-http/src/wasi_2023_10_18.rs
@@ -43,6 +43,7 @@ pub mod exports {
     }
 }
 
+pub use bindings::{Proxy, ProxyIndices};
 use wasi::http::types::{
     Error as HttpError, Fields, FutureIncomingResponse, FutureTrailers, Headers, IncomingBody,
     IncomingRequest, IncomingResponse, Method, OutgoingBody, OutgoingRequest, OutgoingResponse,

--- a/crates/factor-outbound-http/src/wasi_2023_11_10.rs
+++ b/crates/factor-outbound-http/src/wasi_2023_11_10.rs
@@ -47,6 +47,7 @@ pub mod exports {
     }
 }
 
+pub use bindings::{Proxy, ProxyIndices};
 use wasi::http::types::{
     DnsErrorPayload, ErrorCode as HttpErrorCode, FieldSizePayload, Fields, FutureIncomingResponse,
     FutureTrailers, HeaderError, Headers, IncomingBody, IncomingRequest, IncomingResponse, Method,

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -16,11 +16,13 @@ serde = { workspace = true }
 spin-app = { path = "../app", optional = true }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
-wasmtime-wasi-http = { workspace = true, optional = true }
+wasmtime-wasi = { workspace = true }
+wasmtime-wasi-http = { workspace = true }
+spin-factor-outbound-http = { path = "../factor-outbound-http" }
 
 [dev-dependencies]
 toml = { workspace = true }
 
 [features]
 default = ["runtime"]
-runtime = ["dep:spin-app", "dep:wasmtime-wasi-http"]
+runtime = ["dep:spin-app"]

--- a/crates/http/src/trigger.rs
+++ b/crates/http/src/trigger.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
+use spin_factor_outbound_http::wasi_2023_10_18::ProxyIndices as ProxyIndices2023_10_18;
+use spin_factor_outbound_http::wasi_2023_11_10::ProxyIndices as ProxyIndices2023_11_10;
 use wasmtime::component::Component;
+use wasmtime_wasi::bindings::CommandIndices;
+use wasmtime_wasi_http::bindings::ProxyIndices;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -14,64 +18,57 @@ pub fn default_base() -> String {
 }
 
 /// The type of http handler export used by a component.
-#[derive(Clone, Copy)]
 pub enum HandlerType {
     Spin,
-    Wagi,
-    Wasi0_2,
-    Wasi2023_11_10,
-    Wasi2023_10_18,
+    Wagi(CommandIndices),
+    Wasi0_2(ProxyIndices),
+    Wasi2023_11_10(ProxyIndices2023_11_10),
+    Wasi2023_10_18(ProxyIndices2023_10_18),
 }
 
 /// The `incoming-handler` export for `wasi:http` version rc-2023-10-18
-pub const WASI_HTTP_EXPORT_2023_10_18: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-10-18";
+const WASI_HTTP_EXPORT_2023_10_18: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-10-18";
 /// The `incoming-handler` export for `wasi:http` version rc-2023-11-10
-pub const WASI_HTTP_EXPORT_2023_11_10: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-11-10";
+const WASI_HTTP_EXPORT_2023_11_10: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-11-10";
 /// The `incoming-handler` export prefix for all `wasi:http` 0.2 versions
-pub const WASI_HTTP_EXPORT_0_2_PREFIX: &str = "wasi:http/incoming-handler@0.2";
+const WASI_HTTP_EXPORT_0_2_PREFIX: &str = "wasi:http/incoming-handler@0.2";
 /// The `inbound-http` export for `fermyon:spin`
-pub const SPIN_HTTP_EXPORT: &str = "fermyon:spin/inbound-http";
+const SPIN_HTTP_EXPORT: &str = "fermyon:spin/inbound-http";
 
 impl HandlerType {
     /// Determine the handler type from the exports of a component.
-    pub fn from_component(
-        engine: &wasmtime::Engine,
-        component: &Component,
-    ) -> anyhow::Result<HandlerType> {
-        let mut handler_ty = None;
-
-        let mut set = |ty: HandlerType| {
-            if handler_ty.is_none() {
-                handler_ty = Some(ty);
-                Ok(())
-            } else {
-                Err(anyhow::anyhow!(
-                    "component exports multiple different handlers but \
-                     it's expected to export only one"
-                ))
-            }
-        };
-        let ty = component.component_type();
-        for (name, _) in ty.exports(engine) {
-            match name {
-                WASI_HTTP_EXPORT_2023_10_18 => set(HandlerType::Wasi2023_10_18)?,
-                WASI_HTTP_EXPORT_2023_11_10 => set(HandlerType::Wasi2023_11_10)?,
-                SPIN_HTTP_EXPORT => set(HandlerType::Spin)?,
-                name if name.starts_with(WASI_HTTP_EXPORT_0_2_PREFIX) => set(HandlerType::Wasi0_2)?,
-                _ => {}
-            }
+    pub fn from_component(component: &Component) -> anyhow::Result<HandlerType> {
+        let mut candidates = Vec::new();
+        if let Ok(indices) = ProxyIndices::new(component) {
+            candidates.push(HandlerType::Wasi0_2(indices));
+        }
+        if let Ok(indices) = ProxyIndices2023_10_18::new(component) {
+            candidates.push(HandlerType::Wasi2023_10_18(indices));
+        }
+        if let Ok(indices) = ProxyIndices2023_11_10::new(component) {
+            candidates.push(HandlerType::Wasi2023_11_10(indices));
+        }
+        if component.export_index(None, SPIN_HTTP_EXPORT).is_some() {
+            candidates.push(HandlerType::Spin);
         }
 
-        handler_ty.ok_or_else(|| {
-            anyhow::anyhow!(
-                "Expected component to export one of \
-                `{WASI_HTTP_EXPORT_2023_10_18}`, \
-                `{WASI_HTTP_EXPORT_2023_11_10}`, \
-                `{WASI_HTTP_EXPORT_0_2_PREFIX}.*`, \
-                 or `{SPIN_HTTP_EXPORT}` but it exported none of those. \
-                 This may mean the component handles a different trigger, or that its `wasi:http` export is newer then those supported by Spin. \
-                 If you're sure this is an HTTP module, check if a Spin upgrade is available: this may handle the newer version."
-            )
-        })
+        match candidates.len() {
+            0 => {
+                anyhow::bail!(
+                    "Expected component to export one of \
+                    `{WASI_HTTP_EXPORT_2023_10_18}`, \
+                    `{WASI_HTTP_EXPORT_2023_11_10}`, \
+                    `{WASI_HTTP_EXPORT_0_2_PREFIX}.*`, \
+                     or `{SPIN_HTTP_EXPORT}` but it exported none of those. \
+                     This may mean the component handles a different trigger, or that its `wasi:http` export is newer then those supported by Spin. \
+                     If you're sure this is an HTTP module, check if a Spin upgrade is available: this may handle the newer version."
+                )
+            }
+            1 => Ok(candidates.pop().unwrap()),
+            _ => anyhow::bail!(
+                "component exports multiple different handlers but \
+                     it's expected to export only one"
+            ),
+        }
     }
 }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -264,6 +264,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auditable-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,7 +840,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1672,12 +1684,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide 0.8.5",
 ]
 
 [[package]]
@@ -1985,7 +1997,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]
@@ -2621,6 +2632,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2835,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -3534,7 +3551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -4447,11 +4464,11 @@ version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
  "tracing",
- "wasm-encoder 0.217.0",
- "wasm-metadata 0.217.0",
- "wasmparser 0.217.0",
+ "wasm-encoder 0.227.1",
+ "wasm-metadata 0.227.1",
+ "wasmparser 0.227.1",
  "wit-component",
- "wit-parser 0.217.0",
+ "wit-parser 0.227.1",
 ]
 
 [[package]]
@@ -5471,6 +5488,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5935,16 +5958,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88b0814c9a2b323a9b46c687e726996c255ac8b64aa237dd11c81ed4854760"
-dependencies = [
- "leb128",
- "wasmparser 0.217.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
@@ -5961,6 +5974,16 @@ checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
 dependencies = [
  "leb128",
  "wasmparser 0.224.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]
@@ -5981,18 +6004,21 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.217.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a146bf9a60e9264f0548a2599aa9656dba9a641eff9ab88299dc2a637e483c"
+checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
 dependencies = [
  "anyhow",
+ "auditable-serde",
+ "flate2",
  "indexmap 2.7.1",
  "serde",
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.217.0",
- "wasmparser 0.217.0",
+ "url",
+ "wasm-encoder 0.227.1",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]
@@ -6042,20 +6068,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca917a21307d3adf2b9857b94dd05ebf8496bdcff4437a9b9fb3899d3e6c74e7"
-dependencies = [
- "ahash",
- "bitflags 2.6.0",
- "hashbrown 0.14.3",
- "indexmap 2.7.1",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9845c470a2e10b61dd42c385839cdd6496363ed63b5c9e420b5488b77bd22083"
@@ -6076,6 +6088,19 @@ dependencies = [
  "bitflags 2.6.0",
  "indexmap 2.7.1",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
+dependencies = [
+ "bitflags 2.6.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "semver",
+ "serde",
 ]
 
 [[package]]
@@ -6766,9 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.217.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7117809905e49db716d81e794f79590c052bf2fdbbcda1731ca0fb28f6f3ddf"
+checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -6777,28 +6802,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.217.0",
- "wasm-metadata 0.217.0",
- "wasmparser 0.217.0",
- "wit-parser 0.217.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.217.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb893dcd6d370cfdf19a0d9adfcd403efb8e544e1a0ea3a8b81a21fe392eaa78"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.7.1",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.217.0",
+ "wasm-encoder 0.227.1",
+ "wasm-metadata 0.227.1",
+ "wasmparser 0.227.1",
+ "wit-parser 0.227.1",
 ]
 
 [[package]]
@@ -6817,6 +6824,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.221.2",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.7.1",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.227.1",
 ]
 
 [[package]]

--- a/tests/test-components/build.rs
+++ b/tests/test-components/build.rs
@@ -41,7 +41,12 @@ fn main() {
             .arg("build")
             .arg("--target=wasm32-wasip1")
             .env("RUSTFLAGS", rustflags())
-            .env("CARGO_TARGET_DIR", &out_dir);
+            .env("CARGO_TARGET_DIR", &out_dir)
+            // If RUSTFLAGS was set it'll be passed to this build script through
+            // this variable but since we're cross-compiling to wasm we almost
+            // surely don't want this to get picked up, so remove this from the
+            // destination flags.
+            .env_remove("CARGO_ENCODED_RUSTFLAGS");
         eprintln!("running: {cargo:?}");
         let status = cargo.status().expect("`cargo build` failed");
         assert!(status.success(), "{status:?}");


### PR DESCRIPTION
This commit implements an optimization available from Wasmtime to improve the per-request dispatching to a wasm handler for an HTTP request. Previously the typed view of a request handler was loaded on each request but this involves somewhat expensive work such as:

* A number of string lookups to find the right export.
* A type-check to ensure that the component export has the right type.

This can all be front-loaded to component-load time with `*Indices` structures that are generated by Wasmtime's `bindgen!` macro. This commit uses these generated structures to replace handler detection and then plumbs the final `*Indices` structure to dispatching the request so the dispatch doesn't need to perform extra work per-request.