### PR TITLE
More comprehensive templates option

### DIFF
--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -539,6 +539,7 @@ mod tests {
             accept_defaults: false,
             no_vcs: false,
             allow_overwrite: false,
+            explain: false,
         };
         rest(&mut options);
         options

--- a/crates/templates/src/renderer.rs
+++ b/crates/templates/src/renderer.rs
@@ -8,7 +8,7 @@ use crate::writer::{TemplateOutput, TemplateOutputs};
 // it needs to render.
 pub(crate) struct TemplateRenderer {
     pub render_operations: Vec<RenderOperation>,
-    pub parameter_values: HashMap<String, String>,
+    pub parameter_values: HashMap<String, liquid_core::model::Scalar>,
 }
 
 pub(crate) enum TemplateContent {
@@ -50,7 +50,7 @@ impl TemplateRenderer {
         for (k, v) in &self.parameter_values {
             object.insert(
                 k.to_owned().into(),
-                liquid_core::Value::Scalar(v.to_owned().into()),
+                liquid_core::Value::Scalar(v.to_owned()),
             );
         }
 

--- a/crates/templates/src/test_built_ins/mod.rs
+++ b/crates/templates/src/test_built_ins/mod.rs
@@ -40,6 +40,7 @@ async fn new_fileserver_creates_assets_dir() -> anyhow::Result<()> {
         accept_defaults: true,
         no_vcs: false,
         allow_overwrite: false,
+        explain: false,
     };
     manager
         .get("static-fileserver")?
@@ -87,6 +88,7 @@ async fn add_fileserver_creates_assets_dir_next_to_manifest() -> anyhow::Result<
         accept_defaults: true,
         no_vcs: false,
         allow_overwrite: false,
+        explain: false,
     };
     manager
         .get("http-empty")?
@@ -107,6 +109,7 @@ async fn add_fileserver_creates_assets_dir_next_to_manifest() -> anyhow::Result<
         accept_defaults: true,
         no_vcs: false,
         allow_overwrite: false,
+        explain: false,
     };
     manager
         .get("static-fileserver")?

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -76,6 +76,12 @@ pub struct TemplateNewCommandCore {
         takes_value = false
     )]
     pub allow_overwrite: bool,
+
+    /// Include additional explanatory information, where available, in the generated code.
+    /// This can be useful for learning about available options, but some users will find
+    /// the extra output burdensome.
+    #[clap(long = "explain", takes_value = false)]
+    explain: bool,
 }
 
 /// Scaffold a new application based on a template.
@@ -195,6 +201,7 @@ impl TemplateNewCommandCore {
             accept_defaults: self.accept_defaults,
             no_vcs: self.no_vcs,
             allow_overwrite: self.allow_overwrite,
+            explain: self.explain,
         };
 
         let run = template.run(options);

--- a/templates/http-rust/content/spin.toml
+++ b/templates/http-rust/content/spin.toml
@@ -12,7 +12,22 @@ component = "{{project-name | kebab_case}}"
 
 [component.{{project-name | kebab_case}}]
 source = "target/wasm32-wasip1/release/{{project-name | snake_case}}.wasm"
+{% if explain %}# The network hosts to which the component may make requests to. E.g. ["https://example.com", "postgres://data.example.com:4004"]
+# Learn more: https://spinframework.dev/v3/http-outbound#granting-http-permissions-to-components, https://spinframework.dev/v3/mqtt-outbound#granting-network-permissions-to-components, https://spinframework.dev/v3/rdbms-storage#granting-network-permissions-to-components
 allowed_outbound_hosts = []
+# The files from your host system that should be included in the application and available to the component. E.g. [{ source = "assets", destination = "/"}]
+# Learn more: https://spinframework.dev/v3/writing-apps#including-files-with-components
+files = []
+# The key-value stores the component should have access to. E.g. ["default", "cache"]. Learn more: https://spinframework.dev/v3/kv-store-api-guide#granting-key-value-store-permissions-to-components
+# Non-default stores must be mapped in a runtime config file. Learn more: https://spinframework.dev/v3/dynamic-configuration#key-value-store-runtime-configuration
+key_value_stores = []
+# The SQLite databases the component should have access to. E.g. ["default", "accounts"]. Learn more: https://spinframework.dev/v3/sqlite-api-guide#granting-sqlite-database-permissions-to-components
+# Non-default databases must be mapped in a runtime config file. Learn more: hhttps://spinframework.dev/v3/dynamic-configuration#sqlite-storage-runtime-configuration
+sqlite_databases = []
+
+[component.{{project-name | kebab_case}}.dependencies]
+# Wasm components on which your Wasm binary depends. Learn more: https://spinframework.dev/v3/writing-apps#using-component-dependencies
+{% else %}allowed_outbound_hosts = []{% endif %}
 [component.{{project-name | kebab_case}}.build]
 command = "cargo build --target wasm32-wasip1 --release"
 watch = ["src/**/*.rs", "Cargo.toml"]


### PR DESCRIPTION
We have a tension in the template system between those who want the generate code to give users a clear roadmap to all the things and those who were _extremely burned by 2010s Microsoft project templates that gave you 44 files of an entire working N-tier application that you had to spend half a day deleting code out of to get it back to a point where--_ uh anyway some of us were cautious about overdoing it.

This PR explores offering a command line flag on `new/add` which is passed through to the template and can be used by the template to add optional fields, comments, links, etc. that may feel like clutter to some but provide helpful pointers to others.  The flag is currently called `--explain` and is defaulted to false: both of these are up for grabs (in particular, the default means that users need to know that the flag exists to get the extra stuff, which may well be perverse).

Another possible approach is, instead of making it a system-level flag, have it as a parameter within each template, where it could be prompted for.  This avoids the need for new users to know about the magic flag.  But having it at system level opens the door to adding more guidance outside of template execution, e.g. displaying instructions on how to run `spin build` and `spin up`.  (A future thing could also allow for displaying template-specific guidance e.g. "you'll need Rust 1.99 and the wasm32-wasip7 target, here's how to get them.")

The PR currently updates just one template, ye olde http-rust.  If we decide we want to do this, and once we are aligned on the approach, it should be easy to update others.

Sample generated manifest from `spin new http-rust explain-test -a --explain`:

```toml
spin_manifest_version = 2

[application]
name = "explain-test"
version = "0.1.0"
authors = ["itowlson <ivan.towlson@fermyon.com>"]
description = ""

[[trigger.http]]
route = "/..."
component = "explain-test"

[component.explain-test]
source = "target/wasm32-wasip1/release/explain_test.wasm"
# The network hosts to which the component may make requests to. E.g. ["https://example.com", "postgres://data.example.com:4004"]
# Learn more: https://spinframework.dev/v3/http-outbound#granting-http-permissions-to-components, https://spinframework.dev/v3/mqtt-outbound#granting-network-permissions-to-components, https://spinframework.dev/v3/rdbms-storage#granting-network-permissions-to-components
allowed_outbound_hosts = []
# The files from your host system that should be included in the application and available to the component. E.g. [{ source = "assets", destination = "/"}]
# Learn more: https://spinframework.dev/v3/writing-apps#including-files-with-components
files = []
# The key-value stores the component should have access to. E.g. ["default", "cache"]. Learn more: https://spinframework.dev/v3/kv-store-api-guide#granting-key-value-store-permissions-to-components
# Non-default stores must be mapped in a runtime config file. Learn more: https://spinframework.dev/v3/dynamic-configuration#key-value-store-runtime-configuration
key_value_stores = []
# The SQLite databases the component should have access to. E.g. ["default", "accounts"]. Learn more: https://spinframework.dev/v3/sqlite-api-guide#granting-sqlite-database-permissions-to-components
# Non-default databases must be mapped in a runtime config file. Learn more: hhttps://spinframework.dev/v3/dynamic-configuration#sqlite-storage-runtime-configuration
sqlite_databases = []

[component.explain-test.dependencies]
# Wasm components on which your Wasm binary depends. Learn more: https://spinframework.dev/v3/writing-apps#using-component-dependencies

[component.explain-test.build]
command = "cargo build --target wasm32-wasip1 --release"
watch = ["src/**/*.rs", "Cargo.toml"]
```

(Draft for now because if we go forward there will be more to do on other templates.)
