### PR TITLE
Add support for limiting instance memory usage in spin up

### DIFF
--- a/crates/runtime-factors/src/build.rs
+++ b/crates/runtime-factors/src/build.rs
@@ -6,8 +6,9 @@ use anyhow::Context as _;
 use spin_factors_executor::FactorsExecutor;
 use spin_runtime_config::ResolvedRuntimeConfig;
 use spin_trigger::cli::{
-    FactorsConfig, InitialKvSetterHook, KeyValueDefaultStoreSummaryHook, RuntimeFactorsBuilder,
-    SqlStatementExecutorHook, SqliteDefaultStoreSummaryHook, StdioLoggingExecutorHooks,
+    FactorsConfig, InitialKvSetterHook, KeyValueDefaultStoreSummaryHook, MaxInstanceMemoryHook,
+    RuntimeFactorsBuilder, SqlStatementExecutorHook, SqliteDefaultStoreSummaryHook,
+    StdioLoggingExecutorHooks,
 };
 
 /// A [`RuntimeFactorsBuilder`] for [`TriggerFactors`].
@@ -56,6 +57,16 @@ impl RuntimeFactorsBuilder for FactorsBuilder {
         executor.add_hooks(InitialKvSetterHook::new(args.key_values.clone()));
         executor.add_hooks(SqliteDefaultStoreSummaryHook);
         executor.add_hooks(KeyValueDefaultStoreSummaryHook);
+
+        let max_instance_memory = args
+            .max_instance_memory
+            .or(runtime_config.max_instance_memory());
+
+        // Only add the hook if a max instance memory size is specified via flag or runtime config.
+        if let Some(max_instance_memory) = max_instance_memory {
+            executor.add_hooks(MaxInstanceMemoryHook::new(max_instance_memory));
+        }
+
         Ok(())
     }
 }

--- a/crates/runtime-factors/src/lib.rs
+++ b/crates/runtime-factors/src/lib.rs
@@ -100,6 +100,10 @@ pub struct TriggerAppArgs {
     /// To run from a file, prefix the filename with @ e.g. spin up --sqlite @migration.sql
     #[clap(long = "sqlite")]
     pub sqlite_statements: Vec<String>,
+
+    /// Sets the maxmimum memory allocation limit for an instance in bytes.
+    #[clap(long, env = "SPIN_MAX_INSTANCE_MEMORY")]
+    pub max_instance_memory: Option<usize>,
 }
 
 impl From<ResolvedRuntimeConfig<TriggerFactorsRuntimeConfig>> for TriggerFactorsRuntimeConfig {

--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -1,5 +1,6 @@
 mod initial_kv_setter;
 mod launch_metadata;
+mod max_instance_memory;
 mod sqlite_statements;
 mod stdio;
 mod summary;
@@ -19,6 +20,7 @@ use spin_factors_executor::{ComponentLoader, FactorsExecutor};
 use crate::{loader::ComponentLoader as ComponentLoaderImpl, Trigger, TriggerApp};
 pub use initial_kv_setter::InitialKvSetterHook;
 pub use launch_metadata::LaunchMetadata;
+pub use max_instance_memory::MaxInstanceMemoryHook;
 pub use sqlite_statements::SqlStatementExecutorHook;
 use stdio::FollowComponents;
 pub use stdio::StdioLoggingExecutorHooks;

--- a/crates/trigger/src/cli/max_instance_memory.rs
+++ b/crates/trigger/src/cli/max_instance_memory.rs
@@ -1,0 +1,26 @@
+use spin_core::async_trait;
+use spin_factors::RuntimeFactors;
+use spin_factors_executor::{ExecutorHooks, FactorsInstanceBuilder};
+
+/// An [`ExecutorHooks`] that sets the maximum memory allocation limit.
+pub struct MaxInstanceMemoryHook {
+    max_instance_memory: usize,
+}
+
+impl MaxInstanceMemoryHook {
+    pub fn new(max_instance_memory: usize) -> Self {
+        Self {
+            max_instance_memory,
+        }
+    }
+}
+
+#[async_trait]
+impl<F: RuntimeFactors, U> ExecutorHooks<F, U> for MaxInstanceMemoryHook {
+    fn prepare_instance(&self, builder: &mut FactorsInstanceBuilder<F, U>) -> anyhow::Result<()> {
+        builder
+            .store_builder()
+            .max_memory_size(self.max_instance_memory);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implements a CLI flag and runtime config option for configuring the maximum memory allocation limit for an instance. The limit (implemented as a new `ExecutorHooks`) gets applied to the store via implementation of `ExecutorHooks::prepare_instance`.

Closes #3132 