### PR TITLE
Add schema directive to template manifests

### DIFF
--- a/templates/http-c/content/spin.toml
+++ b/templates/http-c/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/http-go/content/spin.toml
+++ b/templates/http-go/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/http-grain/content/spin.toml
+++ b/templates/http-grain/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/http-php/content/spin.toml
+++ b/templates/http-php/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/http-rust/content/spin.toml
+++ b/templates/http-rust/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/http-zig/content/spin.toml
+++ b/templates/http-zig/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/redirect/content/spin.toml
+++ b/templates/redirect/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/redis-go/content/spin.toml
+++ b/templates/redis-go/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/redis-rust/content/spin.toml
+++ b/templates/redis-rust/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]

--- a/templates/static-fileserver/content/spin.toml
+++ b/templates/static-fileserver/content/spin.toml
@@ -1,3 +1,5 @@
+#:schema https://schemas.spinframework.dev/spin/manifest-v2/latest.json
+
 spin_manifest_version = 2
 
 [application]


### PR DESCRIPTION
As of Spin 3.3 we include a `spin.toml` JSON schema as part of each release.  This PR proposes linking that schema from template manifests: this provides (a measure of) validation and code completion out of the box (well, if the user has Even Better TOML or its equivalent installed).

![image](https://github.com/user-attachments/assets/f7bbf59c-5d9a-4cc8-b404-66154fd661e4)

In this PR, I link to the manifest via a versioned release URL.  We get this for free, but it does mean we need to update the templates whenever we update the schema doc (or on every release, if we want to avoid folks going "I'm on Spin 3.5, why did you give me this OLD schema"), and that users need to rev the link to get schema updates.  If we wanted to invest a little more in the plumbing, we could upload schemas to a version-neutral location so users could automatically inherit improvements (or could still lock to a version via a GH URL).  Thoughts?
