### PR TITLE
Less allocations in router

### DIFF
--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -226,7 +226,7 @@ pub struct RouteMatch<'router, 'path> {
     inner: RouteMatchKind<'router, 'path>,
 }
 
-impl<'router, 'path> RouteMatch<'router, 'path> {
+impl RouteMatch<'_, '_> {
     /// A synthetic match as if the given path was matched against the wildcard route.
     /// Used in service chaining.
     pub fn synthetic(component_id: String, path: String) -> Self {
@@ -309,7 +309,7 @@ enum RouteMatchKind<'router, 'path> {
     },
 }
 
-impl<'router, 'path> RouteMatchKind<'router, 'path> {
+impl RouteMatchKind<'_, '_> {
     /// The route handler that matched the path.
     fn route_handler(&self) -> &RouteHandler {
         match self {

--- a/crates/http/src/routes.rs
+++ b/crates/http/src/routes.rs
@@ -22,9 +22,9 @@ struct RouteHandler {
     /// The component ID that the route maps to.
     component_id: String,
     /// The route, including any application base.
-    based_route: String,
+    based_route: Cow<'static, str>,
     /// The route, not including any application base.
-    raw_route: String,
+    raw_route: Cow<'static, str>,
     /// The route, including any application base and capturing information about whether it has a trailing wildcard.
     /// (This avoids re-parsing the route string.)
     parsed_based_route: ParsedRoute,
@@ -111,8 +111,8 @@ impl Router {
 
             let handler = RouteHandler {
                 component_id: re.component_id.to_string(),
-                based_route: re.based_route,
-                raw_route: re.raw_route.to_string(),
+                based_route: re.based_route.into(),
+                raw_route: re.raw_route.to_string().into(),
                 parsed_based_route: parsed,
             };
 
@@ -235,8 +235,8 @@ impl<'router, 'path> RouteMatch<'router, 'path> {
         Self {
             route_handler: Cow::Owned(RouteHandler {
                 component_id,
-                based_route: "/...".to_string(),
-                raw_route: "/...".to_string(),
+                based_route: "/...".into(),
+                raw_route: "/...".into(),
                 parsed_based_route: ParsedRoute::TrailingWildcard(String::new()),
             }),
             best_match: None,

--- a/crates/http/src/wagi/mod.rs
+++ b/crates/http/src/wagi/mod.rs
@@ -105,7 +105,7 @@ pub fn build_headers(
     // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.13
     headers.insert(
         "SCRIPT_NAME".to_owned(),
-        route_match.based_route_or_prefix(),
+        route_match.based_route_or_prefix().to_owned(),
     );
     // PATH_INFO is any path information after SCRIPT_NAME
     //
@@ -117,7 +117,10 @@ pub fn build_headers(
     // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.5
     let pathsegment = path_info;
     let pathinfo = percent_encoding::percent_decode_str(&pathsegment).decode_utf8_lossy();
-    headers.insert("X_RAW_PATH_INFO".to_owned(), pathsegment.clone());
+    headers.insert(
+        "X_RAW_PATH_INFO".to_owned(),
+        pathsegment.as_ref().to_owned(),
+    );
     headers.insert("PATH_INFO".to_owned(), pathinfo.to_string());
     // PATH_TRANSLATED is the url-decoded version of PATH_INFO
     // https://datatracker.ietf.org/doc/html/rfc3875#section-4.1.6

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -801,8 +801,8 @@ pub async fn unpack_archive_layer(
 fn digest_from_url(manifest_url: &str) -> Option<String> {
     // The URL is in the form "https://host/v2/refname/manifests/sha256:..."
     let manifest_url = Url::parse(manifest_url).ok()?;
-    let segments = manifest_url.path_segments()?;
-    let last = segments.last()?;
+    let mut segments = manifest_url.path_segments()?;
+    let last = segments.next_back()?;
     if last.contains(':') {
         Some(last.to_owned())
     } else {

--- a/crates/trigger-http/src/headers.rs
+++ b/crates/trigger-http/src/headers.rs
@@ -25,12 +25,16 @@ pub const RAW_COMPONENT_ROUTE: [&str; 2] = ["SPIN_RAW_COMPONENT_ROUTE", "X_RAW_C
 pub const BASE_PATH: [&str; 2] = ["SPIN_BASE_PATH", "X_BASE_PATH"];
 pub const CLIENT_ADDR: [&str; 2] = ["SPIN_CLIENT_ADDR", "X_CLIENT_ADDR"];
 
+// Header key/value pairs that use copy on write to avoid allocation
+pub type HeaderPair<'a> = ([Cow<'static, str>; 2], Cow<'a, str>);
+
+/// Compute the default headers to be passed to the component.
 pub fn compute_default_headers<'a>(
     uri: &Uri,
     host: &str,
     route_match: &'a RouteMatch,
     client_addr: SocketAddr,
-) -> anyhow::Result<Vec<([Cow<'static, str>; 2], Cow<'a, str>)>> {
+) -> anyhow::Result<Vec<HeaderPair<'a>>> {
     fn owned(strs: &[&'static str; 2]) -> [Cow<'static, str>; 2] {
         [strs[0].into(), strs[1].into()]
     }

--- a/crates/trigger-http/src/outbound_http.rs
+++ b/crates/trigger-http/src/outbound_http.rs
@@ -32,7 +32,8 @@ impl<F: RuntimeFactors> intercept::OutboundHttpInterceptor for OutboundHttpInter
         // Handle service chaining requests
         if let Some(component_id) = parse_service_chaining_target(request.uri()) {
             let req = request.into_hyper_request();
-            let route_match = RouteMatch::synthetic(&component_id, req.uri().path());
+            let path = req.uri().path().to_owned();
+            let route_match = RouteMatch::synthetic(component_id, path);
             let resp = self
                 .server
                 .handle_trigger_route(req, route_match, Scheme::HTTP, CHAINED_CLIENT_ADDR)

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -222,7 +222,7 @@ impl<F: RuntimeFactors> HttpServer<F> {
     pub async fn handle_trigger_route(
         self: &Arc<Self>,
         mut req: Request<Body>,
-        route_match: RouteMatch,
+        route_match: RouteMatch<'_, '_>,
         server_scheme: Scheme,
         client_addr: SocketAddr,
     ) -> anyhow::Result<Response<Body>> {
@@ -471,7 +471,7 @@ pub(crate) trait HttpExecutor {
     fn execute<F: RuntimeFactors>(
         &self,
         instance_builder: TriggerInstanceBuilder<F>,
-        route_match: &RouteMatch,
+        route_match: &RouteMatch<'_, '_>,
         req: Request<Body>,
         client_addr: SocketAddr,
     ) -> impl Future<Output = anyhow::Result<Response<Body>>>;

--- a/crates/trigger-http/src/spin.rs
+++ b/crates/trigger-http/src/spin.rs
@@ -24,7 +24,7 @@ impl HttpExecutor for SpinHttpExecutor {
     async fn execute<F: RuntimeFactors>(
         &self,
         instance_builder: TriggerInstanceBuilder<'_, F>,
-        route_match: &RouteMatch,
+        route_match: &RouteMatch<'_, '_>,
         req: Request<Body>,
         client_addr: SocketAddr,
     ) -> Result<Response<Body>> {

--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -71,7 +71,7 @@ impl HttpExecutor for WagiHttpExecutor<'_> {
         // `PATH_INFO`, or `X_FULL_URL`).
         // Note that this overrides any existing headers previously set by Wagi.
         for (keys, val) in compute_default_headers(&parts.uri, host, route_match, client_addr)? {
-            headers.insert(keys[1].to_string(), val);
+            headers.insert(keys[1].to_string(), val.into_owned());
         }
 
         let stdout = MemoryOutputPipe::new(usize::MAX);

--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -23,7 +23,7 @@ impl HttpExecutor for WagiHttpExecutor<'_> {
     async fn execute<F: RuntimeFactors>(
         &self,
         mut instance_builder: TriggerInstanceBuilder<'_, F>,
-        route_match: &RouteMatch,
+        route_match: &RouteMatch<'_, '_>,
         req: Request<Body>,
         client_addr: SocketAddr,
     ) -> Result<Response<Body>> {

--- a/crates/trigger-http/src/wasi.rs
+++ b/crates/trigger-http/src/wasi.rs
@@ -27,7 +27,7 @@ impl HttpExecutor for WasiHttpExecutor<'_> {
     async fn execute<F: RuntimeFactors>(
         &self,
         instance_builder: TriggerInstanceBuilder<'_, F>,
-        route_match: &RouteMatch,
+        route_match: &RouteMatch<'_, '_>,
         mut req: Request<Body>,
         client_addr: SocketAddr,
     ) -> Result<Response<Body>> {

--- a/tests/test-components/build.rs
+++ b/tests/test-components/build.rs
@@ -58,7 +58,7 @@ fn main() {
             .join("debug")
             .join(format!("{binary_name}.wasm"));
 
-        let adapter_version = package.split('v').last().and_then(|v| match v {
+        let adapter_version = package.split('v').next_back().and_then(|v| match v {
             // Only allow these versions through
             "0.2.0-rc-2023-11-10" | "0.2.0" => Some(v),
             _ => None,


### PR DESCRIPTION
This trades a bit of code complexity for less allocations in routing. Given routing can be quite performance sensitive, in my opinion this tradeoff is worth it. 

On every request we no longer:
* Clone a `RouteHandler` (3-4 `String`s)
* Clone the `trailing_wildcard` `String`

In service chaining we also no longer:
* allocate two strings in the synthetic `RouteHandler` unnecessarily. 
* unnecessarily clone the `component_id`