### PR TITLE
[Backport v3.3] fix: enable compiling when `unsafe-aot-compilation` feat enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test: lint test-unit test-integration
 
 .PHONY: lint
 lint:
-	cargo clippy --all --all-targets --features all-tests -- -D warnings
+	cargo clippy --all --all-targets --features "all-tests unsafe-aot-compilation" -- -D warnings
 	cargo fmt --all -- --check
 
 .PHONY: lint-rust-examples

--- a/crates/trigger/src/loader.rs
+++ b/crates/trigger/src/loader.rs
@@ -53,7 +53,7 @@ impl ComponentLoader {
         path: &std::path::Path,
     ) -> anyhow::Result<Component> {
         assert!(self.aot_compilation_enabled);
-        match engine.detect_precompiled_file(path)? {
+        match wasmtime::Engine::detect_precompiled_file(path)? {
             Some(wasmtime::Precompiled::Component) => unsafe {
                 Component::deserialize_file(engine, path)
             },


### PR DESCRIPTION
Backporting #3159 to v3.3