### PR TITLE
ref(templates/go): use spinframework import path

### DIFF
--- a/templates/Makefile
+++ b/templates/Makefile
@@ -1,4 +1,3 @@
-SDK_VERSION ?= v0.0.0
 CRATES_IO_VERSION := $(shell echo "${SDK_VERSION}" | tr -d 'v')
 
 bump-versions: bump-go-versions bump-rust-versions
@@ -6,8 +5,8 @@ bump-versions: bump-go-versions bump-rust-versions
 bump-go-versions:
 	@for dir in $$(ls -d *-go) ; do \
 		cd $$dir/content ; \
-		sed -r -i.sed-bak -e 's%require github.com/fermyon/spin/sdk/go/v2 [-a-zA-Z0-9.]+%require github.com/fermyon/spin/sdk/go/v2 ${SDK_VERSION}%g' go.mod ; \
 		sed -i.sed-bak -e 's/{{project-name | snake_case}}/foo/g' go.mod ; \
+		go get -u github.com/spinframework/spin-go-sdk ; \
 		go mod tidy ; \
 		sed -i.sed-bak -e 's/foo/{{project-name | snake_case}}/g' go.mod ; \
 		rm *.sed-bak ; \

--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -2,6 +2,6 @@ module github.com/{{project-name | snake_case}}
 
 go 1.22
 
-require github.com/fermyon/spin/sdk/go/v2 v2.2.0
+require github.com/spinframework/spin-go-sdk v0.0.0-20250411015808-ee0bd1e7d170
 
 require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/templates/http-go/content/go.sum
+++ b/templates/http-go/content/go.sum
@@ -1,4 +1,4 @@
-github.com/fermyon/spin/sdk/go/v2 v2.2.0 h1:zHZdIqjbUwyxiwdygHItnM+vUUNSZ3CX43jbIUemBI4=
-github.com/fermyon/spin/sdk/go/v2 v2.2.0/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/spinframework/spin-go-sdk v0.0.0-20250411015808-ee0bd1e7d170 h1:juNekE6jdrv6p7WtGGBTunnz4T0KNmcFh3Ar9DLIgCQ=
+github.com/spinframework/spin-go-sdk v0.0.0-20250411015808-ee0bd1e7d170/go.mod h1:e5+1n8xZksPGEpspNjTZ03vYe1qIK6Jb+k/OVja5QWU=

--- a/templates/http-go/content/main.go
+++ b/templates/http-go/content/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	spinhttp "github.com/spinframework/spin-go-sdk/http"
 )
 
 func init() {

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.22
 
-require github.com/fermyon/spin/sdk/go/v2 v2.2.0
+require github.com/spinframework/spin-go-sdk v0.0.0-20250411015808-ee0bd1e7d170

--- a/templates/redis-go/content/go.sum
+++ b/templates/redis-go/content/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go/v2 v2.2.0 h1:zHZdIqjbUwyxiwdygHItnM+vUUNSZ3CX43jbIUemBI4=
-github.com/fermyon/spin/sdk/go/v2 v2.2.0/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
+github.com/spinframework/spin-go-sdk v0.0.0-20250411015808-ee0bd1e7d170 h1:juNekE6jdrv6p7WtGGBTunnz4T0KNmcFh3Ar9DLIgCQ=
+github.com/spinframework/spin-go-sdk v0.0.0-20250411015808-ee0bd1e7d170/go.mod h1:e5+1n8xZksPGEpspNjTZ03vYe1qIK6Jb+k/OVja5QWU=

--- a/templates/redis-go/content/main.go
+++ b/templates/redis-go/content/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/fermyon/spin/sdk/go/v2/redis"
+	"github.com/spinframework/spin-go-sdk/redis"
 )
 
 func init() {


### PR DESCRIPTION
There's no tagged releases for the new Go SDK. This pins the SDK in the templates to a git sha.