### PR TITLE
Remove wasm-pkg-common as dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5162,6 +5162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "monostate"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5337,7 +5348,7 @@ dependencies = [
  "inotify",
  "kqueue",
  "libc",
- "mio",
+ "mio 0.8.11",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -6305,9 +6316,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -8509,7 +8520,6 @@ dependencies = [
  "toml",
  "ui-testing",
  "url",
- "wasm-pkg-common",
 ]
 
 [[package]]
@@ -8636,10 +8646,11 @@ version = "3.4.0-pre0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "futures-util",
+ "http 1.1.0",
  "schemars",
  "semver",
  "serde",
- "wasm-pkg-common",
 ]
 
 [[package]]
@@ -9397,28 +9408,27 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ pretty_assertions = "1.3"
 regex = { workspace = true }
 reqwest = { workspace = true }
 rpassword = "7"
-schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
+schemars = { workspace = true }
 semver = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { workspace = true }
@@ -151,6 +151,7 @@ rusqlite = "0.34"
 # If both `aws_lc_rs` and `ring` are enabled, a panic at runtime will occur.
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 rustls-pki-types = "1.12"
+schemars = { version = "0.8.22", features = ["indexmap2", "semver"] }
 semver = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -170,7 +171,6 @@ walkdir = "2"
 wasm-encoder = "0.230"
 wasm-metadata = "0.230"
 wasm-pkg-client = "0.10"
-wasm-pkg-common = "0.10"
 wasmparser = "0.230"
 wasmtime = "33.0.0"
 wasmtime-wasi = "33.0.0"

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
-schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
+schemars = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 spin-serde = { path = "../serde" }
@@ -15,7 +15,6 @@ terminal = { path = "../terminal" }
 thiserror = { workspace = true }
 toml = { workspace = true, features = ["preserve_order"] }
 url = { workspace = true }
-wasm-pkg-common = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/manifest/src/schema/common.rs
+++ b/crates/manifest/src/schema/common.rs
@@ -2,8 +2,7 @@ use std::fmt::Display;
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use wasm_pkg_common::{package::PackageRef, registry::Registry};
+use spin_serde::{PackageRef, Registry};
 
 /// Variable definition
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -7,7 +7,11 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
-schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
+http = { workspace = true }
+schemars = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
-wasm-pkg-common = { workspace = true }
+
+# Without this dependency, this crate will not compile on its own.
+# We should figure out why.
+futures-util = "0.3.30"

--- a/crates/serde/src/lib.rs
+++ b/crates/serde/src/lib.rs
@@ -9,7 +9,7 @@ mod version;
 
 pub use version::{FixedStringVersion, FixedVersion, FixedVersionBackwardCompatible};
 
-pub use dependencies::{DependencyName, DependencyPackageName};
+pub use dependencies::{DependencyName, DependencyPackageName, PackageRef, Registry};
 
 /// A "kebab-case" identifier.
 pub type KebabId = id::Id<'-', false>;


### PR DESCRIPTION
Fixes #3165

I'm not sure if this is the way we'd like to address this issue. It does involve copying a few definitions from `wasm-pkg-common`, but perhaps that's easiest?