### PR TITLE
SQLite affected row count and last_insert_rowid

### DIFF
--- a/crates/factor-sqlite/src/host.rs
+++ b/crates/factor-sqlite/src/host.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use spin_factors::wasmtime::component::Resource;
 use spin_factors::{anyhow, SelfInstanceBuilder};
+use spin_world::spin::sqlite::sqlite as v3;
 use spin_world::v1::sqlite as v1;
 use spin_world::v2::sqlite as v2;
 use tracing::field::Empty;
@@ -34,14 +35,48 @@ impl InstanceState {
     }
 
     /// Get a connection for a given database label.
-    fn get_connection(
+    fn get_connection<T: 'static>(
         &self,
-        connection: Resource<v2::Connection>,
-    ) -> Result<&dyn Connection, v2::Error> {
+        connection: Resource<T>,
+    ) -> Result<&dyn Connection, v3::Error> {
         self.connections
             .get(connection.rep())
             .map(|conn| conn.as_ref())
-            .ok_or(v2::Error::InvalidConnection)
+            .ok_or(v3::Error::InvalidConnection)
+    }
+
+    async fn open_impl<T: 'static>(&mut self, database: String) -> Result<Resource<T>, v3::Error> {
+        if !self.allowed_databases.contains(&database) {
+            return Err(v3::Error::AccessDenied);
+        }
+        let conn = self
+            .connection_creators
+            .get(&database)
+            .ok_or(v3::Error::NoSuchDatabase)?
+            .create_connection(&database)
+            .await?;
+        tracing::Span::current().record(
+            "sqlite.backend",
+            conn.summary().as_deref().unwrap_or("unknown"),
+        );
+        self.connections
+            .push(conn)
+            .map_err(|()| v3::Error::Io("too many connections opened".to_string()))
+            .map(Resource::new_own)
+    }
+
+    async fn execute_impl<T: 'static>(
+        &mut self,
+        connection: Resource<T>,
+        query: String,
+        parameters: Vec<v3::Value>,
+    ) -> Result<v3::QueryResult, v3::Error> {
+        let conn = self.get_connection(connection)?;
+        tracing::Span::current().record(
+            "sqlite.backend",
+            conn.summary().as_deref().unwrap_or("unknown"),
+        );
+        conn.query(&query, parameters).await
     }
 
     /// Get the set of allowed databases.
@@ -52,6 +87,64 @@ impl InstanceState {
 
 impl SelfInstanceBuilder for InstanceState {}
 
+impl v3::Host for InstanceState {
+    fn convert_error(&mut self, error: v3::Error) -> anyhow::Result<v3::Error> {
+        Ok(error)
+    }
+}
+
+impl v3::HostConnection for InstanceState {
+    #[instrument(name = "spin_sqlite.open", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", sqlite.backend = Empty))]
+    async fn open(&mut self, database: String) -> Result<Resource<v3::Connection>, v3::Error> {
+        self.open_impl(database).await
+    }
+
+    #[instrument(name = "spin_sqlite.execute", skip(self, connection, parameters), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query, sqlite.backend = Empty))]
+    async fn execute(
+        &mut self,
+        connection: Resource<v3::Connection>,
+        query: String,
+        parameters: Vec<v3::Value>,
+    ) -> Result<v3::QueryResult, v3::Error> {
+        self.execute_impl(connection, query, parameters).await
+    }
+
+    async fn changes(
+        &mut self,
+        connection: Resource<v3::Connection>,
+    ) -> spin_factors::wasmtime::Result<u64> {
+        let conn = match self.get_connection(connection) {
+            Ok(c) => c,
+            Err(err) => return Err(err.into()),
+        };
+        tracing::Span::current().record(
+            "sqlite.backend",
+            conn.summary().as_deref().unwrap_or("unknown"),
+        );
+        conn.changes().await.map_err(|e| e.into())
+    }
+
+    async fn last_insert_rowid(
+        &mut self,
+        connection: Resource<v3::Connection>,
+    ) -> spin_factors::wasmtime::Result<i64> {
+        let conn = match self.get_connection(connection) {
+            Ok(c) => c,
+            Err(err) => return Err(err.into()),
+        };
+        tracing::Span::current().record(
+            "sqlite.backend",
+            conn.summary().as_deref().unwrap_or("unknown"),
+        );
+        conn.last_insert_rowid().await.map_err(|e| e.into())
+    }
+
+    async fn drop(&mut self, connection: Resource<v3::Connection>) -> anyhow::Result<()> {
+        let _ = self.connections.remove(connection.rep());
+        Ok(())
+    }
+}
+
 impl v2::Host for InstanceState {
     fn convert_error(&mut self, error: v2::Error) -> anyhow::Result<v2::Error> {
         Ok(error)
@@ -61,23 +154,7 @@ impl v2::Host for InstanceState {
 impl v2::HostConnection for InstanceState {
     #[instrument(name = "spin_sqlite.open", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", sqlite.backend = Empty))]
     async fn open(&mut self, database: String) -> Result<Resource<v2::Connection>, v2::Error> {
-        if !self.allowed_databases.contains(&database) {
-            return Err(v2::Error::AccessDenied);
-        }
-        let conn = self
-            .connection_creators
-            .get(&database)
-            .ok_or(v2::Error::NoSuchDatabase)?
-            .create_connection(&database)
-            .await?;
-        tracing::Span::current().record(
-            "sqlite.backend",
-            conn.summary().as_deref().unwrap_or("unknown"),
-        );
-        self.connections
-            .push(conn)
-            .map_err(|()| v2::Error::Io("too many connections opened".to_string()))
-            .map(Resource::new_own)
+        self.open_impl(database).await.map_err(to_v2_error)
     }
 
     #[instrument(name = "spin_sqlite.execute", skip(self, connection, parameters), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query, sqlite.backend = Empty))]
@@ -87,15 +164,14 @@ impl v2::HostConnection for InstanceState {
         query: String,
         parameters: Vec<v2::Value>,
     ) -> Result<v2::QueryResult, v2::Error> {
-        let conn = match self.get_connection(connection) {
-            Ok(c) => c,
-            Err(err) => return Err(err),
-        };
-        tracing::Span::current().record(
-            "sqlite.backend",
-            conn.summary().as_deref().unwrap_or("unknown"),
-        );
-        conn.query(&query, parameters).await
+        self.execute_impl(
+            connection,
+            query,
+            parameters.into_iter().map(from_v2_value).collect(),
+        )
+        .await
+        .map(to_v2_query_result)
+        .map_err(to_v2_error)
     }
 
     async fn drop(&mut self, connection: Resource<v2::Connection>) -> anyhow::Result<()> {
@@ -106,7 +182,7 @@ impl v2::HostConnection for InstanceState {
 
 impl v1::Host for InstanceState {
     async fn open(&mut self, database: String) -> Result<u32, v1::Error> {
-        let result = <Self as v2::HostConnection>::open(self, database).await;
+        let result = <Self as v3::HostConnection>::open(self, database).await;
         result.map_err(to_legacy_error).map(|s| s.rep())
     }
 
@@ -117,7 +193,7 @@ impl v1::Host for InstanceState {
         parameters: Vec<spin_world::v1::sqlite::Value>,
     ) -> Result<spin_world::v1::sqlite::QueryResult, v1::Error> {
         let this = Resource::new_borrow(connection);
-        let result = <Self as v2::HostConnection>::execute(
+        let result = <Self as v3::HostConnection>::execute(
             self,
             this,
             query,
@@ -136,45 +212,88 @@ impl v1::Host for InstanceState {
     }
 }
 
-fn to_legacy_error(error: v2::Error) -> v1::Error {
+fn to_v2_error(error: v3::Error) -> v2::Error {
     match error {
-        v2::Error::NoSuchDatabase => v1::Error::NoSuchDatabase,
-        v2::Error::AccessDenied => v1::Error::AccessDenied,
-        v2::Error::InvalidConnection => v1::Error::InvalidConnection,
-        v2::Error::DatabaseFull => v1::Error::DatabaseFull,
-        v2::Error::Io(s) => v1::Error::Io(s),
+        v3::Error::NoSuchDatabase => v2::Error::NoSuchDatabase,
+        v3::Error::AccessDenied => v2::Error::AccessDenied,
+        v3::Error::InvalidConnection => v2::Error::InvalidConnection,
+        v3::Error::DatabaseFull => v2::Error::DatabaseFull,
+        v3::Error::Io(s) => v2::Error::Io(s),
     }
 }
 
-fn to_legacy_query_result(result: v2::QueryResult) -> v1::QueryResult {
+fn to_legacy_error(error: v3::Error) -> v1::Error {
+    match error {
+        v3::Error::NoSuchDatabase => v1::Error::NoSuchDatabase,
+        v3::Error::AccessDenied => v1::Error::AccessDenied,
+        v3::Error::InvalidConnection => v1::Error::InvalidConnection,
+        v3::Error::DatabaseFull => v1::Error::DatabaseFull,
+        v3::Error::Io(s) => v1::Error::Io(s),
+    }
+}
+
+fn to_v2_query_result(result: v3::QueryResult) -> v2::QueryResult {
+    v2::QueryResult {
+        columns: result.columns,
+        rows: result.rows.into_iter().map(to_v2_row_result).collect(),
+    }
+}
+
+fn to_legacy_query_result(result: v3::QueryResult) -> v1::QueryResult {
     v1::QueryResult {
         columns: result.columns,
         rows: result.rows.into_iter().map(to_legacy_row_result).collect(),
     }
 }
 
-fn to_legacy_row_result(result: v2::RowResult) -> v1::RowResult {
+fn to_v2_row_result(result: v3::RowResult) -> v2::RowResult {
+    v2::RowResult {
+        values: result.values.into_iter().map(to_v2_value).collect(),
+    }
+}
+
+fn to_legacy_row_result(result: v3::RowResult) -> v1::RowResult {
     v1::RowResult {
         values: result.values.into_iter().map(to_legacy_value).collect(),
     }
 }
 
-fn to_legacy_value(value: v2::Value) -> v1::Value {
+fn to_v2_value(value: v3::Value) -> v2::Value {
     match value {
-        v2::Value::Integer(i) => v1::Value::Integer(i),
-        v2::Value::Real(r) => v1::Value::Real(r),
-        v2::Value::Text(t) => v1::Value::Text(t),
-        v2::Value::Blob(b) => v1::Value::Blob(b),
-        v2::Value::Null => v1::Value::Null,
+        v3::Value::Integer(i) => v2::Value::Integer(i),
+        v3::Value::Real(r) => v2::Value::Real(r),
+        v3::Value::Text(t) => v2::Value::Text(t),
+        v3::Value::Blob(b) => v2::Value::Blob(b),
+        v3::Value::Null => v2::Value::Null,
     }
 }
 
-fn from_legacy_value(value: v1::Value) -> v2::Value {
+fn to_legacy_value(value: v3::Value) -> v1::Value {
     match value {
-        v1::Value::Integer(i) => v2::Value::Integer(i),
-        v1::Value::Real(r) => v2::Value::Real(r),
-        v1::Value::Text(t) => v2::Value::Text(t),
-        v1::Value::Blob(b) => v2::Value::Blob(b),
-        v1::Value::Null => v2::Value::Null,
+        v3::Value::Integer(i) => v1::Value::Integer(i),
+        v3::Value::Real(r) => v1::Value::Real(r),
+        v3::Value::Text(t) => v1::Value::Text(t),
+        v3::Value::Blob(b) => v1::Value::Blob(b),
+        v3::Value::Null => v1::Value::Null,
+    }
+}
+
+fn from_v2_value(value: v2::Value) -> v3::Value {
+    match value {
+        v2::Value::Integer(i) => v3::Value::Integer(i),
+        v2::Value::Real(r) => v3::Value::Real(r),
+        v2::Value::Text(t) => v3::Value::Text(t),
+        v2::Value::Blob(b) => v3::Value::Blob(b),
+        v2::Value::Null => v3::Value::Null,
+    }
+}
+
+fn from_legacy_value(value: v1::Value) -> v3::Value {
+    match value {
+        v1::Value::Integer(i) => v3::Value::Integer(i),
+        v1::Value::Real(r) => v3::Value::Real(r),
+        v1::Value::Text(t) => v3::Value::Text(t),
+        v1::Value::Blob(b) => v3::Value::Blob(b),
+        v1::Value::Null => v3::Value::Null,
     }
 }

--- a/crates/factor-sqlite/tests/factor_test.rs
+++ b/crates/factor-sqlite/tests/factor_test.rs
@@ -9,7 +9,7 @@ use spin_factors::{
     RuntimeFactors,
 };
 use spin_factors_test::{toml, TestEnvironment};
-use spin_world::{async_trait, v2::sqlite as v2};
+use spin_world::{async_trait, spin::sqlite::sqlite as v3, v2::sqlite as v2};
 use v2::HostConnection as _;
 
 #[derive(RuntimeFactors)]
@@ -103,7 +103,7 @@ impl spin_factor_sqlite::ConnectionCreator for MockConnectionCreator {
     async fn create_connection(
         &self,
         label: &str,
-    ) -> Result<Box<dyn spin_factor_sqlite::Connection + 'static>, v2::Error> {
+    ) -> Result<Box<dyn spin_factor_sqlite::Connection + 'static>, v3::Error> {
         let _ = label;
         Ok(Box::new(MockConnection))
     }
@@ -117,14 +117,22 @@ impl spin_factor_sqlite::Connection for MockConnection {
     async fn query(
         &self,
         query: &str,
-        parameters: Vec<v2::Value>,
-    ) -> Result<v2::QueryResult, v2::Error> {
+        parameters: Vec<v3::Value>,
+    ) -> Result<v3::QueryResult, v3::Error> {
         let _ = (query, parameters);
-        Err(v2::Error::Io("Mock connection".into()))
+        Err(v3::Error::Io("Mock connection".into()))
     }
 
     async fn execute_batch(&self, statements: &str) -> anyhow::Result<()> {
         let _ = statements;
         bail!("Mock connection")
+    }
+
+    async fn changes(&self) -> Result<u64, v3::Error> {
+        Ok(123)
+    }
+
+    async fn last_insert_rowid(&self) -> Result<i64, v3::Error> {
+        Ok(456)
     }
 }

--- a/crates/sqlite-inproc/src/lib.rs
+++ b/crates/sqlite-inproc/src/lib.rs
@@ -7,7 +7,7 @@ use std::{
 use anyhow::Context as _;
 use async_trait::async_trait;
 use spin_factor_sqlite::Connection;
-use spin_world::v2::sqlite;
+use spin_world::spin::sqlite::sqlite;
 
 /// The location of an in-process sqlite database.
 #[derive(Debug, Clone)]
@@ -104,6 +104,18 @@ impl Connection for InProcConnection {
         .await?
         .context("failed to spawn blocking task")?;
         Ok(())
+    }
+
+    async fn changes(&self) -> Result<u64, sqlite::Error> {
+        let connection = self.db_connection()?;
+        let conn = connection.lock().unwrap();
+        Ok(conn.changes())
+    }
+
+    async fn last_insert_rowid(&self) -> Result<i64, sqlite::Error> {
+        let connection = self.db_connection()?;
+        let conn = connection.lock().unwrap();
+        Ok(conn.last_insert_rowid())
     }
 
     fn summary(&self) -> Option<String> {

--- a/crates/trigger/src/cli/sqlite_statements.rs
+++ b/crates/trigger/src/cli/sqlite_statements.rs
@@ -109,7 +109,7 @@ mod tests {
 
     use spin_core::async_trait;
     use spin_factor_sqlite::{Connection, ConnectionCreator};
-    use spin_world::v2::sqlite as v2;
+    use spin_world::spin::sqlite::sqlite as v3;
     use tempfile::NamedTempFile;
 
     use super::*;
@@ -183,7 +183,7 @@ mod tests {
         async fn create_connection(
             &self,
             label: &str,
-        ) -> Result<Box<dyn Connection + 'static>, v2::Error> {
+        ) -> Result<Box<dyn Connection + 'static>, v3::Error> {
             self.push(label);
             Ok(Box::new(MockConnection {
                 tx: self.tx.clone(),
@@ -200,11 +200,11 @@ mod tests {
         async fn query(
             &self,
             query: &str,
-            parameters: Vec<v2::Value>,
-        ) -> Result<v2::QueryResult, v2::Error> {
+            parameters: Vec<v3::Value>,
+        ) -> Result<v3::QueryResult, v3::Error> {
             self.tx.send(Action::Query(query.to_string())).unwrap();
             let _ = parameters;
-            Ok(v2::QueryResult {
+            Ok(v3::QueryResult {
                 columns: Vec::new(),
                 rows: Vec::new(),
             })
@@ -216,6 +216,16 @@ mod tests {
                 .unwrap();
             Ok(())
         }
+
+        async fn changes(&self) -> Result<u64, v3::Error> {
+            self.tx.send(Action::Changes).unwrap();
+            Ok(123)
+        }
+
+        async fn last_insert_rowid(&self) -> Result<i64, v3::Error> {
+            self.tx.send(Action::LastInsertRowid).unwrap();
+            Ok(456)
+        }
     }
 
     #[derive(Debug, PartialEq)]
@@ -223,5 +233,7 @@ mod tests {
         CreateConnection(String),
         Query(String),
         Execute(String),
+        Changes,
+        LastInsertRowid,
     }
 }

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -31,6 +31,7 @@ wasmtime::component::bindgen!({
         "fermyon:spin/sqlite/error" => v1::sqlite::Error,
         "fermyon:spin/variables@2.0.0/error" => v2::variables::Error,
         "spin:postgres/postgres/error" => spin::postgres::postgres::Error,
+        "spin:sqlite/sqlite/error" => spin::sqlite::sqlite::Error,
         "wasi:config/store@0.2.0-draft-2024-09-27/error" => wasi::config::store::Error,
         "wasi:keyvalue/store/error" => wasi::keyvalue::store::Error,
         "wasi:keyvalue/atomics/cas-error" => wasi::keyvalue::atomics::CasError,

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -10,6 +10,7 @@ wasmtime::component::bindgen!({
         include fermyon:spin/host;
         include fermyon:spin/platform@2.0.0;
         include fermyon:spin/platform@3.0.0;
+        include spin:up/platform@3.2.0;
         include wasi:keyvalue/imports@0.2.0-draft2;
     }
     "#,

--- a/tests/test-components/helper/src/lib.rs
+++ b/tests/test-components/helper/src/lib.rs
@@ -17,7 +17,7 @@ use bindings::wasi::io0_2_0::streams::OutputStream;
 #[cfg(feature = "define-component")]
 pub mod http_trigger_bindings {
     wit_bindgen::generate!({
-        world: "fermyon:spin/http-trigger@3.0.0",
+        world: "spin:up/http-trigger@3.2.0",
         path: "../../../wit",
         generate_all,
         pub_export_macro: true,

--- a/wit/deps/spin-sqlite@3.0.0/sqlite.wit
+++ b/wit/deps/spin-sqlite@3.0.0/sqlite.wit
@@ -1,0 +1,60 @@
+package spin:sqlite@3.0.0;
+
+interface sqlite {
+  /// A handle to an open sqlite instance
+  resource connection {
+    /// Open a connection to a named database instance.
+    ///
+    /// If `database` is "default", the default instance is opened.
+    ///
+    /// `error::no-such-database` will be raised if the `name` is not recognized.
+    open: static func(database: string) -> result<connection, error>;
+
+    /// Execute a statement returning back data if there is any
+    execute: func(statement: string, parameters: list<value>) -> result<query-result, error>;
+
+    /// The SQLite rowid of the most recent successful INSERT on the connection, or 0 if
+    /// there has not yet been an INSERT on the connection.
+    last-insert-rowid: func() -> s64;
+
+    /// The number of rows modified, inserted or deleted by the most recently completed
+    /// INSERT, UPDATE or DELETE statement on the connection.
+    changes: func() -> u64;
+  }
+
+  /// The set of errors which may be raised by functions in this interface
+  variant error {
+    /// The host does not recognize the database name requested.
+    no-such-database,
+    /// The requesting component does not have access to the specified database (which may or may not exist).
+    access-denied,
+    /// The provided connection is not valid
+    invalid-connection,
+    /// The database has reached its capacity
+    database-full,
+    /// Some implementation-specific error has occurred (e.g. I/O)
+    io(string)
+  }
+
+  /// A result of a query
+  record query-result {
+    /// The names of the columns retrieved in the query
+    columns: list<string>,
+    /// the row results each containing the values for all the columns for a given row
+    rows: list<row-result>,
+  }
+
+  /// A set of values for each of the columns in a query-result
+  record row-result {
+    values: list<value>
+  }
+
+  /// A single column's result from a database query
+  variant value {
+    integer(s64),
+    real(f64),
+    text(string),
+    blob(list<u8>),
+    null
+  }
+}

--- a/wit/deps/spin@3.0.0/world.wit
+++ b/wit/deps/spin@3.0.0/world.wit
@@ -1,4 +1,4 @@
-package spin:up@3.2.0;
+package fermyon:spin@3.0.0;
 
 /// The full world of a guest targeting an http-trigger
 world http-trigger {
@@ -11,6 +11,5 @@ world platform {
   include fermyon:spin/platform@2.0.0;
   include wasi:keyvalue/imports@0.2.0-draft2;
   import spin:postgres/postgres@3.0.0;
-  import spin:sqlite/sqlite@3.0.0;
   import wasi:config/store@0.2.0-draft-2024-09-27;
 }

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -11,5 +11,6 @@ world platform {
   include fermyon:spin/platform@2.0.0;
   include wasi:keyvalue/imports@0.2.0-draft2;
   import spin:postgres/postgres@3.0.0;
+  import spin:sqlite/sqlite@3.0.0;
   import wasi:config/store@0.2.0-draft-2024-09-27;
 }


### PR DESCRIPTION
Fixes #3092.

**~WIP for now~**

This adds two functions to the SQLite `connection` resource:

* `changes()` - the number of rows affected by the last insert/delete/update
* `last_insert_rowid()` - the rowid of the last inserted row

The names are taken from the SQLite API, and I'm in favour of sticking with that standard rather than giving them names that might be more self-documenting (stop shuffling your feet at the back, `changes`).

WIPness: the new functions appear to work but:

* ~It needs tests~ Added to the existing SQLite test
* It needs trying with libSQL
* ~It needs a world update (for dev purposes I shoved it into the 3.0 world but that's not appropriate for shipping)~ Done - see separate comment below
* ~I want to try to remove the v2/v3 duplication~ Done (hopefully satisfactorily)

I'm putting it into PR now so that 1. the integration tests pick up any regressions and 2. if folks have other things they want to put in then we can consider rolling them into a single rev.

The new interface is backward compatible and I did consider doing one of those "since" things to make it a minor version rev, which would eliminate all the duplication, but I provisionally went for a new interface because we are trying to shift from the `fermyon:` namespace to a `spin:` namespace.  Happy to receive feedback on this!
