### PR TITLE
Fix subsets inheriting service chaining requirement from whole app

### DIFF
--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -16,8 +16,8 @@ use std::{collections::HashMap, sync::Arc};
 
 pub use config::{
     allowed_outbound_hosts, is_service_chaining_host, parse_service_chaining_target,
-    validate_service_chaining_for_components, AllowedHostConfig, AllowedHostsConfig, HostConfig,
-    OutboundUrl, SERVICE_CHAINING_DOMAIN_SUFFIX,
+    update_service_chaining_host_requirement, validate_service_chaining_for_components,
+    AllowedHostConfig, AllowedHostsConfig, HostConfig, OutboundUrl, SERVICE_CHAINING_DOMAIN_SUFFIX,
 };
 
 pub use runtime_config::ComponentTlsConfigs;


### PR DESCRIPTION
Fixes #2915 and #3088 

When an application uses local service chaining, this is noted in the lockfile, so that if a host can't provide the service chaining guarantees, it can reject the application at load time.

Unfortunately, this does not play nicely with application splitting or multi-trigger applications.  If a host doesn't support service chaining, it's perfectly safe for that host to run a _subset_ of the app that doesn't use service chaining.  But currently this doesn't work because the lockfile's "host requirements" section is calculated on the basis of the _whole_ app not the subset.

I don't much love the fix in this PR.  I've added a pass to app splitting/subsetting to recalculate if service chaining is needed, but this duplicates a lot of the existing validation pass.  (Perhaps they could/should be combined?  Allowing a validator to mutate the validatee revolts my gentle spirit though.)  The PR also, of necessity, creates separate lockfiles to pass to different trigger binaries, each with only the components used by the relevant trigger type.  This feels like a substantial and complicating change to a simple protocol that has served us well since the early days.  I'm also anxious about unintended consequences of deferring the creation of the lockfile.

Anyway putting it up as a draft so that knowledgeable folks can weigh in on better approaches and possible impacts.  (And so I can see if it blows up the integration tests!)

cc @kate-goldenring as the app splitting expert!
