### PR TITLE
fix: enable compiling when `unsafe-aot-compilation` feat enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: lint test-unit test-integration
 
 .PHONY: lint
 lint:
-	cargo clippy --all --all-targets --features all-tests -- -D warnings
+	cargo clippy --all --all-targets --features "all-tests unsafe-aot-compilation" -- -D warnings
 	cargo fmt --all -- --check
 
 .PHONY: lint-rust-examples

--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -53,7 +53,7 @@ impl ComponentLoader {
         path: &std::path::Path,
     ) -> anyhow::Result<Component> {
         assert!(self.aot_compilation_enabled);
-        match engine.detect_precompiled_file(path)? {
+        match wasmtime::Engine::detect_precompiled_file(path)? {
             Some(wasmtime::Precompiled::Component) => unsafe {
                 Component::deserialize_file(engine, path)
             },


### PR DESCRIPTION
We will need to cut a patch release to fix this:

```sh
Compiling wasm-pkg-client v0.10.0
error[E0599]: no method named `detect_precompiled_file` found for reference `&WasmtimeEngine` in the current scope
  --> /home/kagold/.cargo/git/checkouts/spin-6133b75e3590288b/9dadd8c/crates/trigger/src/loader.rs:56:22
   |
56 |         match engine.detect_precompiled_file(path)? {
   |               -------^^^^^^^^^^^^^^^^^^^^^^^------
   |               |      |
   |               |      this is an associated function, not a method
   |               help: use associated function syntax instead: `WasmtimeEngine::detect_precompiled_file(path)`
   |
   = note: found the following associated functions; to be used as methods, functions must have a `self` parameter
   = note: the candidate is defined in an impl for the type `WasmtimeEngine`

   Compiling conformance-tests v0.1.0 (https://github.com/fermyon/conformance-tests?rev=6ec9e9d95e3b333de85685131337c8864c1af67d#6ec9e9d9)
   ```