### PR TITLE
Clippy 1.88 fixes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -51,7 +51,7 @@ fn main() {
         let default_toolchain = default_toolchain.split(['-', ' ']).next().unwrap();
 
         let toolchain_override = if current_toolchain != default_toolchain {
-            format!(" +{}", current_toolchain)
+            format!(" +{current_toolchain}")
         } else {
             String::new()
         };
@@ -59,8 +59,7 @@ fn main() {
         println!(
             r#"
 error: the `wasm32-wasip1` target is not installed
-    = help: consider downloading the target with `rustup{} target add wasm32-wasip1`"#,
-            toolchain_override
+    = help: consider downloading the target with `rustup{toolchain_override} target add wasm32-wasip1`"#
         );
         process::exit(1);
     }

--- a/src/bin/spin.rs
+++ b/src/bin/spin.rs
@@ -86,9 +86,9 @@ fn print_error_chain(err: anyhow::Error) {
         eprintln!("\nCaused by:");
         for (i, err) in err.chain().skip(1).enumerate() {
             if is_multiple {
-                eprintln!("{i:>4}: {}", err)
+                eprintln!("{i:>4}: {err}")
             } else {
-                eprintln!("      {}", err)
+                eprintln!("      {err}")
             }
         }
     }

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -14,7 +14,7 @@ use tokio::process::Command;
 const BADGER_GRACE_PERIOD_MILLIS: u64 = 50;
 
 fn override_flag() -> String {
-    format!("--{}", PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG)
+    format!("--{PLUGIN_OVERRIDE_COMPATIBILITY_CHECK_FLAG}")
 }
 
 // Returns true if the argument was removed from the list
@@ -369,7 +369,7 @@ mod test {
             )
         );
 
-        let cmd_with_args_override = format!("example arg1 arg2 {}", override_flag)
+        let cmd_with_args_override = format!("example arg1 arg2 {override_flag}")
             .split(' ')
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
@@ -382,7 +382,7 @@ mod test {
             )
         );
 
-        let cmd_with_args_override = format!("example {} arg1 arg2", override_flag)
+        let cmd_with_args_override = format!("example {override_flag} arg1 arg2")
             .split(' ')
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
@@ -395,7 +395,7 @@ mod test {
             )
         );
 
-        let cmd_with_args_override = format!("{} example arg1 arg2", override_flag)
+        let cmd_with_args_override = format!("{override_flag} example arg1 arg2")
             .split(' ')
             .map(|s| s.to_string())
             .collect::<Vec<String>>();

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -143,7 +143,7 @@ impl TemplateNewCommandCore {
         let template = match &template_id {
             Some(template_id) => match template_manager
                 .get(template_id)
-                .with_context(|| format!("Error retrieving template {}", template_id))?
+                .with_context(|| format!("Error retrieving template {template_id}"))?
             {
                 Some(template) => template,
                 None => match prompt_template(&template_manager, &variant, &[template_id.clone()])
@@ -416,7 +416,7 @@ mod tests {
     /// Writes to a new temporary file, closes it, and returns its path.
     fn create_tempfile(content: &str) -> Result<TempPath> {
         let mut file = NamedTempFile::new()?;
-        write!(file, "{}", content).unwrap();
+        write!(file, "{content}").unwrap();
         Ok(file.into_temp_path())
     }
 
@@ -445,11 +445,7 @@ mod tests {
         ];
         for content in bad_content {
             let file = create_tempfile(content).unwrap();
-            assert!(
-                values_from_file(&file).await.is_err(),
-                "content: {}",
-                content
-            );
+            assert!(values_from_file(&file).await.is_err(), "content: {content}");
         }
     }
 

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -683,7 +683,7 @@ impl List {
         let json_vals: Vec<_> = plugins.iter().map(json_list_format).collect();
 
         let json_text = serde_json::to_string_pretty(&json_vals)?;
-        println!("{}", json_text);
+        println!("{json_text}");
         Ok(())
     }
 }

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -178,7 +178,7 @@ impl Install {
                 }
 
                 println!();
-                println!("{}", table);
+                println!("{table}");
             }
             if !skipped.is_empty() {
                 println!();
@@ -193,7 +193,7 @@ impl Install {
                 }
 
                 println!();
-                println!("{}", table);
+                println!("{table}");
             }
         }
     }
@@ -366,7 +366,7 @@ impl Upgrade {
             }
 
             println!();
-            println!("{}", table);
+            println!("{table}");
         }
 
         println!();
@@ -384,7 +384,7 @@ impl Upgrade {
             }
 
             println!();
-            println!("{}", table);
+            println!("{table}");
             println!();
         }
     }
@@ -547,7 +547,7 @@ impl List {
                 table.add_row(row);
             }
 
-            println!("{}", table);
+            println!("{table}");
         }
 
         if !warnings.is_empty() {
@@ -573,7 +573,7 @@ impl List {
             .collect();
 
         let json_text = serde_json::to_string_pretty(&json_vals)?;
-        println!("{}", json_text);
+        println!("{json_text}");
         Ok(())
     }
 }
@@ -603,13 +603,13 @@ impl ProgressReporter for ConsoleProgressReporter {
 fn skipped_reason_text(reason: &SkippedReason) -> String {
     match reason {
         SkippedReason::AlreadyExists => "Already exists".to_owned(),
-        SkippedReason::InvalidManifest(msg) => format!("Template load error: {}", msg),
+        SkippedReason::InvalidManifest(msg) => format!("Template load error: {msg}"),
     }
 }
 
 fn list_warn_reason_text(reason: &InstalledTemplateWarning) -> String {
     match reason {
-        InstalledTemplateWarning::InvalidManifest(msg) => format!("Template load error: {}", msg),
+        InstalledTemplateWarning::InvalidManifest(msg) => format!("Template load error: {msg}"),
     }
 }
 
@@ -625,8 +625,7 @@ pub(crate) async fn prompt_install_default_templates(
         Ok(Some(template_manager.list().await?.templates))
     } else {
         println!(
-            "You can install the default templates later with 'spin templates install --git {}'",
-            DEFAULT_TEMPLATE_REPO
+            "You can install the default templates later with 'spin templates install --git {DEFAULT_TEMPLATE_REPO}'"
         );
         Ok(None)
     }

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -26,7 +26,7 @@ impl std::fmt::Display for ExitStatusError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let _ = write!(f, "subprocess exited with status: ");
         if let Some(status) = self.status {
-            writeln!(f, "{}", status)
+            writeln!(f, "{status}")
         } else {
             writeln!(f, "unknown")
         }

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -336,7 +336,7 @@ pub fn bootstrap_smoke_test(
                     .unwrap_or_default()
                     .clone_into(&mut custom_path);
             }
-            build.env(key, format!("{}:{}", custom_path, path));
+            build.env(key, format!("{custom_path}:{path}"));
         } else {
             build.env(key, value);
         }


### PR DESCRIPTION
Rust 1.88 is out and Clippy has new opinions.

This month it seems to be mostly mad about people using positional formatting instead of interpolating.
