### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,14 +200,14 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.22'
+          go-version: '1.23'
           cache-dependency-path: "**/go.sum"  # To suppress warning: https://github.com/actions/setup-go/issues/427
       - uses: acifani/setup-tinygo@v2
         with:
-          tinygo-version: '0.35.0'
+          tinygo-version: '0.37.0'
       - uses: actions/setup-node@v3
         with:
-          node-version: '20.x'
+          node-version: '22.x'
       - name: Install Grain
         run: |
           wget https://github.com/grain-lang/grain/releases/download/grain-v0.6.6/grain-linux-x64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2379,13 +2379,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -2397,8 +2406,20 @@ checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.4.6",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2408,7 +2429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -3216,6 +3237,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "getset"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3597,11 +3630,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -4620,9 +4653,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -6395,6 +6428,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6419,6 +6458,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6439,6 +6488,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6454,6 +6513,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -6606,6 +6674,17 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6874,14 +6953,14 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
  "bitflags 2.6.0",
  "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink 0.10.0",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -7668,7 +7747,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "indicatif",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static 1.5.0",
  "levenshtein",
  "nix 0.29.0",
@@ -7723,7 +7802,7 @@ name = "spin-common"
 version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "sha2",
  "tempfile",
  "tokio",
@@ -7737,7 +7816,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cap-std",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",
@@ -7768,7 +7847,7 @@ dependencies = [
  "spin-common",
  "spin-componentize",
  "spin-serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "wac-graph",
 ]
@@ -7820,7 +7899,7 @@ dependencies = [
  "async-trait",
  "futures",
  "spin-locked-app",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
 ]
@@ -7840,7 +7919,7 @@ dependencies = [
  "spin-resource-table",
  "spin-world",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tracing",
@@ -8041,7 +8120,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-factors-derive",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "toml",
  "wasmtime",
 ]
@@ -8164,7 +8243,7 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "candle-transformers",
- "rand 0.8.5",
+ "rand 0.9.1",
  "safetensors",
  "serde",
  "serde_json",
@@ -8194,7 +8273,7 @@ name = "spin-loader"
 version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "futures",
  "glob",
  "path-absolutize",
@@ -8225,7 +8304,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -8240,7 +8319,7 @@ dependencies = [
  "serde_json",
  "spin-serde",
  "terminal",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "toml",
  "ui-testing",
  "url",
@@ -8256,11 +8335,11 @@ dependencies = [
  "async-tar",
  "base64 0.22.1",
  "chrono",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "dkregistry",
  "docker_credential",
  "futures-util",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "oci-distribution",
  "reqwest 0.12.9",
  "serde",
@@ -8285,7 +8364,7 @@ version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
  "chrono",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "fd-lock",
  "flate2",
  "is-terminal",
@@ -8298,7 +8377,7 @@ dependencies = [
  "tar",
  "tempfile",
  "terminal",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
@@ -8441,7 +8520,7 @@ dependencies = [
  "fs_extra",
  "heck 0.5.0",
  "indexmap 2.7.1",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "lazy_static 1.5.0",
  "liquid",
  "liquid-core",
@@ -9515,7 +9594,7 @@ name = "ui-testing"
 version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "libtest-mimic",
  "snapbox",
  "tokio",
@@ -9936,6 +10015,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasite"
@@ -11159,6 +11247,15 @@ checksum = "f9643b83820c0cd246ecabe5fa454dd04ba4fa67996369466d0747472d337346"
 dependencies = [
  "bitflags 2.6.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,12 +1465,6 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
@@ -1597,7 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f3f22f1a586604e62efd23f78218f3ccdecf7a33c4500db2d37d85a24fe994"
 dependencies = [
  "nix 0.26.4",
- "terminfo",
+ "terminfo 0.8.0",
  "thiserror 1.0.69",
  "which 4.4.2",
  "winapi",
@@ -1605,15 +1599,15 @@ dependencies = [
 
 [[package]]
 name = "clearscreen"
-version = "3.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8c93eb5f77c9050c7750e14f13ef1033a40a0aac70c6371535b6763a01438c"
+checksum = "8c41dc435a7b98e4608224bbf65282309f5403719df9113621b30f8b6f74e2f4"
 dependencies = [
- "nix 0.28.0",
- "terminfo",
- "thiserror 1.0.69",
- "which 6.0.3",
- "winapi",
+ "nix 0.29.0",
+ "terminfo 0.9.0",
+ "thiserror 2.0.12",
+ "which 7.0.3",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2624,6 +2618,12 @@ dependencies = [
  "quote",
  "syn 2.0.87",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -5154,25 +5154,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "cfg_aliases 0.1.1",
- "libc",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "memoffset 0.9.1",
 ]
@@ -6410,7 +6398,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
- "cfg_aliases 0.2.1",
+ "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
@@ -7733,7 +7721,7 @@ dependencies = [
  "bytes",
  "cargo-target-dep",
  "clap 3.2.25",
- "clearscreen 3.0.0",
+ "clearscreen 4.0.1",
  "comfy-table",
  "command-group",
  "conformance",
@@ -8953,6 +8941,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
 dependencies = [
  "dirs 4.0.0",
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
  "fnv",
  "nom",
  "phf",
@@ -10833,13 +10833,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "6.0.3"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
- "home",
- "rustix 0.38.40",
+ "env_home",
+ "rustix 1.0.5",
  "winsafe",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,42 +1217,48 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.6.1"
-source = "git+https://github.com/huggingface/candle?rev=e3261216b157a7305c18ccdd766b6e2a41afe483#e3261216b157a7305c18ccdd766b6e2a41afe483"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
 dependencies = [
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
  "cudarc",
- "gemm",
+ "gemm 0.17.1",
  "half",
  "memmap2 0.9.5",
- "metal",
+ "metal 0.27.0",
  "num-traits",
  "num_cpus",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_distr",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "thiserror 1.0.69",
+ "ug",
+ "ug-cuda",
+ "ug-metal",
  "yoke",
  "zip",
 ]
 
 [[package]]
 name = "candle-kernels"
-version = "0.6.1"
-source = "git+https://github.com/huggingface/candle?rev=e3261216b157a7305c18ccdd766b6e2a41afe483#e3261216b157a7305c18ccdd766b6e2a41afe483"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10885bd902fad1b8518ba2b22369aaed88a3d94e123533ad3ca73db33b1c8ca"
 dependencies = [
  "bindgen_cuda",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.6.1"
-source = "git+https://github.com/huggingface/candle?rev=e3261216b157a7305c18ccdd766b6e2a41afe483#e3261216b157a7305c18ccdd766b6e2a41afe483"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c85c21827c28db94e7112e364abe7e0cf8d2b022c014edf08642be6b94f21e"
 dependencies = [
- "metal",
+ "metal 0.27.0",
  "once_cell",
  "thiserror 1.0.69",
  "tracing",
@@ -1260,31 +1266,33 @@ dependencies = [
 
 [[package]]
 name = "candle-nn"
-version = "0.6.1"
-source = "git+https://github.com/huggingface/candle?rev=e3261216b157a7305c18ccdd766b6e2a41afe483#e3261216b157a7305c18ccdd766b6e2a41afe483"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
  "half",
- "metal",
+ "metal 0.27.0",
  "num-traits",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "serde",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "candle-transformers"
-version = "0.6.1"
-source = "git+https://github.com/huggingface/candle?rev=e3261216b157a7305c18ccdd766b6e2a41afe483#e3261216b157a7305c18ccdd766b6e2a41afe483"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a0900d49f8605e0e7e6693a1f560e6271279de98e5fa369e7abf3aac245020"
 dependencies = [
  "byteorder",
  "candle-core",
  "candle-nn",
  "fancy-regex",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rayon",
  "serde",
  "serde_json",
@@ -2056,9 +2064,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.12.1"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cd60a9a42ec83a2ed7effb0b1f073270264ea99da7acfc44f7e8d74dee0384"
+checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
 dependencies = [
  "half",
  "libloading",
@@ -2473,6 +2481,15 @@ checksum = "56e53799688f5632f364f8fb387488dd05db9fe45db7011be066fc20e7027f8b"
 dependencies = [
  "bytemuck",
  "reborrow",
+]
+
+[[package]]
+name = "dyn-stack"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490bd48eb68fffcfed519b4edbfd82c69cbe741d175b84f0e0cbe8c57cbe0bdd"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -3051,17 +3068,37 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ab24cc62135b40090e31a76a9b2766a501979f3070fa27f689c27ec04377d32"
 dependencies = [
- "dyn-stack",
- "gemm-c32",
- "gemm-c64",
- "gemm-common",
- "gemm-f16",
- "gemm-f32",
- "gemm-f64",
+ "dyn-stack 0.10.0",
+ "gemm-c32 0.17.1",
+ "gemm-c64 0.17.1",
+ "gemm-common 0.17.1",
+ "gemm-f16 0.17.1",
+ "gemm-f32 0.17.1",
+ "gemm-f64 0.17.1",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-c32 0.18.2",
+ "gemm-c64 0.18.2",
+ "gemm-common 0.18.2",
+ "gemm-f16 0.18.2",
+ "gemm-f32 0.18.2",
+ "gemm-f64 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
  "seq-macro",
 ]
 
@@ -3071,12 +3108,27 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c030d0b983d1e34a546b86e08f600c11696fde16199f971cd46c12e67512c0"
 dependencies = [
- "dyn-stack",
- "gemm-common",
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
  "seq-macro",
 ]
 
@@ -3086,12 +3138,27 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb5f2e79fefb9693d18e1066a557b4546cd334b226beadc68b11a8f9431852a"
 dependencies = [
- "dyn-stack",
- "gemm-common",
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-c64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
  "seq-macro",
 ]
 
@@ -3102,17 +3169,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
 dependencies = [
  "bytemuck",
- "dyn-stack",
+ "dyn-stack 0.10.0",
  "half",
  "num-complex",
  "num-traits",
  "once_cell",
  "paste",
- "pulp",
- "raw-cpuid",
+ "pulp 0.18.22",
+ "raw-cpuid 10.7.0",
  "rayon",
  "seq-macro",
- "sysctl",
+ "sysctl 0.5.5",
+]
+
+[[package]]
+name = "gemm-common"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
+dependencies = [
+ "bytemuck",
+ "dyn-stack 0.13.0",
+ "half",
+ "libm",
+ "num-complex",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "pulp 0.21.4",
+ "raw-cpuid 11.5.0",
+ "rayon",
+ "seq-macro",
+ "sysctl 0.6.0",
 ]
 
 [[package]]
@@ -3121,14 +3209,32 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ca4c06b9b11952071d317604acb332e924e817bd891bec8dfb494168c7cedd4"
 dependencies = [
- "dyn-stack",
- "gemm-common",
- "gemm-f32",
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
+ "gemm-f32 0.17.1",
  "half",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid",
+ "raw-cpuid 10.7.0",
+ "rayon",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f16"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "gemm-f32 0.18.2",
+ "half",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
  "rayon",
  "seq-macro",
 ]
@@ -3139,12 +3245,27 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9a69f51aaefbd9cf12d18faf273d3e982d9d711f60775645ed5c8047b4ae113"
 dependencies = [
- "dyn-stack",
- "gemm-common",
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f32"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
  "seq-macro",
 ]
 
@@ -3154,12 +3275,27 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa397a48544fadf0b81ec8741e5c0fba0043008113f71f2034def1935645d2b0"
 dependencies = [
- "dyn-stack",
- "gemm-common",
+ "dyn-stack 0.10.0",
+ "gemm-common 0.17.1",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid",
+ "raw-cpuid 10.7.0",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
+dependencies = [
+ "dyn-stack 0.13.0",
+ "gemm-common 0.18.2",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid 11.5.0",
  "seq-macro",
 ]
 
@@ -3541,15 +3677,15 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.1",
  "rand_distr",
 ]
 
@@ -4904,6 +5040,21 @@ name = "metal"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
 dependencies = [
  "bitflags 2.6.0",
  "block",
@@ -6318,6 +6469,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulp"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95fb7a99b37aaef4c7dd2fd15a819eb8010bfc7a2c2155230d51f497316cad6d"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6474,12 +6639,12 @@ dependencies = [
 
 [[package]]
 name = "rand_distr"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.9.1",
 ]
 
 [[package]]
@@ -6507,6 +6672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -7134,6 +7308,16 @@ name = "safetensors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "safetensors"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc0cdb7198d738a111f6df8fef42cb175412c311d0c4ac9126ff4e550ad1a0e8"
 dependencies = [
  "serde",
  "serde_json",
@@ -8186,7 +8370,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "rand 0.9.1",
- "safetensors",
+ "safetensors 0.5.3",
  "serde",
  "serde_json",
  "spin-common",
@@ -8779,6 +8963,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01198a2debb237c62b6826ec7081082d951f46dbb64b0e8c7649a452230d1dfc"
+dependencies = [
+ "bitflags 2.6.0",
+ "byteorder",
+ "enum-as-inner",
+ "libc",
+ "thiserror 1.0.69",
+ "walkdir",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9107,16 +9305,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.20.3"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b67c92f6d705e2a1d106fb0b28c696f9074901a9c656ee5d9f5de204c39bf7"
+checksum = "3169b3195f925496c895caee7978a335d49218488ef22375267fba5a46a40bd7"
 dependencies = [
  "aho-corasick",
  "derive_builder 0.20.2",
  "esaxx-rs",
  "getrandom 0.2.15",
  "indicatif",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "lazy_static 1.5.0",
  "log",
  "macro_rules_attribute",
@@ -9131,7 +9329,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spm_precompiled",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "unicode-normalization-alignments",
  "unicode-segmentation",
  "unicode_categories",
@@ -9535,6 +9733,54 @@ dependencies = [
  "memoffset 0.9.1",
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "ug"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03719c61a91b51541f076dfdba45caacf750b230cefaa4b32d6f5411c3f7f437"
+dependencies = [
+ "gemm 0.18.2",
+ "half",
+ "libloading",
+ "memmap2 0.9.5",
+ "num",
+ "num-traits",
+ "num_cpus",
+ "rayon",
+ "safetensors 0.4.5",
+ "serde",
+ "thiserror 1.0.69",
+ "tracing",
+ "yoke",
+]
+
+[[package]]
+name = "ug-cuda"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50758486d7941f8b0a636ba7e29455c07071f41590beac1fd307ec893e8db69a"
+dependencies = [
+ "cudarc",
+ "half",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
+]
+
+[[package]]
+name = "ug-metal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02ddc17bf32f7dcaaf016b6735f7198082b82f122df7b3ca15d8ead5911ccef"
+dependencies = [
+ "half",
+ "metal 0.29.0",
+ "objc",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,24 +1037,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.6.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "bindgen_cuda"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,15 +1431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,17 +1465,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1888,7 +1850,7 @@ dependencies = [
  "log",
  "pulley-interpreter",
  "regalloc2",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "serde",
  "smallvec",
  "target-lexicon",
@@ -5060,9 +5022,9 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
 name = "mysql_async"
-version = "0.34.2"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b66e411c31265e879d9814d03721f2daa7ad07337b6308cb4bb0cde7e6fd47"
+checksum = "d14cf024116ba8fef4a7fec5abf0bd5de89b9fb29a7e55818a119ac5ec745077"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -5081,7 +5043,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -5091,12 +5053,11 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.32.4"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+checksum = "34a9141e735d5bb02414a7ac03add09522466d4db65bdd827069f76ae0850e58"
 dependencies = [
- "base64 0.21.7",
- "bindgen",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "btoi",
  "byteorder",
@@ -5115,7 +5076,6 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "smallvec",
  "subprocess",
  "thiserror 1.0.69",
  "uuid",
@@ -6367,7 +6327,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.18",
  "socket2",
  "thiserror 1.0.69",
@@ -6384,7 +6344,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "rustls 0.23.18",
  "slab",
  "thiserror 1.0.69",
@@ -6685,7 +6645,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.15.2",
  "log",
- "rustc-hash 2.0.0",
+ "rustc-hash",
  "smallvec",
 ]
 
@@ -6968,12 +6928,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -9547,14 +9501,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "static_assertions",
-]
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8367,7 +8367,6 @@ dependencies = [
  "dirs 6.0.0",
  "fd-lock",
  "flate2",
- "is-terminal",
  "path-absolutize",
  "reqwest 0.12.9",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
 dependencies = [
  "fastrand 2.2.0",
 ]
@@ -6555,32 +6555,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.5"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cccf17a692ce51b86564334614d72dcae1def0fd5ecebc9f02956da74352b5"
-dependencies = [
- "arc-swap",
- "async-trait",
- "bytes",
- "combine",
- "futures-util",
- "itoa",
- "num-bigint",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "sha1_smol",
- "socket2",
- "tokio",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "redis"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff21dd025d2d3d2a6ad6788c0f7153f82d063216a7638f70367aac5790fea5da"
+checksum = "1bc42f3a12fd4408ce64d8efef67048a924e543bd35c6591c0447fda9054695f"
 dependencies = [
  "arc-swap",
  "backon",
@@ -6588,7 +6565,6 @@ dependencies = [
  "combine",
  "futures-channel",
  "futures-util",
- "itertools 0.13.0",
  "itoa",
  "native-tls",
  "num-bigint",
@@ -7699,7 +7675,7 @@ dependencies = [
  "openssl",
  "path-absolutize",
  "pretty_assertions",
- "redis 0.27.5",
+ "redis 0.29.5",
  "regex",
  "reqwest 0.12.9",
  "rpassword",
@@ -8159,7 +8135,7 @@ name = "spin-key-value-redis"
 version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
- "redis 0.28.0",
+ "redis 0.29.5",
  "serde",
  "spin-core",
  "spin-factor-key-value",
@@ -8554,7 +8530,7 @@ version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
- "redis 0.27.5",
+ "redis 0.29.5",
  "serde",
  "spin-factor-variables",
  "spin-factors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ clap = "3.2"
 conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "ecd22a45bcc5c775a56c67689a89aa4005866ac0" }
 ctrlc = { version = "3.4", features = ["termination"] }
 dialoguer = "0.11"
-dirs = "5.0"
+dirs = "6.0"
 flate2 = "1"
 futures = "0.3"
 futures-util = "0.3"
@@ -137,20 +137,20 @@ http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 indexmap = "2"
-itertools = "0.13"
+itertools = "0.14"
 lazy_static = "1.5"
 opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
 path-absolutize = "3"
 quote = "1"
-rand = "0.8"
+rand = "0.9"
 redis = "0.29"
 regex = "1"
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
-rusqlite = "0.32"
+rusqlite = "0.34"
 # In `rustls` turn off the `aws_lc_rs` default feature and turn on `ring`.
 # If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
-rustls-pemfile = "2.1.2"
+rustls-pemfile = "2.2"
 rustls-pki-types = "1.8"
 semver = "1"
 serde = { version = "1", features = ["derive", "rc"] }
@@ -160,7 +160,7 @@ syn = "2"
 tar = "0.4"
 tempfile = "3"
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "ecd22a45bcc5c775a56c67689a89aa4005866ac0" }
-thiserror = "1"
+thiserror = "2"
 tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 toml = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,15 +170,14 @@ walkdir = "2"
 wasi-common-preview1 = { version = "32.0.0", package = "wasi-common", features = [
   "tokio",
 ] }
+wasm-encoder = "0.229"
+wasm-metadata = "0.229"
 wasm-pkg-client = "0.10"
 wasm-pkg-common = "0.10"
+wasmparser = "0.229"
 wasmtime = "32.0.0"
 wasmtime-wasi = "32.0.0"
 wasmtime-wasi-http = "32.0.0"
-
-wasm-encoder = "0.229"
-wasm-metadata = "0.229"
-wasmparser = "0.229"
 wit-component = "0.229"
 wit-parser = "0.229"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,25 +18,25 @@ rust-version = "1.81"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
-clap = { version = "3.2.24", features = ["derive", "env"] }
+clap = { workspace = true, features = ["derive", "env"] }
 clearscreen = "3"
 comfy-table = "7"
 command-group = "2"
-ctrlc = { version = "3.4", features = ["termination"] }
-dialoguer = "0.11"
+ctrlc = { workspace = true }
+dialoguer = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 indicatif = "0.17"
 itertools = { workspace = true }
-lazy_static = "1.5"
+lazy_static = { workspace = true }
 levenshtein = "1"
 nix = { version = "0.29", features = ["signal"] }
-path-absolutize = "3"
+path-absolutize = { workspace = true }
 pretty_assertions = "1.3"
 regex = { workspace = true }
 reqwest = { workspace = true }
 rpassword = "7"
-semver = "1"
+semver = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -83,8 +83,8 @@ conformance-tests = { workspace = true }
 hex = "0.4"
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { version = "0.1", features = ["tokio"] }
-redis = "0.27"
+hyper-util = { workspace = true }
+redis = { workspace = true }
 runtime-tests = { path = "tests/runtime-tests" }
 test-codegen-macro = { path = "crates/test-codegen-macro" }
 test-components = { path = "tests/test-components" }
@@ -119,34 +119,55 @@ members = [
 [workspace.dependencies]
 anyhow = "1"
 async-trait = "0.1"
+base64 = "0.22"
 bytes = "1"
+chrono = "0.4"
+clap = "3.2"
 conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "ecd22a45bcc5c775a56c67689a89aa4005866ac0" }
+ctrlc = { version = "3.4", features = ["termination"] }
+dialoguer = "0.11"
 dirs = "5.0"
+flate2 = "1"
 futures = "0.3"
+futures-util = "0.3"
 glob = "0.3"
+heck = "0.5"
 http = "1"
 http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
+indexmap = "2"
 itertools = "0.13"
+lazy_static = "1.5"
 opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
-opentelemetry_sdk = { version = "0.28", features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
+path-absolutize = "3"
+quote = "1"
 rand = "0.8"
+redis = "0.29"
 regex = "1"
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
+rusqlite = "0.32"
 # In `rustls` turn off the `aws_lc_rs` default feature and turn on `ring`.
 # If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
+rustls-pemfile = "2.1.2"
+rustls-pki-types = "1.8"
+semver = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"
 sha2 = "0.10"
+syn = "2"
+tar = "0.4"
 tempfile = "3"
 test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "ecd22a45bcc5c775a56c67689a89aa4005866ac0" }
 thiserror = "1"
 tokio = "1"
+tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 toml = "0.8"
+toml_edit = "0.22"
 tracing = { version = "0.1", features = ["log"] }
-tracing-opentelemetry = { version = "0.29", default-features = false, features = ["metrics"] }
 url = "2"
+walkdir = "2"
 wasi-common-preview1 = { version = "32.0.0", package = "wasi-common", features = [
   "tokio",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 homepage = "https://spinframework.dev"
 repository = "https://github.com/spinframework/spin"
-rust-version = "1.81"
+rust-version = "1.84"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
-clearscreen = "3"
+clearscreen = "4"
 comfy-table = "7"
 command-group = "2"
 ctrlc = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,6 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 indexmap = "2"
 itertools = "0.14"
 lazy_static = "1.5"
-opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
 path-absolutize = "3"
 quote = "1"
 rand = "0.9"

--- a/crates/compose/Cargo.toml
+++ b/crates/compose/Cargo.toml
@@ -11,8 +11,8 @@ rust-version.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-indexmap = "2"
-semver = "1"
+indexmap = { workspace = true }
+semver = { workspace = true }
 spin-app = { path = "../app" }
 spin-common = { path = "../common" }
 spin-componentize = { path = "../componentize" }

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-reqwest = { version = "0.12", features = ["stream"] }
+reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true }
 similar = "2"
 spin-common = { path = "../common" }
@@ -16,7 +16,7 @@ tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 tokio = { workspace = true, features = ["process"] }
 toml = { workspace = true }
-toml_edit = { version = "0.22", features = ["serde"] }
+toml_edit = { workspace = true, features = ["serde"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/factor-llm/Cargo.toml
+++ b/crates/factor-llm/Cargo.toml
@@ -21,12 +21,12 @@ spin-factors = { path = "../factors" }
 spin-llm-local = { path = "../llm-local", optional = true }
 spin-llm-remote-http = { path = "../llm-remote-http" }
 spin-locked-app = { path = "../locked-app" }
-spin-world = { path = "../world" }
-tracing = { workspace = true }
 spin-telemetry = { path = "../telemetry" }
+spin-world = { path = "../world" }
 tokio = { workspace = true, features = ["sync"] }
 toml = { workspace = true }
-url = { version = "2", features = ["serde"] }
+tracing = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -7,17 +7,17 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 http = { workspace = true }
-http-body-util = "0.1"
+http-body-util = { workspace = true }
 hyper = { workspace = true }
 ip_network = "0.4"
-reqwest = { version = "0.12", features = ["gzip"] }
+reqwest = { workspace = true, features = ["gzip"] }
 rustls = { workspace = true }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
 tokio = { workspace = true, features = ["macros", "rt", "net"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
+tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 anyhow = { workspace = true }
 # Removing default features for mysql_async to remove flate2/zlib feature
-mysql_async = { version = "0.34", default-features = false, features = [
+mysql_async = { version = "0.35", default-features = false, features = [
   "native-tls-tls",
 ] }
 spin-core = { path = "../core" }

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -6,12 +6,12 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-futures-util = "0.3"
+futures-util = { workspace = true }
 http = { workspace = true }
 ipnet = "2"
 rustls = { workspace = true }
-rustls-pemfile = { version = "2", optional = true }
-rustls-pki-types = "1.8"
+rustls-pemfile = { workspace = true, optional = true }
+rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 spin-expressions = { path = "../expressions" }
 spin-factor-variables = { path = "../factor-variables" }

--- a/crates/factor-outbound-pg/Cargo.toml
+++ b/crates/factor-outbound-pg/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-chrono = "0.4"
+chrono = { workspace = true }
 native-tls = "0.2"
 postgres-native-tls = "0.5"
 spin-core = { path = "../core" }

--- a/crates/factors-derive/Cargo.toml
+++ b/crates/factors-derive/Cargo.toml
@@ -13,8 +13,8 @@ expander = ["dep:expander"]
 [dependencies]
 expander = { version = "2.2.1", optional = true }
 proc-macro2 = "1.0.79"
-quote = "1.0.35"
-syn = "2.0.52"
+quote = { workspace = true }
+syn = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -9,16 +9,16 @@ anyhow = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-indexmap = "2"
+indexmap = { workspace = true }
 percent-encoding = "2"
 routefinder = "0.5.4"
 serde = { workspace = true }
 spin-app = { path = "../app", optional = true }
+spin-factor-outbound-http = { path = "../factor-outbound-http" }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
-spin-factor-outbound-http = { path = "../factor-outbound-http" }
 
 [dev-dependencies]
 toml = { workspace = true }

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -10,14 +10,14 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
+azure_core = "0.21.0"
 azure_data_cosmos = "0.21.0"
 azure_identity = "0.21.0"
-azure_core = "0.21.0"
 futures = { workspace = true }
-serde = { workspace = true }
-async-trait = { workspace = true }
-spin-factor-key-value = { path = "../factor-key-value" }
 reqwest = { version = "0.12", default-features = false }
+serde = { workspace = true }
+spin-factor-key-value = { path = "../factor-key-value" }
 
 [lints]
 workspace = true

--- a/crates/key-value-redis/Cargo.toml
+++ b/crates/key-value-redis/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-redis = { version = "0.28", features = ["tokio-comp", "tokio-native-tls-comp", "connection-manager"] }
+redis = { workspace = true, features = ["tokio-comp", "tokio-native-tls-comp", "connection-manager"] }
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }

--- a/crates/key-value-spin/Cargo.toml
+++ b/crates/key-value-spin/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-rusqlite = { version = "0.32", features = ["bundled", "array"] }
+rusqlite = { workspace = true, features = ["bundled", "array"] }
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -5,7 +5,7 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 candle = { git = "https://github.com/huggingface/candle", rev = "e3261216b157a7305c18ccdd766b6e2a41afe483", package = "candle-core" }
 candle-nn = { git = "https://github.com/huggingface/candle", rev = "e3261216b157a7305c18ccdd766b6e2a41afe483" }
 candle-transformers = { git = "https://github.com/huggingface/candle", rev = "e3261216b157a7305c18ccdd766b6e2a41afe483" }

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -6,17 +6,17 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-candle = { git = "https://github.com/huggingface/candle", rev = "e3261216b157a7305c18ccdd766b6e2a41afe483", package = "candle-core" }
-candle-nn = { git = "https://github.com/huggingface/candle", rev = "e3261216b157a7305c18ccdd766b6e2a41afe483" }
-candle-transformers = { git = "https://github.com/huggingface/candle", rev = "e3261216b157a7305c18ccdd766b6e2a41afe483" }
+candle = { version = "0.8", package = "candle-core" }
+candle-nn = "0.8"
+candle-transformers = "0.8"
 rand = { workspace = true }
-safetensors = "0.4"
+safetensors = "0.5"
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-common = { path = "../common" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }
-tokenizers = "0.20"
+tokenizers = "0.21"
 tokio = { workspace = true, features = ["macros", "sync", "fs"] }
 tracing = { workspace = true }
 

--- a/crates/llm-local/src/llama.rs
+++ b/crates/llm-local/src/llama.rs
@@ -99,7 +99,7 @@ impl InferencingModel for LlamaModels {
             .map_err(|e| anyhow!(e.to_string()))?
             .get_ids()
             .to_vec();
-        let mut rng = rand::rngs::StdRng::from_entropy();
+        let mut rng = rand::rngs::StdRng::from_os_rng();
 
         let mut logits_processor = {
             let temperature = params.temperature;

--- a/crates/llm-remote-http/Cargo.toml
+++ b/crates/llm-remote-http/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-reqwest = { version = "0.12", features = ["gzip", "json"] }
+reqwest = { workspace = true, features = ["gzip", "json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-telemetry = { path = "../telemetry" }

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -9,9 +9,9 @@ anyhow = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true }
 glob = { workspace = true }
-path-absolutize = { version = "3", features = ["use_unix_paths_on_wasm"] }
-reqwest = "0.12"
-semver = "1"
+path-absolutize = { workspace = true, features = ["use_unix_paths_on_wasm"] }
+reqwest = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -6,13 +6,13 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-indexmap = { version = "2", features = ["serde"] }
-semver = { version = "1.0", features = ["serde"] }
+indexmap = { workspace = true, features = ["serde"] }
+semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 spin-serde = { path = "../serde" }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
-toml = { version = "0.8.0", features = ["preserve_order"] }
+toml = { workspace = true, features = ["preserve_order"] }
 url = { workspace = true }
 wasm-pkg-common = { workspace = true }
 

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -8,17 +8,17 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 async-compression = { version = "0.4", features = ["gzip", "tokio"] }
 async-tar = "0.5"
-base64 = "0.22"
-chrono = "0.4"
+base64 = { workspace = true }
+chrono = { workspace = true }
 # Fork with updated auth to support ACR login
 # Ref https://github.com/camallo/dkregistry-rs/pull/263
 dirs = { workspace = true }
 dkregistry = { git = "https://github.com/fermyon/dkregistry-rs", rev = "161cf2b66996ed97c7abaf046e38244484814de3" }
 docker_credential = "1"
-futures-util = "0.3"
+futures-util = { workspace = true }
 itertools = { workspace = true }
 oci-distribution = { git = "https://github.com/fermyon/oci-distribution", rev = "7b291a39f74d1a3c9499d934a56cae6580fc8e37" }
-reqwest = "0.12"
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-common = { path = "../common" }
@@ -29,7 +29,7 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = { workspace = true }
-walkdir = "2"
+walkdir = { workspace = true }
 
 [dev-dependencies]
 wasm-encoder = { workspace = true }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -6,21 +6,21 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true, features = ["serde"] }
 dirs = { workspace = true }
 fd-lock = "4"
-flate2 = "1"
+flate2 = { workspace = true }
 is-terminal = "0.4"
-path-absolutize = "3"
-reqwest = { version = "0.12", features = ["json"] }
-semver = { version = "1.0", features = ["serde"] }
+path-absolutize = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-common = { path = "../common" }
-tar = "0.4"
+tar = { workspace = true }
 tempfile = { workspace = true }
 terminal = { path = "../terminal" }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "process", "rt", "macros"] }
 tracing = { workspace = true }
-url = { version = "2", features = ["serde"] }
+url = { workspace = true, features = ["serde"] }

--- a/crates/plugins/Cargo.toml
+++ b/crates/plugins/Cargo.toml
@@ -10,7 +10,6 @@ chrono = { workspace = true, features = ["serde"] }
 dirs = { workspace = true }
 fd-lock = "4"
 flate2 = { workspace = true }
-is-terminal = "0.4"
 path-absolutize = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 semver = { workspace = true, features = ["serde"] }

--- a/crates/plugins/src/badger/mod.rs
+++ b/crates/plugins/src/badger/mod.rs
@@ -1,8 +1,9 @@
 mod store;
 
+use std::io::IsTerminal;
+
 use self::store::{BadgerRecordManager, PreviousBadger};
 use crate::manifest::PluginManifest;
-use is_terminal::IsTerminal;
 
 const BADGER_TIMEOUT_DAYS: i64 = 14;
 

--- a/crates/runtime-config/Cargo.toml
+++ b/crates/runtime-config/Cargo.toml
@@ -35,9 +35,9 @@ toml = { workspace = true }
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }
 spin-world = { path = "../world" }
-tempfile = "3.2"
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
-toml = "0.8"
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/runtime-factors/Cargo.toml
+++ b/crates/runtime-factors/Cargo.toml
@@ -15,7 +15,7 @@ llm-cublas = ["spin-factor-llm/llm-cublas"]
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "3.1.18", features = ["derive", "env"] }
+clap = { workspace = true, features = ["derive", "env"] }
 spin-common = { path = "../common" }
 spin-factor-key-value = { path = "../factor-key-value" }
 spin-factor-llm = { path = "../factor-llm" }

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = "0.22.1"
-semver = { version = "1.0", features = ["serde"] }
+base64 = { workspace = true }
+semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 wasm-pkg-common = { workspace = true }

--- a/crates/sqlite-inproc/Cargo.toml
+++ b/crates/sqlite-inproc/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { workspace = true, features = ["bundled"] }
 spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-world = { path = "../world" }
 tokio = { workspace = true }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -11,10 +11,10 @@ http1 = { version = "1.0.0", package = "http" }
 opentelemetry = { workspace = true }
 opentelemetry-appender-tracing = "0.28"
 opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
-opentelemetry_sdk = { workspace = true }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }
-tracing-opentelemetry = { workspace = true }
+tracing-opentelemetry = { version = "0.29", default-features = false, features = ["metrics"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "fmt", "ansi", "std", "env-filter", "json", "registry"] }
 
 [features]

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -8,7 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
-opentelemetry = { workspace = true }
+opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
 opentelemetry-appender-tracing = "0.28"
 opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
 opentelemetry_sdk = { version = "0.28", features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }

--- a/crates/templates/Cargo.toml
+++ b/crates/templates/Cargo.toml
@@ -7,28 +7,28 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
-dialoguer = "0.11"
+dialoguer = { workspace = true }
+flate2 = { workspace = true }
 fs_extra = "1"
-heck = "0.5"
-flate2 = "1"
-indexmap = { version = "2", features = ["serde"] }
+heck = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
-lazy_static = "1"
+lazy_static = { workspace = true }
 liquid = "0.26"
 liquid-core = "0.26"
 liquid-derive = "0.26"
-path-absolutize = "3"
+path-absolutize = { workspace = true }
 pathdiff = "0.2"
 regex = { workspace = true }
 reqwest = { workspace = true }
-semver = "1"
+semver = { workspace = true }
 serde = { workspace = true }
 spin-common = { path = "../common" }
 spin-manifest = { path = "../manifest" }
-tar = "0.4"
+tar = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "process", "rt", "macros"] }
 toml = { workspace = true }
-toml_edit = "0.22"
+toml_edit = { workspace = true }
 url = { workspace = true }
-walkdir = "2"
+walkdir = { workspace = true }

--- a/crates/test-codegen-macro/Cargo.toml
+++ b/crates/test-codegen-macro/Cargo.toml
@@ -10,6 +10,6 @@ doctest = false
 test = false
 
 [dependencies]
-heck = "0.5"
-quote = "1"
-syn = "2"
+heck = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -9,15 +9,15 @@ doctest = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = "3"
+clap = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper-util = { workspace = true }
 rustls = { workspace = true }
-rustls-pemfile = "2.1.2"
-rustls-pki-types = "1.7"
+rustls-pemfile = { workspace = true }
+rustls-pki-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 spin-app = { path = "../app" }
@@ -32,7 +32,7 @@ spin-trigger = { path = "../trigger" }
 spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
 tokio = { workspace = true, features = ["full"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
+tokio-rustls = { workspace = true }
 tracing = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }

--- a/crates/trigger-redis/Cargo.toml
+++ b/crates/trigger-redis/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 [dependencies]
 anyhow = { workspace = true }
 futures = { workspace = true }
-redis = { version = "0.27", features = ["tokio-comp"] }
+redis = { workspace = true, features = ["tokio-comp"] }
 serde = { workspace = true }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factors = { path = "../factors" }

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -16,8 +16,8 @@ unsafe-aot-compilation = []
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { version = "3.1.18", features = ["derive", "env"] }
-ctrlc = { version = "3.2", features = ["termination"] }
+clap = { workspace = true, features = ["derive", "env"] }
+ctrlc = { workspace = true }
 futures = { workspace = true }
 sanitize-filename = "0.5"
 serde = { workspace = true }

--- a/crates/variables/Cargo.toml
+++ b/crates/variables/Cargo.toml
@@ -15,8 +15,8 @@ azure_security_keyvault = { git = "https://github.com/azure/azure-sdk-for-rust",
 dotenvy = "0.15"
 serde = { workspace = true }
 spin-expressions = { path = "../expressions" }
-spin-factors = { path = "../factors" }
 spin-factor-variables = { path = "../factor-variables" }
+spin-factors = { path = "../factors" }
 spin-world = { path = "../world" }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy 0.7.35",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,24 +837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,15 +1002,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,17 +1026,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1533,11 +1483,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -1547,20 +1497,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
+ "redox_users 0.5.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1570,7 +1520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.6",
  "winapi",
 ]
 
@@ -2046,15 +1996,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
@@ -2067,11 +2008,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -2609,15 +2550,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2705,16 +2637,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2789,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "fbb8270bb4060bd76c6e96f20c52d80620f1d82a3470885694e41e0f81ef6fe7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2903,12 +2825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,9 +2846,9 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.34.2"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b66e411c31265e879d9814d03721f2daa7ad07337b6308cb4bb0cde7e6fd47"
+checksum = "d14cf024116ba8fef4a7fec5abf0bd5de89b9fb29a7e55818a119ac5ec745077"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2951,7 +2867,7 @@ dependencies = [
  "serde",
  "serde_json",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -2961,12 +2877,11 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.32.4"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478b0ff3f7d67b79da2b96f56f334431aef65e15ba4b29dd74a4236e29582bdc"
+checksum = "34a9141e735d5bb02414a7ac03add09522466d4db65bdd827069f76ae0850e58"
 dependencies = [
- "base64 0.21.7",
- "bindgen",
+ "base64 0.22.1",
  "bitflags 2.9.0",
  "btoi",
  "byteorder",
@@ -2985,7 +2900,6 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2",
- "smallvec",
  "subprocess",
  "thiserror 1.0.69",
  "uuid",
@@ -3019,16 +2933,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -3513,7 +3417,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3716,7 +3620,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3830,9 +3734,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.28.2"
+version = "0.29.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37ec3fd44bea2ec947ba6cc7634d7999a6590aca7c35827c250bc0de502bda6"
+checksum = "1bc42f3a12fd4408ce64d8efef67048a924e543bd35c6591c0447fda9054695f"
 dependencies = [
  "arc-swap",
  "backon",
@@ -3872,6 +3776,17 @@ dependencies = [
  "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4026,9 +3941,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.32.1"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "37e34486da88d8e051c7c0e23c3f15fd806ea8546260aa2fec247e97242ec143"
 dependencies = [
  "bitflags 2.9.0",
  "fallible-iterator 0.3.0",
@@ -4533,7 +4448,7 @@ name = "spin-common"
 version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "sha2",
  "tempfile",
  "tokio",
@@ -4565,7 +4480,7 @@ dependencies = [
  "spin-common",
  "spin-componentize",
  "spin-serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "wac-graph",
 ]
@@ -4588,7 +4503,7 @@ dependencies = [
  "async-trait",
  "futures",
  "spin-locked-app",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4602,7 +4517,7 @@ dependencies = [
  "spin-locked-app",
  "spin-resource-table",
  "spin-world",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tokio",
  "toml",
  "tracing",
@@ -4781,7 +4696,7 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-factors-derive",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "toml",
  "wasmtime",
 ]
@@ -4839,7 +4754,7 @@ name = "spin-key-value-redis"
 version = "3.3.0-pre0"
 dependencies = [
  "anyhow",
- "redis 0.28.2",
+ "redis 0.29.5",
  "serde",
  "spin-core",
  "spin-factor-key-value",
@@ -4882,7 +4797,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4895,7 +4810,7 @@ dependencies = [
  "serde",
  "spin-serde",
  "terminal",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "toml",
  "url",
  "wasm-pkg-common",
@@ -5085,12 +5000,6 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -5728,14 +5637,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "rand 0.8.5",
- "static_assertions",
-]
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
 
 [[package]]
 name = "typenum"
@@ -7094,31 +6998,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.24",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "zerocopy-derive",
 ]
 
 [[package]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -808,10 +808,6 @@ criteria = "safe-to-deploy"
 version = "2.7.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.is-terminal]]
-version = "0.4.4"
-criteria = "safe-to-deploy"
-
 [[exemptions.itertools]]
 version = "0.10.5"
 criteria = "safe-to-deploy"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -301,7 +301,7 @@ mod integration_tests {
     }
 
     #[test]
-    /// Test that mounting works properly
+    /// Test a bunch of old apps for backwards compatibility
     fn legacy_apps() -> anyhow::Result<()> {
         run_test(
             "legacy-apps-test",

--- a/tests/testing-framework/Cargo.toml
+++ b/tests/testing-framework/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 http = "1.0"
-http-body-util = "0.1.0"
+http-body-util = { workspace = true }
 log = "0.4"
 nix = "0.29"
 reqwest = { workspace = true }


### PR DESCRIPTION
A big update of dependencies.

I left some dependencies alone that require a bit more intervention to update:
* wasmtime (and related crates)
* redis
* azure SDKs

This bumps the minimum supported Rust version from 1.81 to 1.83. I'm not sure what our policy is on MSRV, but this seems reasonable to me. 1.83 is ~6 months old now. 