### PR TITLE
Do less allocation when building routes.

### DIFF
--- a/crates/trigger-http/src/headers.rs
+++ b/crates/trigger-http/src/headers.rs
@@ -177,7 +177,7 @@ mod tests {
             .uri(req_uri)
             .body("")?;
 
-        let (router, _) = Router::build("/", [("DUMMY", &trigger_route.into())])?;
+        let router = Router::build("/", [("DUMMY", &trigger_route.into())], None)?;
         let route_match = router.route("/foo/bar")?;
 
         let default_headers = compute_default_headers(req.uri(), host, &route_match, client_addr)?;
@@ -233,7 +233,7 @@ mod tests {
             .uri(req_uri)
             .body("")?;
 
-        let (router, _) = Router::build("/", [("DUMMY", &trigger_route.into())])?;
+        let router = Router::build("/", [("DUMMY", &trigger_route.into())], None)?;
         let route_match = router.route("/foo/42/bar")?;
 
         let default_headers = compute_default_headers(req.uri(), host, &route_match, client_addr)?;

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -77,7 +77,8 @@ impl<F: RuntimeFactors> HttpServer<F> {
         let component_routes = component_trigger_configs
             .iter()
             .map(|(component_id, config)| (component_id.as_str(), &config.route));
-        let (router, duplicate_routes) = Router::build("/", component_routes)?;
+        let mut duplicate_routes = Vec::new();
+        let router = Router::build("/", component_routes, Some(&mut duplicate_routes))?;
         if !duplicate_routes.is_empty() {
             tracing::error!(
                 "The following component routes are duplicates and will never be used:"


### PR DESCRIPTION
In particular avoid allocating duplicate routes if they won't be used.

This will avoid allocating:
* 1 vector of `routes_iter`
* An `effective_id` string for every route (only allocating if there is a duplicate and duplicates will be used)
* A `component_id` string for every duplicate route (only allocating if duplicates will be used)

This will be particularly useful for embedders that need to build routes for often than Spin CLI does. 