### PR TITLE
Selective error spans in variables and key-value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8297,6 +8297,7 @@ dependencies = [
  "spin-expressions",
  "spin-factors",
  "spin-factors-test",
+ "spin-telemetry",
  "spin-world",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8124,6 +8124,7 @@ dependencies = [
  "spin-key-value-spin",
  "spin-locked-app",
  "spin-resource-table",
+ "spin-telemetry",
  "spin-world",
  "tempfile",
  "thiserror 2.0.12",

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -11,11 +11,12 @@ spin-core = { path = "../core" }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }
 spin-resource-table = { path = "../table" }
+spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "sync", "rt"] }
 toml = { workspace = true }
 tracing = { workspace = true }
-thiserror = { workspace = true }
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }

--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -129,7 +129,7 @@ impl key_value::HostStore for KeyValueDispatch {
         .await)
     }
 
-    #[instrument(name = "spin_key_value.get", skip(self, store, key), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.get", skip_all, fields(otel.kind = "client"))]
     async fn get(
         &mut self,
         store: Resource<key_value::Store>,
@@ -139,7 +139,7 @@ impl key_value::HostStore for KeyValueDispatch {
         Ok(store.get(&key).await.map_err(track_error_on_span))
     }
 
-    #[instrument(name = "spin_key_value.set", skip(self, store, key, value), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.set", skip_all, fields(otel.kind = "client"))]
     async fn set(
         &mut self,
         store: Resource<key_value::Store>,
@@ -150,7 +150,7 @@ impl key_value::HostStore for KeyValueDispatch {
         Ok(store.set(&key, &value).await.map_err(track_error_on_span))
     }
 
-    #[instrument(name = "spin_key_value.delete", skip(self, store, key), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.delete", skip_all, fields(otel.kind = "client"))]
     async fn delete(
         &mut self,
         store: Resource<key_value::Store>,
@@ -160,7 +160,7 @@ impl key_value::HostStore for KeyValueDispatch {
         Ok(store.delete(&key).await.map_err(track_error_on_span))
     }
 
-    #[instrument(name = "spin_key_value.exists", skip(self, store, key), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.exists", skip_all, fields(otel.kind = "client"))]
     async fn exists(
         &mut self,
         store: Resource<key_value::Store>,
@@ -170,7 +170,7 @@ impl key_value::HostStore for KeyValueDispatch {
         Ok(store.exists(&key).await.map_err(track_error_on_span))
     }
 
-    #[instrument(name = "spin_key_value.get_keys", skip(self, store), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.get_keys", skip_all, fields(otel.kind = "client"))]
     async fn get_keys(
         &mut self,
         store: Resource<key_value::Store>,
@@ -205,7 +205,7 @@ fn to_wasi_err(e: Error) -> wasi_keyvalue::store::Error {
 }
 
 impl wasi_keyvalue::store::Host for KeyValueDispatch {
-    #[instrument(name = "wasi_key_value.open", skip(self, identifier), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value.open", skip_all, fields(otel.kind = "client"))]
     async fn open(
         &mut self,
         identifier: String,
@@ -233,7 +233,7 @@ impl wasi_keyvalue::store::Host for KeyValueDispatch {
 
 use wasi_keyvalue::store::Bucket;
 impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
-    #[instrument(name = "wasi_key_value.get", skip(self, self_, key), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value.get", skip_all, fields(otel.kind = "client"))]
     async fn get(
         &mut self,
         self_: Resource<Bucket>,
@@ -243,7 +243,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         store.get(&key).await.map_err(to_wasi_err)
     }
 
-    #[instrument(name = "wasi_key_value.set", skip(self, self_, key, value), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value.set", skip_all, fields(otel.kind = "client"))]
     async fn set(
         &mut self,
         self_: Resource<Bucket>,
@@ -254,7 +254,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         store.set(&key, &value).await.map_err(to_wasi_err)
     }
 
-    #[instrument(name = "wasi_key_value.delete", skip(self, self_, key), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value.delete", skip_all, fields(otel.kind = "client"))]
     async fn delete(
         &mut self,
         self_: Resource<Bucket>,
@@ -264,7 +264,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         store.delete(&key).await.map_err(to_wasi_err)
     }
 
-    #[instrument(name = "wasi_key_value.exists", skip(self, self_, key), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value.exists", skip_all, fields(otel.kind = "client"))]
     async fn exists(
         &mut self,
         self_: Resource<Bucket>,
@@ -274,7 +274,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         store.exists(&key).await.map_err(to_wasi_err)
     }
 
-    #[instrument(name = "wasi_key_value.list_keys", skip(self, self_, cursor), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value.list_keys", skip_all, fields(otel.kind = "client"))]
     async fn list_keys(
         &mut self,
         self_: Resource<Bucket>,
@@ -299,7 +299,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
 }
 
 impl wasi_keyvalue::batch::Host for KeyValueDispatch {
-    #[instrument(name = "spin_key_value.get_many", skip(self, bucket, keys), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.get_many", skip_all, fields(otel.kind = "client"))]
     #[allow(clippy::type_complexity)]
     async fn get_many(
         &mut self,
@@ -313,7 +313,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         store.get_many(keys).await.map_err(to_wasi_err)
     }
 
-    #[instrument(name = "spin_key_value.set_many", skip(self, bucket, key_values), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.set_many", skip_all, fields(otel.kind = "client"))]
     async fn set_many(
         &mut self,
         bucket: Resource<wasi_keyvalue::batch::Bucket>,
@@ -326,7 +326,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         store.set_many(key_values).await.map_err(to_wasi_err)
     }
 
-    #[instrument(name = "spin_key_value.delete_many", skip(self, bucket, keys), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.delete_many", skip_all, fields(otel.kind = "client"))]
     async fn delete_many(
         &mut self,
         bucket: Resource<wasi_keyvalue::batch::Bucket>,
@@ -341,7 +341,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
 }
 
 impl wasi_keyvalue::atomics::HostCas for KeyValueDispatch {
-    #[instrument(name = "wasi_key_value_cas.new", skip(self, bucket, key), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value_cas.new", skip_all, fields(otel.kind = "client"))]
     async fn new(
         &mut self,
         bucket: Resource<wasi_keyvalue::atomics::Bucket>,
@@ -364,7 +364,7 @@ impl wasi_keyvalue::atomics::HostCas for KeyValueDispatch {
             .map(Resource::new_own)
     }
 
-    #[instrument(name = "wasi_key_value_cas.current", skip(self, cas), fields(otel.kind = "client"))]
+    #[instrument(name = "wasi_key_value_cas.current", skip_all, fields(otel.kind = "client"))]
     async fn current(
         &mut self,
         cas: Resource<wasi_keyvalue::atomics::Cas>,
@@ -389,7 +389,7 @@ impl wasi_keyvalue::atomics::Host for KeyValueDispatch {
         Ok(error)
     }
 
-    #[instrument(name = "spin_key_value.increment", skip(self, bucket, key, delta), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.increment", skip_all, fields(otel.kind = "client"))]
     async fn increment(
         &mut self,
         bucket: Resource<wasi_keyvalue::atomics::Bucket>,
@@ -400,7 +400,7 @@ impl wasi_keyvalue::atomics::Host for KeyValueDispatch {
         store.increment(key, delta).await.map_err(to_wasi_err)
     }
 
-    #[instrument(name = "spin_key_value.swap", skip(self, cas_res, value), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_key_value.swap", skip_all, fields(otel.kind = "client"))]
     async fn swap(
         &mut self,
         cas_res: Resource<atomics::Cas>,

--- a/crates/factor-variables/Cargo.toml
+++ b/crates/factor-variables/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [dependencies]
 spin-expressions = { path = "../expressions" }
 spin-factors = { path = "../factors" }
+spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
 tracing = { workspace = true }
 

--- a/crates/factor-variables/src/host.rs
+++ b/crates/factor-variables/src/host.rs
@@ -1,5 +1,5 @@
 use spin_factors::anyhow;
-use spin_telemetry::OpenTelemetrySpanExt as _;
+use spin_telemetry::traces::{self, Fault};
 use spin_world::{v1, v2::variables, wasi::config as wasi_config};
 use tracing::instrument;
 
@@ -73,19 +73,18 @@ impl wasi_config::store::Host for InstanceState {
     }
 }
 
+/// Convert a `spin_expressions::Error` to a `variables::Error`, setting the current span's status and fault attribute.
 fn expressions_to_variables_err(err: spin_expressions::Error) -> variables::Error {
     use spin_expressions::Error;
+    let fault = match err {
+        Error::InvalidName(_) | Error::InvalidTemplate(_) | Error::Undefined(_) => Fault::Guest,
+        Error::Provider(_) => Fault::Host,
+    };
+    traces::mark_as_error(&err, Some(fault));
     match err {
         Error::InvalidName(msg) => variables::Error::InvalidName(msg),
         Error::Undefined(msg) => variables::Error::Undefined(msg),
-        other @ Error::InvalidTemplate(_) => variables::Error::Other(format!("{other}")),
-        Error::Provider(err) => {
-            // This error may not be caused by bad user input, so set the span status to error.
-            let current_span = tracing::Span::current();
-            current_span.set_status(spin_telemetry::opentelemetry::trace::Status::error(
-                err.to_string(),
-            ));
-            variables::Error::Provider(err.to_string())
-        }
+        Error::InvalidTemplate(_) => variables::Error::Other(format!("{err}")),
+        Error::Provider(err) => variables::Error::Provider(err.to_string()),
     }
 }

--- a/crates/factor-variables/src/host.rs
+++ b/crates/factor-variables/src/host.rs
@@ -1,5 +1,5 @@
 use spin_factors::anyhow;
-use spin_telemetry::traces::{self, Fault};
+use spin_telemetry::traces::{self, Blame};
 use spin_world::{v1, v2::variables, wasi::config as wasi_config};
 use tracing::instrument;
 
@@ -76,11 +76,11 @@ impl wasi_config::store::Host for InstanceState {
 /// Convert a `spin_expressions::Error` to a `variables::Error`, setting the current span's status and fault attribute.
 fn expressions_to_variables_err(err: spin_expressions::Error) -> variables::Error {
     use spin_expressions::Error;
-    let fault = match err {
-        Error::InvalidName(_) | Error::InvalidTemplate(_) | Error::Undefined(_) => Fault::Guest,
-        Error::Provider(_) => Fault::Host,
+    let blame = match err {
+        Error::InvalidName(_) | Error::InvalidTemplate(_) | Error::Undefined(_) => Blame::Guest,
+        Error::Provider(_) => Blame::Host,
     };
-    traces::mark_as_error(&err, Some(fault));
+    traces::mark_as_error(&err, Some(blame));
     match err {
         Error::InvalidName(msg) => variables::Error::InvalidName(msg),
         Error::Undefined(msg) => variables::Error::Undefined(msg),

--- a/crates/factor-variables/src/host.rs
+++ b/crates/factor-variables/src/host.rs
@@ -1,11 +1,12 @@
 use spin_factors::anyhow;
+use spin_telemetry::OpenTelemetrySpanExt as _;
 use spin_world::{v1, v2::variables, wasi::config as wasi_config};
-use tracing::{instrument, Level};
+use tracing::instrument;
 
 use crate::InstanceState;
 
 impl variables::Host for InstanceState {
-    #[instrument(name = "spin_variables.get", skip(self), err(level = Level::INFO), fields(otel.kind = "client"))]
+    #[instrument(name = "spin_variables.get", skip(self), fields(otel.kind = "client"))]
     async fn get(&mut self, key: String) -> Result<String, variables::Error> {
         let key = spin_expressions::Key::new(&key).map_err(expressions_to_variables_err)?;
         self.expression_resolver
@@ -20,6 +21,7 @@ impl variables::Host for InstanceState {
 }
 
 impl v1::config::Host for InstanceState {
+    #[instrument(name = "spin_config.get", skip(self), fields(otel.kind = "client"))]
     async fn get_config(&mut self, key: String) -> Result<String, v1::config::Error> {
         <Self as variables::Host>::get(self, key)
             .await
@@ -36,6 +38,7 @@ impl v1::config::Host for InstanceState {
 }
 
 impl wasi_config::store::Host for InstanceState {
+    #[instrument(name = "wasi_config.get", skip(self), fields(otel.kind = "client"))]
     async fn get(&mut self, key: String) -> Result<Option<String>, wasi_config::store::Error> {
         match <Self as variables::Host>::get(self, key).await {
             Ok(value) => Ok(Some(value)),
@@ -46,6 +49,7 @@ impl wasi_config::store::Host for InstanceState {
         }
     }
 
+    #[instrument(name = "wasi_config.get_all", skip(self), fields(otel.kind = "client"))]
     async fn get_all(&mut self) -> Result<Vec<(String, String)>, wasi_config::store::Error> {
         let all = self
             .expression_resolver
@@ -74,7 +78,14 @@ fn expressions_to_variables_err(err: spin_expressions::Error) -> variables::Erro
     match err {
         Error::InvalidName(msg) => variables::Error::InvalidName(msg),
         Error::Undefined(msg) => variables::Error::Undefined(msg),
-        Error::Provider(err) => variables::Error::Provider(err.to_string()),
-        other => variables::Error::Other(format!("{other}")),
+        other @ Error::InvalidTemplate(_) => variables::Error::Other(format!("{other}")),
+        Error::Provider(err) => {
+            // This error may not be caused by bad user input, so set the span status to error.
+            let current_span = tracing::Span::current();
+            current_span.set_status(spin_telemetry::opentelemetry::trace::Status::error(
+                err.to_string(),
+            ));
+            variables::Error::Provider(err.to_string())
+        }
     }
 }

--- a/crates/telemetry/src/env.rs
+++ b/crates/telemetry/src/env.rs
@@ -77,6 +77,7 @@ pub(crate) fn otel_sdk_disabled() -> bool {
 }
 
 /// The protocol to use for OTLP exporter.
+#[derive(Debug)]
 pub(crate) enum OtlpProtocol {
     Grpc,
     HttpProtobuf,

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -15,6 +15,9 @@ pub mod metrics;
 mod propagation;
 mod traces;
 
+pub use opentelemetry;
+pub use tracing_opentelemetry::OpenTelemetrySpanExt;
+
 #[cfg(feature = "testing")]
 pub mod testing;
 

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -13,10 +13,7 @@ mod env;
 pub mod logs;
 pub mod metrics;
 mod propagation;
-mod traces;
-
-pub use opentelemetry;
-pub use tracing_opentelemetry::OpenTelemetrySpanExt;
+pub mod traces;
 
 #[cfg(feature = "testing")]
 pub mod testing;

--- a/crates/telemetry/src/traces.rs
+++ b/crates/telemetry/src/traces.rs
@@ -67,27 +67,27 @@ pub(crate) fn otel_tracing_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
 ///
 /// This can be used to filter errors in telemetry or logging systems.
 #[derive(Debug)]
-pub enum Fault {
+pub enum Blame {
     /// The error is most likely caused by the guest.
     Guest,
     /// The error might have been caused by the host.
     Host,
 }
 
-impl Fault {
+impl Blame {
     fn as_str(&self) -> &'static str {
         match self {
-            Fault::Guest => "guest",
-            Fault::Host => "host",
+            Blame::Guest => "guest",
+            Blame::Host => "host",
         }
     }
 }
 
-/// Marks the current span as an error with the given error message and optional fault type.
-pub fn mark_as_error<E: std::fmt::Display>(err: &E, fault: Option<Fault>) {
+/// Marks the current span as an error with the given error message and optional blame.
+pub fn mark_as_error<E: std::fmt::Display>(err: &E, blame: Option<Blame>) {
     let current_span = tracing::Span::current();
     current_span.set_status(opentelemetry::trace::Status::error(err.to_string()));
-    if let Some(fault) = fault {
-        current_span.set_attribute("error.fault", fault.as_str());
+    if let Some(blame) = blame {
+        current_span.set_attribute("error.blame", blame.as_str());
     }
 }

--- a/hack/o11y-stack/docker-compose.yaml
+++ b/hack/o11y-stack/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   otel-collector:
     image: otel/opentelemetry-collector-contrib:0.98.0


### PR DESCRIPTION
We currently set spans as errored in variables and key-value on any error. This includes errors that are purely caused by bad app input - for example key-value's `Error::NoSuchStore`. 

## Open Question

The current behavior is arguably correct in the Spin CLI local developer setting where the operator of Spin and the author of the app that it's running are probably the same. However, in other setups like SpinKube, this assumption breaks down - the author of the app running and the operator of Spin are probably not the same.

We could consider making this configurable where Spin CLI will continue to mark _all_ errors as errored spans, but other uses of these factors could change to only mark spans as errored when its clearer that it was not caused by app behavior. 