### PR TITLE
chore(governance): propose adding spin-deps-plugin

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,6 +16,7 @@ The Spin project consists of several codebases with different release cycles. Th
     - [Spin Plugins Index Repository](https://github.com/spinframework/spin-plugins)
     - [Fermyon Platform Plugin](https://github.com/fermyon/platform-plugin)
     - [Spin Test Plugin](https://github.com/spinframework/spin-test)
+    - [Spin Deps Plugin](https://github.com/spinframework/spin-deps-plugin)
 - Triggers:
     - [Spin Command Trigger](https://github.com/spinframework/spin-trigger-command)
     - [Spin SQS Trigger](https://github.com/spinframework/spin-trigger-sqs)


### PR DESCRIPTION
Proposes adding the [Spin Deps Plugin repo](https://github.com/fermyon/spin-deps-plugin) to the Spin project, including migration to the `spinframework` GH org.

TODO:
- [ ] The link uses the speculative `https://github.com/spinframework/spin-deps-plugin` form, which depends on the repo moving to the `spinframework` org