### PR TITLE
fix(templates/http-go): enable GC on builds

### DIFF
--- a/templates/http-go/content/spin.toml
+++ b/templates/http-go/content/spin.toml
@@ -14,5 +14,5 @@ component = "{{project-name | kebab_case}}"
 source = "main.wasm"
 allowed_outbound_hosts = []
 [component.{{project-name | kebab_case}}.build]
-command = "tinygo build -target=wasip1 -gc=leaking -buildmode=c-shared -no-debug -o main.wasm ."
+command = "tinygo build -target=wasip1 -buildmode=c-shared -no-debug -o main.wasm ."
 watch = ["**/*.go", "go.mod"]


### PR DESCRIPTION
The TinyGo GC seems to be working now for wasi.