### PR TITLE
Move router to its own separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8354,11 +8354,24 @@ dependencies = [
  "serde",
  "spin-app",
  "spin-factor-outbound-http",
+ "spin-http-routes",
  "toml",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
+]
+
+[[package]]
+name = "spin-http-routes"
+version = "3.4.0-pre0"
+dependencies = [
+ "anyhow",
+ "indexmap 2.7.1",
+ "percent-encoding",
+ "routefinder",
+ "serde",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -15,6 +15,7 @@ routefinder = "0.5.4"
 serde = { workspace = true }
 spin-app = { path = "../app", optional = true }
 spin-factor-outbound-http = { path = "../factor-outbound-http" }
+spin-http-routes = { path = "../routes" }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/crates/http/src/config.rs
+++ b/crates/http/src/config.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use spin_http_routes::HttpTriggerRouteConfig;
 
 /// Configuration for the HTTP trigger
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -11,34 +12,6 @@ pub struct HttpTriggerConfig {
     /// The HTTP executor the component requires
     #[serde(default)]
     pub executor: Option<HttpExecutorType>,
-}
-
-/// An HTTP trigger route
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged)]
-pub enum HttpTriggerRouteConfig {
-    Route(String),
-    Private(HttpPrivateEndpoint),
-}
-
-/// Indicates that a trigger is a private endpoint (not routable).
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct HttpPrivateEndpoint {
-    /// Whether the private endpoint is private. This must be true.
-    pub private: bool,
-}
-
-impl Default for HttpTriggerRouteConfig {
-    fn default() -> Self {
-        Self::Route(Default::default())
-    }
-}
-
-impl<T: Into<String>> From<T> for HttpTriggerRouteConfig {
-    fn from(value: T) -> Self {
-        Self::Route(value.into())
-    }
 }
 
 /// The executor for the HTTP component.

--- a/crates/http/src/lib.rs
+++ b/crates/http/src/lib.rs
@@ -3,12 +3,12 @@ pub use wasmtime_wasi_http::body::HyperIncomingBody as Body;
 
 pub mod app_info;
 pub mod config;
-pub mod routes;
 pub mod trigger;
 #[cfg(feature = "runtime")]
 pub mod wagi;
 
-pub const WELL_KNOWN_PREFIX: &str = "/.well-known/spin/";
+pub use spin_http_routes as routes;
+pub use spin_http_routes::WELL_KNOWN_PREFIX;
 
 #[cfg(feature = "runtime")]
 pub mod body {

--- a/crates/routes/Cargo.toml
+++ b/crates/routes/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "spin-http-routes"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+indexmap = { workspace = true }
+percent-encoding = "2"
+routefinder = "0.5.4"
+serde = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Same idea as #3167 - this allows the router to be used in wasm (e.g., in `spin-test`).