### PR TITLE
Chore(governance): Propose adding js-wasi-ext

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,6 +12,7 @@ The Spin project consists of several codebases with different release cycles. Th
     - [Spin Rust SDK](https://github.com/spinframework/spin-rust-sdk)
     - [Spin .NET SDK](https://github.com/spinframework/spin-dotnet-sdk)
     - [Spin Go SDK](https://github.com/spinframework/spin-go-sdk)
+    - [JS Wasi Ext](https://github.com/spinframework/js-wasi-ext)
 - Plugins:
     - [Spin Plugins Index Repository](https://github.com/spinframework/spin-plugins)
     - [Fermyon Platform Plugin](https://github.com/fermyon/platform-plugin)


### PR DESCRIPTION
This commit adds the js-wasi-ext to the spin project. This is a library compatible with WASI 0.2 that makes select Node.js APIs available in ComponentizeJS and StarlingMonkey. This library depends on the build tooling used in the Spin JS SDK. This enables having more library compatibility for npm packages with the Spin JS SDK.

TODO:
- [ ] The link in the doc is to be the URL once the repository is moved here. 