### PR TITLE
Support Liquid partials in templates

### DIFF
--- a/crates/templates/src/store.rs
+++ b/crates/templates/src/store.rs
@@ -68,6 +68,7 @@ pub(crate) struct TemplateLayout {
 const METADATA_DIR_NAME: &str = "metadata";
 const CONTENT_DIR_NAME: &str = "content";
 const SNIPPETS_DIR_NAME: &str = "snippets";
+const PARTIALS_DIR_NAME: &str = "partials";
 
 const MANIFEST_FILE_NAME: &str = "spin-template.toml";
 
@@ -94,6 +95,10 @@ impl TemplateLayout {
 
     pub fn snippets_dir(&self) -> PathBuf {
         self.metadata_dir().join(SNIPPETS_DIR_NAME)
+    }
+
+    pub fn partials_dir(&self) -> PathBuf {
+        self.metadata_dir().join(PARTIALS_DIR_NAME)
     }
 
     pub fn installation_record_file(&self) -> PathBuf {

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -30,6 +30,7 @@ pub struct Template {
     parameters: Vec<TemplateParameter>,
     extra_outputs: Vec<ExtraOutputAction>,
     snippets_dir: Option<PathBuf>,
+    partials_dir: Option<PathBuf>,
     content_dir: Option<PathBuf>, // TODO: maybe always need a spin.toml file in there?
 }
 
@@ -184,6 +185,12 @@ impl Template {
             None
         };
 
+        let partials_dir = if layout.partials_dir().exists() {
+            Some(layout.partials_dir())
+        } else {
+            None
+        };
+
         let installed_from = read_install_record(layout);
 
         let template = match raw {
@@ -197,6 +204,7 @@ impl Template {
                 parameters: Self::parse_parameters(&raw.parameters)?,
                 extra_outputs: Self::parse_extra_outputs(&raw.outputs)?,
                 snippets_dir,
+                partials_dir,
                 content_dir,
             },
         };
@@ -292,6 +300,10 @@ impl Template {
 
     pub(crate) fn snippets_dir(&self) -> &Option<PathBuf> {
         &self.snippets_dir
+    }
+
+    pub(crate) fn partials_dir(&self) -> &Option<PathBuf> {
+        &self.partials_dir
     }
 
     /// Checks if the template supports the specified variant mode.
@@ -753,6 +765,7 @@ mod test {
             parameters: vec![],
             extra_outputs: vec![],
             snippets_dir: None,
+            partials_dir: None,
             content_dir: None,
         };
 

--- a/crates/templates/tests/templates/partials/content/test.txt
+++ b/crates/templates/tests/templates/partials/content/test.txt
@@ -1,0 +1,3 @@
+Value: {{ example-value }}
+Partial 1: {% render 'p1' %}
+Partial 2: {% render 'p2', value: example-value %}

--- a/crates/templates/tests/templates/partials/metadata/partials/p1.liquid
+++ b/crates/templates/tests/templates/partials/metadata/partials/p1.liquid
@@ -1,0 +1,1 @@
+Hello from P1

--- a/crates/templates/tests/templates/partials/metadata/partials/p2.liquid
+++ b/crates/templates/tests/templates/partials/metadata/partials/p2.liquid
@@ -1,0 +1,1 @@
+Value is {{ value }}

--- a/crates/templates/tests/templates/partials/metadata/spin-template.toml
+++ b/crates/templates/tests/templates/partials/metadata/spin-template.toml
@@ -1,0 +1,7 @@
+manifest_version = "1"
+id = "partials"
+description = "Tests Liquid partials"
+trigger_type = "http"
+
+[parameters]
+example-value = { type = "string", prompt = "Example value" }


### PR DESCRIPTION
Fixes #3110 

How it works:

* There is a new recognised directory `partials` in the template `metadata` directory
* Partials are included as `.liquid` files in the `partials` directory e.g. `fancy-router.liquid`
* Content files reference partials using the `render` directive e.g. `{% render 'fancy-router' %}`
* If a partial uses a parameter then it must be explicitly passed e.g. `{% render 'fancy-router', base-path: base-path %}`. (Yes I realise this could be annoying but it appears to be just how Liquid works. https://liquidjs.com/tags/render.html#Passing-Variables)

See `crates/templates/tests/templates/partials` for an example.

@karthik2804 @ThorstenHans If you have an opportunity to test this on the JS SDK templates then it would be super useful to have your feedback or to let me know if there are bugs which my testing didn't catch!
