### PR TITLE
feat: Add automatic git repository initialization to `spin new` command

### DIFF
--- a/crates/templates/src/run.rs
+++ b/crates/templates/src/run.rs
@@ -474,7 +474,7 @@ impl Run {
         }
     }
 
-    // Function to check if the target directory is already in a git repositoriees
+    // Function to check if the target directory is already in a git repositories
     async fn is_already_in_git_repo(&self, dir: &std::path::Path) -> bool {
         use tokio::process::Command;
 


### PR DESCRIPTION
Fixes: #2580

FYI:

- Detects existing Git repositories to avoid creating nested repos
- Respects the --no-vcs flag to skip Git initialization
- Applies only to new applications, not to component additions
