### PR TITLE
Warn or error on dubious-looking file mount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8452,6 +8452,7 @@ dependencies = [
  "spin-manifest",
  "spin-serde",
  "tempfile",
+ "terminal",
  "tokio",
  "toml",
  "tracing",

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -21,6 +21,7 @@ spin-locked-app = { path = "../locked-app" }
 spin-manifest = { path = "../manifest" }
 spin-serde = { path = "../serde" }
 tempfile = { workspace = true }
+terminal = { path = "../terminal" }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -485,6 +485,20 @@ impl LocalLoader {
         dest_root: &Path,
         exclude_files: &[String],
     ) -> Result<()> {
+        if glob_or_path == ".." || glob_or_path.ends_with("/..") {
+            bail!("A file pattern can't end in a parent directory path (..)\nIf you want to include a directory, use source-destination form, or a glob pattern ending in **/*.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components");
+        }
+        if glob_or_path == "." || glob_or_path.ends_with("/.") {
+            bail!("A file pattern can't end in a current directory path (.)\nIf you want to include a directory, use source-destination form, or a glob pattern ending in **/*.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components");
+        }
+
+        if glob_or_path == "*" {
+            terminal::warn!("A component is including the entire application directory as asset files. This is unlikely to be what you want.\nIf this is what you want, use the pattern \"./*\" to avoid this warning.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components\n");
+        }
+        if glob_or_path == "**/*" {
+            terminal::warn!("A component is including the entire application directory tree as asset files. This is unlikely to be what you want.\nIf this is what you want, use the pattern \"./**/*\" to avoid this warning.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components\n");
+        }
+
         let path = self.app_root.join(glob_or_path);
         if path.exists() {
             let dest = dest_root.join(glob_or_path);

--- a/crates/loader/src/local.rs
+++ b/crates/loader/src/local.rs
@@ -493,10 +493,10 @@ impl LocalLoader {
         }
 
         if glob_or_path == "*" {
-            terminal::warn!("A component is including the entire application directory as asset files. This is unlikely to be what you want.\nIf this is what you want, use the pattern \"./*\" to avoid this warning.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components\n");
+            tracing::warn!(alert_in_dev = true, "A component is including the entire application directory as asset files. This is unlikely to be what you want.\nIf this is what you want, use the pattern \"./*\" to avoid this warning.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components\n");
         }
         if glob_or_path == "**/*" {
-            terminal::warn!("A component is including the entire application directory tree as asset files. This is unlikely to be what you want.\nIf this is what you want, use the pattern \"./**/*\" to avoid this warning.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components\n");
+            tracing::warn!(alert_in_dev = true, "A component is including the entire application directory tree as asset files. This is unlikely to be what you want.\nIf this is what you want, use the pattern \"./**/*\" to avoid this warning.\nLearn more: https://spinframework.dev/writing-apps#including-files-with-components\n");
         }
 
         let path = self.app_root.join(glob_or_path);

--- a/crates/telemetry/src/alert_in_dev.rs
+++ b/crates/telemetry/src/alert_in_dev.rs
@@ -1,0 +1,41 @@
+//! Provides a way for warnings to be force-raised in the
+//! `spin up` environment even if RUST_LOG is not set to warn.
+//! This is useful for things that are not errors but where we
+//! want application developers to know they have a problem.
+
+use tracing::{Event, Subscriber};
+use tracing_subscriber::{filter::filter_fn, registry::LookupSpan, Layer};
+
+const ALERT_IN_DEV_TAG: &str = "alert_in_dev";
+
+/// A layer which prints a terminal warning (using [terminal::warn!]) if
+/// a trace event contains the tag "alert_in_dev" (with any value).
+pub(crate) fn alert_in_dev_layer<S: Subscriber + for<'span> LookupSpan<'span> + 'static>(
+) -> impl Layer<S> {
+    CommandLineAlertingLayer.with_filter(filter_fn(|meta| {
+        meta.fields().field(ALERT_IN_DEV_TAG).is_some()
+    }))
+}
+
+pub struct CommandLineAlertingLayer;
+
+impl<S: Subscriber> Layer<S> for CommandLineAlertingLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        warn(event);
+    }
+}
+
+fn warn(event: &Event<'_>) {
+    let mut visitor = PrintMessageAsWarning;
+    event.record(&mut visitor);
+}
+
+struct PrintMessageAsWarning;
+
+impl tracing::field::Visit for PrintMessageAsWarning {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "message" {
+            terminal::warn!("{value:?}");
+        }
+    }
+}

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -7,6 +7,7 @@ use env::otel_tracing_enabled;
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter, Layer};
 
+mod alert_in_dev;
 pub mod detector;
 mod env;
 pub mod logs;
@@ -83,11 +84,14 @@ pub fn init(spin_version: String) -> anyhow::Result<()> {
         None
     };
 
+    let alert_in_dev_layer = alert_in_dev::alert_in_dev_layer();
+
     // Build a registry subscriber with the layers we want to use.
     registry()
         .with(otel_tracing_layer)
         .with(otel_metrics_layer)
         .with(fmt_layer)
+        .with(alert_in_dev_layer)
         .init();
 
     // Used to propagate trace information in the standard W3C TraceContext format. Even if the otel


### PR DESCRIPTION
**Motivation**

A user had a problem recently where they got a cryptic "cannot create parent directory" error while trying to `spin up` or `spin deploy`.  It turned out that they had tried to use the current directory string `"."` in a component `files` list: this caused us to generate a dubious temp directory string which the filesystem refused to create.

The user had also tried to use the `*` pattern, which successfully copied their current directory, but this was not what they really wanted or expected.

**Proposed behaviour**

This PR attempts to catch dubious-looking file mounts:

* `"."` (current directory), `".."` (parent directory), and any patterns that end in those segments are hard errors.  The error message guides users to use `{ source, destination }` (directory placement) format instead, or a `**/*` pattern.
* `"*"` (all files in current directory) and `"**/*"` (all files in or under current directory) now get a warning.  These aren't errors, we can carry out the instructions, but they are likely to be incorrect - most applications do not seek to include their own `spin.toml` or `.gitignore` files.  So these now warn (and offer equivalent, more explicit, patterns that we accept).

In both cases, the message also links to the documentation on including files with components.

**Concerns**

First off, this is a quite specific response to a rather specific issue, and I am not sure if it is an overreaction.  It may be that this is better handled by keeping the code simple and instead including the information in troubleshooting guides.

Second, this introduces hardwired output to stderr along the loader path.  We do have some precedent for this (e.g. the "Loading Wasm components is taking a few seconds" message) but I wanted to highlight it because other programs (e.g. deployment plugins) link to the loader.  An alternative approach is to make the warning cases errors on the basis that they are almost certain to be not what the user really wants and we are better off forcing them to address it than letting it ride.

All that for four lines!  Oh well, at least now y'all know.
