### PR TITLE
chore: add SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security
+
+## Reporting a Vulnerability
+
+The Spin team and community take security vulnerabilities very seriously. If you find a security related issue with Spin, we kindly ask you to report it [through the GitHub project](https://github.com/spinframework/spin/security). All reports will be thoroughly investigated by the Spin maintainers.
+
+## Disclosure
+
+We will disclose any security vulnerabilities in our [Security Advisories](https://github.com/spinframework/spin/security/advisories).
+
+All vulnerabilities and associated information will be treated with full confidentiality. We are thankful for your efforts in keeping Spin secure, and we will publicly acknowledge your contributions if you wish.


### PR DESCRIPTION
closes https://github.com/spinframework/spin/issues/3077

once we have a security mailing list for maintainers, we can add an email option, as well