### PR TITLE
Refactor how `InitContext` works with factors

### DIFF
--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -38,7 +38,10 @@ impl Factor for KeyValueFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceBuilder;
 
-    fn init<T: Send + 'static>(&mut self, mut ctx: InitContext<T, Self>) -> anyhow::Result<()> {
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: InitContext<Self>,
+    {
         ctx.link_bindings(spin_world::v1::key_value::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::key_value::add_to_linker)?;
         ctx.link_bindings(spin_world::wasi::keyvalue::store::add_to_linker)?;

--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -38,10 +38,7 @@ impl Factor for KeyValueFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceBuilder;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::key_value::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::key_value::add_to_linker)?;
         ctx.link_bindings(spin_world::wasi::keyvalue::store::add_to_linker)?;

--- a/crates/factor-llm/src/lib.rs
+++ b/crates/factor-llm/src/lib.rs
@@ -36,10 +36,10 @@ impl Factor for LlmFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init<T: Send + 'static>(
-        &mut self,
-        mut ctx: spin_factors::InitContext<T, Self>,
-    ) -> anyhow::Result<()> {
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: spin_factors::InitContext<Self>,
+    {
         ctx.link_bindings(spin_world::v1::llm::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::llm::add_to_linker)?;
         Ok(())

--- a/crates/factor-llm/src/lib.rs
+++ b/crates/factor-llm/src/lib.rs
@@ -36,10 +36,7 @@ impl Factor for LlmFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: spin_factors::InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::llm::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::llm::add_to_linker)?;
         Ok(())

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -52,10 +52,7 @@ impl Factor for OutboundHttpFactor {
     type AppState = ();
     type InstanceBuilder = InstanceState;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: spin_factors::InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::http::add_to_linker)?;
         wasi::add_to_linker(ctx)?;
         Ok(())

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -52,12 +52,12 @@ impl Factor for OutboundHttpFactor {
     type AppState = ();
     type InstanceBuilder = InstanceState;
 
-    fn init<T: Send + 'static>(
-        &mut self,
-        mut ctx: spin_factors::InitContext<T, Self>,
-    ) -> anyhow::Result<()> {
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: spin_factors::InitContext<Self>,
+    {
         ctx.link_bindings(spin_world::v1::http::add_to_linker)?;
-        wasi::add_to_linker::<T>(&mut ctx)?;
+        wasi::add_to_linker(ctx)?;
         Ok(())
     }
 

--- a/crates/factor-outbound-http/src/wasi_2023_10_18.rs
+++ b/crates/factor-outbound-http/src/wasi_2023_10_18.rs
@@ -54,10 +54,12 @@ use wasi::io::streams::{InputStream, OutputStream};
 
 use crate::wasi::WasiHttpImplInner;
 
-pub(crate) fn add_to_linker<T, F>(linker: &mut Linker<T>, closure: F) -> Result<()>
+pub(crate) fn add_to_linker<T>(
+    linker: &mut Linker<T>,
+    closure: fn(&mut T) -> WasiHttpImpl<WasiHttpImplInner<'_>>,
+) -> Result<()>
 where
-    T: Send,
-    F: Fn(&mut T) -> WasiHttpImpl<WasiHttpImplInner> + Send + Sync + Copy + 'static,
+    T: Send + 'static,
 {
     wasi::http::types::add_to_linker_get_host(linker, closure)?;
     wasi::http::outgoing_handler::add_to_linker_get_host(linker, closure)?;

--- a/crates/factor-outbound-http/src/wasi_2023_11_10.rs
+++ b/crates/factor-outbound-http/src/wasi_2023_11_10.rs
@@ -59,10 +59,12 @@ use wasi::io::streams::{Error as IoError, InputStream, OutputStream};
 
 use crate::wasi::WasiHttpImplInner;
 
-pub(crate) fn add_to_linker<T, F>(linker: &mut Linker<T>, closure: F) -> Result<()>
+pub(crate) fn add_to_linker<T>(
+    linker: &mut Linker<T>,
+    closure: fn(&mut T) -> WasiHttpImpl<WasiHttpImplInner<'_>>,
+) -> Result<()>
 where
-    T: Send,
-    F: Fn(&mut T) -> WasiHttpImpl<WasiHttpImplInner> + Send + Sync + Copy + 'static,
+    T: Send + 'static,
 {
     wasi::http::types::add_to_linker_get_host(linker, closure)?;
     wasi::http::outgoing_handler::add_to_linker_get_host(linker, closure)?;

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -31,10 +31,7 @@ impl Factor for OutboundMqttFactor {
     type AppState = ();
     type InstanceBuilder = InstanceState;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: spin_factors::InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v2::mqtt::add_to_linker)?;
         Ok(())
     }

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -31,10 +31,10 @@ impl Factor for OutboundMqttFactor {
     type AppState = ();
     type InstanceBuilder = InstanceState;
 
-    fn init<T: Send + 'static>(
-        &mut self,
-        mut ctx: spin_factors::InitContext<T, Self>,
-    ) -> anyhow::Result<()> {
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: spin_factors::InitContext<Self>,
+    {
         ctx.link_bindings(spin_world::v2::mqtt::add_to_linker)?;
         Ok(())
     }

--- a/crates/factor-outbound-mysql/src/lib.rs
+++ b/crates/factor-outbound-mysql/src/lib.rs
@@ -17,7 +17,10 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundMysqlFactor<C> {
     type AppState = ();
     type InstanceBuilder = InstanceState<C>;
 
-    fn init<T: Send + 'static>(&mut self, mut ctx: InitContext<T, Self>) -> anyhow::Result<()> {
+    fn init<I>(&mut self, ctx: &mut I) -> anyhow::Result<()>
+    where
+        I: InitContext<Self>,
+    {
         ctx.link_bindings(v1::add_to_linker)?;
         ctx.link_bindings(v2::add_to_linker)?;
         Ok(())

--- a/crates/factor-outbound-mysql/src/lib.rs
+++ b/crates/factor-outbound-mysql/src/lib.rs
@@ -17,10 +17,7 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundMysqlFactor<C> {
     type AppState = ();
     type InstanceBuilder = InstanceState<C>;
 
-    fn init<I>(&mut self, ctx: &mut I) -> anyhow::Result<()>
-    where
-        I: InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(v1::add_to_linker)?;
         ctx.link_bindings(v2::add_to_linker)?;
         Ok(())

--- a/crates/factor-outbound-pg/src/lib.rs
+++ b/crates/factor-outbound-pg/src/lib.rs
@@ -17,10 +17,7 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundPgFactor<C> {
     type AppState = ();
     type InstanceBuilder = InstanceState<C>;
 
-    fn init<I>(&mut self, ctx: &mut I) -> anyhow::Result<()>
-    where
-        I: spin_factors::InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::postgres::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::postgres::add_to_linker)?;
         ctx.link_bindings(spin_world::spin::postgres::postgres::add_to_linker)?;

--- a/crates/factor-outbound-pg/src/lib.rs
+++ b/crates/factor-outbound-pg/src/lib.rs
@@ -17,10 +17,10 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundPgFactor<C> {
     type AppState = ();
     type InstanceBuilder = InstanceState<C>;
 
-    fn init<T: Send + 'static>(
-        &mut self,
-        mut ctx: spin_factors::InitContext<T, Self>,
-    ) -> anyhow::Result<()> {
+    fn init<I>(&mut self, ctx: &mut I) -> anyhow::Result<()>
+    where
+        I: spin_factors::InitContext<Self>,
+    {
         ctx.link_bindings(spin_world::v1::postgres::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::postgres::add_to_linker)?;
         ctx.link_bindings(spin_world::spin::postgres::postgres::add_to_linker)?;

--- a/crates/factor-outbound-redis/src/lib.rs
+++ b/crates/factor-outbound-redis/src/lib.rs
@@ -23,10 +23,7 @@ impl Factor for OutboundRedisFactor {
     type AppState = ();
     type InstanceBuilder = InstanceState;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: spin_factors::InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::redis::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::redis::add_to_linker)?;
         Ok(())

--- a/crates/factor-outbound-redis/src/lib.rs
+++ b/crates/factor-outbound-redis/src/lib.rs
@@ -23,10 +23,10 @@ impl Factor for OutboundRedisFactor {
     type AppState = ();
     type InstanceBuilder = InstanceState;
 
-    fn init<T: Send + 'static>(
-        &mut self,
-        mut ctx: spin_factors::InitContext<T, Self>,
-    ) -> anyhow::Result<()> {
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: spin_factors::InitContext<Self>,
+    {
         ctx.link_bindings(spin_world::v1::redis::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::redis::add_to_linker)?;
         Ok(())

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -32,10 +32,10 @@ impl Factor for SqliteFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init<T: Send + 'static>(
-        &mut self,
-        mut ctx: spin_factors::InitContext<T, Self>,
-    ) -> anyhow::Result<()> {
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: spin_factors::InitContext<Self>,
+    {
         ctx.link_bindings(v1::add_to_linker)?;
         ctx.link_bindings(v2::add_to_linker)?;
         ctx.link_bindings(v3::add_to_linker)?;

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -32,10 +32,7 @@ impl Factor for SqliteFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: spin_factors::InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(v1::add_to_linker)?;
         ctx.link_bindings(v2::add_to_linker)?;
         ctx.link_bindings(v3::add_to_linker)?;

--- a/crates/factor-variables/src/lib.rs
+++ b/crates/factor-variables/src/lib.rs
@@ -28,7 +28,10 @@ impl Factor for VariablesFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init<T: Send + 'static>(&mut self, mut ctx: InitContext<T, Self>) -> anyhow::Result<()> {
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: InitContext<Self>,
+    {
         ctx.link_bindings(spin_world::v1::config::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::variables::add_to_linker)?;
         ctx.link_bindings(spin_world::wasi::config::store::add_to_linker)?;

--- a/crates/factor-variables/src/lib.rs
+++ b/crates/factor-variables/src/lib.rs
@@ -28,10 +28,7 @@ impl Factor for VariablesFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: InitContext<Self>,
-    {
+    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::config::add_to_linker)?;
         ctx.link_bindings(spin_world::v2::variables::add_to_linker)?;
         ctx.link_bindings(spin_world::wasi::config::store::add_to_linker)?;

--- a/crates/factor-wasi/src/lib.rs
+++ b/crates/factor-wasi/src/lib.rs
@@ -44,66 +44,98 @@ impl WasiFactor {
     }
 }
 
+/// Helper trait to extend `InitContext` with some more `link_*_bindings`
+/// methods related to `wasmtime-wasi` and `wasmtime-wasi-io`-specific
+/// signatures.
+#[allow(clippy::type_complexity, reason = "sorry, blame alex")]
+trait InitContextExt: InitContext<WasiFactor> {
+    fn get_io(data: &mut Self::StoreData) -> IoImpl<WasiImplInner<'_>> {
+        let (state, table) = Self::get_data_with_table(data);
+        IoImpl(WasiImplInner {
+            ctx: &mut state.ctx,
+            table,
+        })
+    }
+
+    fn link_io_bindings(
+        &mut self,
+        add_to_linker: fn(
+            &mut wasmtime::component::Linker<Self::StoreData>,
+            fn(&mut Self::StoreData) -> IoImpl<WasiImplInner<'_>>,
+        ) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        add_to_linker(self.linker(), Self::get_io)
+    }
+
+    fn get_wasi(data: &mut Self::StoreData) -> WasiImpl<WasiImplInner<'_>> {
+        WasiImpl(Self::get_io(data))
+    }
+
+    fn link_wasi_bindings(
+        &mut self,
+        add_to_linker: fn(
+            &mut wasmtime::component::Linker<Self::StoreData>,
+            fn(&mut Self::StoreData) -> WasiImpl<WasiImplInner<'_>>,
+        ) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        add_to_linker(self.linker(), Self::get_wasi)
+    }
+
+    fn link_wasi_default_bindings<O>(
+        &mut self,
+        add_to_linker: fn(
+            &mut wasmtime::component::Linker<Self::StoreData>,
+            &O,
+            fn(&mut Self::StoreData) -> WasiImpl<WasiImplInner<'_>>,
+        ) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()>
+    where
+        O: Default,
+    {
+        add_to_linker(self.linker(), &O::default(), Self::get_wasi)
+    }
+}
+
+impl<T> InitContextExt for T where T: InitContext<WasiFactor> {}
+
 impl Factor for WasiFactor {
     type RuntimeConfig = ();
     type AppState = ();
     type InstanceBuilder = InstanceBuilder;
 
-    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
-    where
-        C: InitContext<Self>,
-    {
-        fn get_io<C: InitContext<WasiFactor>>(
-            data: &mut C::StoreData,
-        ) -> IoImpl<WasiImplInner<'_>> {
-            let (state, table) = C::get_data_with_table(data);
-            IoImpl(WasiImplInner {
-                ctx: &mut state.ctx,
-                table,
-            })
-        }
-
-        fn get_wasi<C: InitContext<WasiFactor>>(
-            data: &mut C::StoreData,
-        ) -> WasiImpl<WasiImplInner<'_>> {
-            WasiImpl(get_io::<C>(data))
-        }
-
-        let get_io = get_io::<C> as fn(&mut C::StoreData) -> IoImpl<WasiImplInner<'_>>;
-        let get_wasi = get_wasi::<C> as fn(&mut C::StoreData) -> WasiImpl<WasiImplInner<'_>>;
-        let linker = ctx.linker();
+    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
         use wasmtime_wasi::bindings;
-        bindings::clocks::wall_clock::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::clocks::monotonic_clock::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::filesystem::types::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::filesystem::preopens::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::io::error::add_to_linker_get_host(linker, get_io)?;
-        bindings::io::poll::add_to_linker_get_host(linker, get_io)?;
-        bindings::io::streams::add_to_linker_get_host(linker, get_io)?;
-        bindings::random::random::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::random::insecure::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::random::insecure_seed::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::exit::add_to_linker_get_host(linker, &Default::default(), get_wasi)?;
-        bindings::cli::environment::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::stdin::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::stdout::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::stderr::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::terminal_input::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::terminal_output::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::terminal_stdin::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::terminal_stdout::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::cli::terminal_stderr::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::sockets::tcp::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::sockets::tcp_create_socket::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::sockets::udp::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::sockets::udp_create_socket::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::sockets::instance_network::add_to_linker_get_host(linker, get_wasi)?;
-        bindings::sockets::network::add_to_linker_get_host(linker, &Default::default(), get_wasi)?;
-        bindings::sockets::ip_name_lookup::add_to_linker_get_host(linker, get_wasi)?;
 
-        wasi_2023_10_18::add_to_linker(linker, get_wasi)?;
-        wasi_2023_11_10::add_to_linker(linker, get_wasi)?;
+        ctx.link_wasi_bindings(bindings::clocks::wall_clock::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::clocks::monotonic_clock::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::filesystem::types::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::filesystem::preopens::add_to_linker_get_host)?;
+        ctx.link_io_bindings(bindings::io::error::add_to_linker_get_host)?;
+        ctx.link_io_bindings(bindings::io::poll::add_to_linker_get_host)?;
+        ctx.link_io_bindings(bindings::io::streams::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::random::random::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::random::insecure::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::random::insecure_seed::add_to_linker_get_host)?;
+        ctx.link_wasi_default_bindings(bindings::cli::exit::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::environment::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::stdin::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::stdout::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::stderr::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::terminal_input::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::terminal_output::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::terminal_stdin::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::terminal_stdout::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::cli::terminal_stderr::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::sockets::tcp::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::sockets::tcp_create_socket::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::sockets::udp::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::sockets::udp_create_socket::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::sockets::instance_network::add_to_linker_get_host)?;
+        ctx.link_wasi_default_bindings(bindings::sockets::network::add_to_linker_get_host)?;
+        ctx.link_wasi_bindings(bindings::sockets::ip_name_lookup::add_to_linker_get_host)?;
 
+        ctx.link_wasi_bindings(wasi_2023_10_18::add_to_linker)?;
+        ctx.link_wasi_bindings(wasi_2023_11_10::add_to_linker)?;
         Ok(())
     }
 

--- a/crates/factor-wasi/src/wasi_2023_10_18.rs
+++ b/crates/factor-wasi/src/wasi_2023_10_18.rs
@@ -118,10 +118,12 @@ use wasi::sockets::udp::Datagram;
 
 use crate::WasiImplInner;
 
-pub fn add_to_linker<T, F>(linker: &mut Linker<T>, closure: F) -> Result<()>
+pub fn add_to_linker<T>(
+    linker: &mut Linker<T>,
+    closure: fn(&mut T) -> WasiImpl<WasiImplInner<'_>>,
+) -> Result<()>
 where
-    T: Send,
-    F: Fn(&mut T) -> WasiImpl<WasiImplInner> + Send + Sync + Copy + 'static,
+    T: Send + 'static,
 {
     wasi::clocks::monotonic_clock::add_to_linker_get_host(linker, closure)?;
     wasi::clocks::wall_clock::add_to_linker_get_host(linker, closure)?;

--- a/crates/factor-wasi/src/wasi_2023_11_10.rs
+++ b/crates/factor-wasi/src/wasi_2023_11_10.rs
@@ -111,10 +111,12 @@ use wasi::sockets::udp::{
 
 use crate::WasiImplInner;
 
-pub fn add_to_linker<T, F>(linker: &mut Linker<T>, closure: F) -> Result<()>
+pub fn add_to_linker<T>(
+    linker: &mut Linker<T>,
+    closure: fn(&mut T) -> WasiImpl<WasiImplInner<'_>>,
+) -> Result<()>
 where
-    T: Send,
-    F: Fn(&mut T) -> WasiImpl<WasiImplInner> + Send + Sync + Copy + 'static,
+    T: Send + 'static,
 {
     wasi::clocks::monotonic_clock::add_to_linker_get_host(linker, closure)?;
     wasi::clocks::wall_clock::add_to_linker_get_host(linker, closure)?;

--- a/crates/factors/src/factor.rs
+++ b/crates/factors/src/factor.rs
@@ -1,8 +1,11 @@
 use std::any::Any;
+use std::marker::PhantomData;
 
 use wasmtime::component::{Linker, ResourceTable};
 
-use crate::{prepare::FactorInstanceBuilder, App, Error, PrepareContext, RuntimeFactors};
+use crate::{
+    prepare::FactorInstanceBuilder, App, AsInstanceState, Error, PrepareContext, RuntimeFactors,
+};
 
 /// A contained (i.e., "factored") piece of runtime functionality.
 pub trait Factor: Any + Sized {
@@ -28,8 +31,11 @@ pub trait Factor: Any + Sized {
     ///
     /// The type parameter `T` here is the same as the [`wasmtime::Store`] type
     /// parameter `T`, which will contain the [`RuntimeFactors::InstanceState`].
-    fn init<T: Send + 'static>(&mut self, mut ctx: InitContext<T, Self>) -> anyhow::Result<()> {
-        _ = &mut ctx;
+    fn init<C>(&mut self, ctx: &mut C) -> anyhow::Result<()>
+    where
+        C: InitContext<Self>,
+    {
+        let _ = ctx;
         Ok(())
     }
 
@@ -70,58 +76,70 @@ pub trait Factor: Any + Sized {
 pub type FactorInstanceState<F> =
     <<F as Factor>::InstanceBuilder as FactorInstanceBuilder>::InstanceState;
 
-pub(crate) type GetDataFn<T, U> = fn(&mut T) -> &mut FactorInstanceState<U>;
-
-pub(crate) type GetDataWithTableFn<T, U> =
-    fn(&mut T) -> (&mut FactorInstanceState<U>, &mut ResourceTable);
-
 /// An InitContext is passed to [`Factor::init`], giving access to the global
 /// common [`wasmtime::component::Linker`].
-pub struct InitContext<'a, T, U: Factor> {
-    pub(crate) linker: &'a mut Linker<T>,
-    pub(crate) get_data: GetDataFn<T, U>,
-    pub(crate) get_data_with_table: GetDataWithTableFn<T, U>,
-}
-
-impl<'a, T, U: Factor> InitContext<'a, T, U> {
-    #[doc(hidden)]
-    pub fn new(
-        linker: &'a mut Linker<T>,
-        get_data: GetDataFn<T, U>,
-        get_data_with_table: GetDataWithTableFn<T, U>,
-    ) -> Self {
-        Self {
-            linker,
-            get_data,
-            get_data_with_table,
-        }
-    }
+pub trait InitContext<F: Factor> {
+    type StoreData: Send + 'static;
 
     /// Returns a mutable reference to the [`wasmtime::component::Linker`].
-    pub fn linker(&mut self) -> &mut Linker<T> {
+    fn linker(&mut self) -> &mut Linker<Self::StoreData>;
+
+    /// Get the instance state for this factor from the store's state.
+    fn get_data(store: &mut Self::StoreData) -> &mut FactorInstanceState<F> {
+        Self::get_data_with_table(store).0
+    }
+
+    /// Get the instance state for this factor from the store's state, with the
+    /// resource table as well.
+    fn get_data_with_table(
+        store: &mut Self::StoreData,
+    ) -> (&mut FactorInstanceState<F>, &mut ResourceTable);
+
+    /// Convenience method to link a binding to the linker.
+    fn link_bindings(
+        &mut self,
+        add_to_linker: impl Fn(
+            &mut Linker<Self::StoreData>,
+            fn(&mut Self::StoreData) -> &mut FactorInstanceState<F>,
+        ) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        let get_data = Self::get_data;
+        add_to_linker(self.linker(), get_data)
+    }
+}
+
+// used in #[derive(RuntimeFactor)]
+#[doc(hidden)]
+pub struct FactorInitContext<'a, T, G> {
+    pub linker: &'a mut Linker<T>,
+    pub _marker: PhantomData<G>,
+}
+
+// used in #[derive(RuntimeFactor)]
+#[doc(hidden)]
+pub trait FactorField {
+    type State: crate::RuntimeFactorsInstanceState;
+    type Factor: Factor;
+
+    fn get(field: &mut Self::State)
+        -> (&mut FactorInstanceState<Self::Factor>, &mut ResourceTable);
+}
+
+impl<T, G> InitContext<G::Factor> for FactorInitContext<'_, T, G>
+where
+    G: FactorField,
+    T: AsInstanceState<G::State> + Send + 'static,
+{
+    type StoreData = T;
+
+    fn linker(&mut self) -> &mut Linker<Self::StoreData> {
         self.linker
     }
 
-    /// Returns a function that can be used to get the instance state for this factor.
-    pub fn get_data_fn(&self) -> GetDataFn<T, U> {
-        self.get_data
-    }
-
-    /// Returns a function that can be used to get the instance state for this
-    /// factor along with the instance's [`ResourceTable`].
-    pub fn get_data_with_table_fn(&self) -> GetDataWithTableFn<T, U> {
-        self.get_data_with_table
-    }
-
-    /// Convenience method to link a binding to the linker.
-    pub fn link_bindings(
-        &mut self,
-        add_to_linker: impl Fn(
-            &mut Linker<T>,
-            fn(&mut T) -> &mut FactorInstanceState<U>,
-        ) -> anyhow::Result<()>,
-    ) -> anyhow::Result<()> {
-        add_to_linker(self.linker, self.get_data)
+    fn get_data_with_table(
+        store: &mut Self::StoreData,
+    ) -> (&mut FactorInstanceState<G::Factor>, &mut ResourceTable) {
+        G::get(store.as_instance_state())
     }
 }
 

--- a/crates/factors/src/lib.rs
+++ b/crates/factors/src/lib.rs
@@ -11,7 +11,10 @@ pub use spin_app::{App, AppComponent};
 pub use spin_factors_derive::RuntimeFactors;
 
 pub use crate::{
-    factor::{ConfigureAppContext, ConfiguredApp, Factor, FactorInstanceState, InitContext},
+    factor::{
+        ConfigureAppContext, ConfiguredApp, Factor, FactorField, FactorInitContext,
+        FactorInstanceState, InitContext,
+    },
     prepare::{FactorInstanceBuilder, PrepareContext, SelfInstanceBuilder},
     runtime_config::{FactorRuntimeConfigSource, RuntimeConfigSourceFinalizer},
     runtime_factors::{


### PR DESCRIPTION
This commit is a refactoring to replace the concrete `InitContext` structure with a generic type parameter instead. The motivation for this is to prepare for handling bytecodealliance/wasmtime#10770. That's a big change to how `add_to_linker` functions work, notably that the argument to the generated functions is a `fn`, not a `F: Fn`. WASI factors currently rely on the closure-like nature this argument which means it's not compatible with that change. The refactoring to use a `trait InitContext` here enables plumbing a type parameter through a function to be able to get a function pointer without relying on closures.