### PR TITLE
ci(.github): bump ubuntu runners to 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   dependency-review:
     name: Review new dependencies for known vulnerabilities
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: 'Checkout Repository'
@@ -32,7 +32,7 @@ jobs:
 
   lint-rust:
     name: Lint Rust
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     permissions:
       ## Allow this job to potentially cancel the running workflow (on failure)
       actions: write
@@ -55,7 +55,7 @@ jobs:
   ## This is separated out to remove full integration tests dependencies on windows/mac builds
   build-rust-ubuntu:
     name: Build Spin Ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
@@ -79,7 +79,7 @@ jobs:
 
   build-spin-static:
     name: Build Spin static
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         config:
@@ -225,7 +225,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               arch: "amd64",
               extension: "",
               # Ubuntu 22.04 no longer ships libssl1.1, so we statically
@@ -235,7 +235,7 @@ jobs:
               targetDir: "target/release",
             }
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               arch: "aarch64",
               extension: "",
               extraArgs: "--features openssl/vendored --target aarch64-unknown-linux-gnu",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         config:
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               arch: "amd64",
               extension: "",
               # Ubuntu 22.04 no longer ships libssl1.1, so we statically
@@ -36,7 +36,7 @@ jobs:
               targetDir: "target/release",
             }
           - {
-              os: "ubuntu-20.04",
+              os: "ubuntu-22.04",
               arch: "aarch64",
               extension: "",
               extraArgs: "--features openssl/vendored --target aarch64-unknown-linux-gnu",
@@ -265,7 +265,7 @@ jobs:
   ## statically linked spin binaries
   build-spin-static:
     name: Build Spin static
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       # cosign uses the GitHub OIDC token
       id-token: write
@@ -363,7 +363,7 @@ jobs:
           client-payload: '{"version": "${{ github.ref_name }}"}'
 
   docker:
-    runs-on: "ubuntu-20.04"
+    runs-on: "ubuntu-22.04"
     needs: [build-and-sign, build-spin-static]
     # Only build/push Docker images if this is a v* tag or if this is main/canary
     # i.e. skip for v* release branches


### PR DESCRIPTION
- Bumps the Ubuntu runner images to 22.04 per the [deprecation of 20.04](https://github.com/actions/runner-images/issues/11101)

(Hitting the first of the brown outs today; 20.04 runners fully removed on 4/15)

I can't recall if there are lib/etc considerations we need to make when bumping the Ubuntu runners (maybe particularly for the static builds)?  _edit: If so, let's create follow-up(s); merging to unblock CI_