### PR TITLE
The, er, rest of the Clippy 1.88 lints

### DIFF
--- a/crates/compose/src/lib.rs
+++ b/crates/compose/src/lib.rs
@@ -474,12 +474,12 @@ impl std::str::FromStr for ImportName {
         if s.contains([':', '/']) {
             let (package, rest) = s
                 .split_once('/')
-                .with_context(|| format!("invalid import name: {}", s))?;
+                .with_context(|| format!("invalid import name: {s}"))?;
 
             let (interface, version) = match rest.split_once('@') {
                 Some((interface, version)) => {
                     let version = Version::parse(version)
-                        .with_context(|| format!("invalid version in import name: {}", s))?;
+                        .with_context(|| format!("invalid version in import name: {s}"))?;
 
                     (interface, Some(version))
                 }

--- a/crates/expressions/src/lib.rs
+++ b/crates/expressions/src/lib.rs
@@ -254,7 +254,7 @@ impl<'a> Key<'a> {
                 .chars()
                 .find(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || c == &'_'))
             {
-                Err(format!("invalid character {:?}. Variable names may contain only lower-case letters, numbers, and underscores.", invalid))
+                Err(format!("invalid character {invalid:?}. Variable names may contain only lower-case letters, numbers, and underscores."))
             } else if !key.bytes().next().unwrap().is_ascii_lowercase() {
                 Err("must start with a lowercase ASCII letter".to_string())
             } else if !key.bytes().last().unwrap().is_ascii_alphanumeric() {

--- a/crates/expressions/src/template.rs
+++ b/crates/expressions/src/template.rs
@@ -55,7 +55,7 @@ impl Display for Template {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.parts().try_for_each(|part| match part {
             Part::Lit(lit) => f.write_str(lit),
-            Part::Expr(expr) => write!(f, "{{ {} }}", expr),
+            Part::Expr(expr) => write!(f, "{{ {expr} }}"),
         })
     }
 }

--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -228,7 +228,7 @@ async fn send_request_handler(
             authority.to_string()
         } else {
             let port = if use_tls { 443 } else { 80 };
-            format!("{}:{port}", authority)
+            format!("{authority}:{port}")
         }
     } else {
         return Err(ErrorCode::HttpRequestUriInvalid);

--- a/crates/factor-outbound-mysql/src/client.rs
+++ b/crates/factor-outbound-mysql/src/client.rs
@@ -55,7 +55,7 @@ impl Client for MysqlClient {
 
         self.exec_batch(&statement, &[parameters])
             .await
-            .map_err(|e| v2::Error::QueryFailed(format!("{:?}", e)))
+            .map_err(|e| v2::Error::QueryFailed(format!("{e:?}")))
     }
 
     async fn query(
@@ -69,7 +69,7 @@ impl Client for MysqlClient {
         let mut query_result = self
             .exec_iter(&statement, parameters)
             .await
-            .map_err(|e| v2::Error::QueryFailed(format!("{:?}", e)))?;
+            .map_err(|e| v2::Error::QueryFailed(format!("{e:?}")))?;
 
         // We have to get these before collect() destroys them
         let columns = convert_columns(query_result.columns());
@@ -193,8 +193,7 @@ fn convert_entry(
     match (row.take(index), columns.get(index)) {
         (None, _) => Ok(DbValue::DbNull), // TODO: is this right or is this an "index out of range" thing
         (_, None) => Err(v2::Error::Other(format!(
-            "Can't get column at index {}",
-            index
+            "Can't get column at index {index}"
         ))),
         (Some(mysql_async::Value::NULL), _) => Ok(DbValue::DbNull),
         (Some(value), Some(column)) => convert_value(value, column),
@@ -261,7 +260,7 @@ fn build_opts(address: &str) -> Result<Opts, mysql_async::Error> {
 }
 
 fn convert_value_to<T: FromValue>(value: mysql_async::Value) -> Result<T, v2::Error> {
-    from_value_opt::<T>(value).map_err(|e| v2::Error::ValueConversionFailed(format!("{}", e)))
+    from_value_opt::<T>(value).map_err(|e| v2::Error::ValueConversionFailed(format!("{e}")))
 }
 
 #[cfg(test)]

--- a/crates/factor-outbound-pg/src/client.rs
+++ b/crates/factor-outbound-pg/src/client.rs
@@ -60,7 +60,7 @@ impl Client for TokioClient {
             .iter()
             .map(to_sql_parameter)
             .collect::<Result<Vec<_>>>()
-            .map_err(|e| v3::Error::ValueConversionFailed(format!("{:?}", e)))?;
+            .map_err(|e| v3::Error::ValueConversionFailed(format!("{e:?}")))?;
 
         let params_refs: Vec<&(dyn ToSql + Sync)> = params
             .iter()
@@ -69,7 +69,7 @@ impl Client for TokioClient {
 
         self.execute(&statement, params_refs.as_slice())
             .await
-            .map_err(|e| v3::Error::QueryFailed(format!("{:?}", e)))
+            .map_err(|e| v3::Error::QueryFailed(format!("{e:?}")))
     }
 
     async fn query(
@@ -81,7 +81,7 @@ impl Client for TokioClient {
             .iter()
             .map(to_sql_parameter)
             .collect::<Result<Vec<_>>>()
-            .map_err(|e| v3::Error::BadParameter(format!("{:?}", e)))?;
+            .map_err(|e| v3::Error::BadParameter(format!("{e:?}")))?;
 
         let params_refs: Vec<&(dyn ToSql + Sync)> = params
             .iter()
@@ -91,7 +91,7 @@ impl Client for TokioClient {
         let results = self
             .query(&statement, params_refs.as_slice())
             .await
-            .map_err(|e| v3::Error::QueryFailed(format!("{:?}", e)))?;
+            .map_err(|e| v3::Error::QueryFailed(format!("{e:?}")))?;
 
         if results.is_empty() {
             return Ok(RowSet {
@@ -105,7 +105,7 @@ impl Client for TokioClient {
             .iter()
             .map(convert_row)
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| v3::Error::QueryFailed(format!("{:?}", e)))?;
+            .map_err(|e| v3::Error::QueryFailed(format!("{e:?}")))?;
 
         Ok(RowSet { columns, rows })
     }

--- a/crates/factor-outbound-pg/src/host.rs
+++ b/crates/factor-outbound-pg/src/host.rs
@@ -51,7 +51,7 @@ impl<C: Client> InstanceState<C> {
                         ports
                             .get(i)
                             .or_else(|| if ports.len() == 1 { ports.get(1) } else { None });
-                    let port_str = port.map(|p| format!(":{}", p)).unwrap_or_default();
+                    let port_str = port.map(|p| format!(":{p}")).unwrap_or_default();
                     let url = format!("{address}{port_str}");
                     if !self.allowed_hosts.check_url(&url, "postgres").await? {
                         return Ok(false);

--- a/crates/http/src/wagi/mod.rs
+++ b/crates/http/src/wagi/mod.rs
@@ -42,7 +42,7 @@ pub fn build_headers(
     // accompanied by a message-body entity.  The CONTENT_LENGTH value must
     // reflect the length of the message-body after the server has removed
     // any transfer-codings or content-codings.
-    headers.insert("CONTENT_LENGTH".to_owned(), format!("{}", content_length));
+    headers.insert("CONTENT_LENGTH".to_owned(), format!("{content_length}"));
 
     // CONTENT_TYPE (from the spec)
     // The server MUST set this meta-variable if an HTTP Content-Type field is present

--- a/crates/key-value-azure/src/store.rs
+++ b/crates/key-value-azure/src/store.rs
@@ -441,7 +441,7 @@ impl AzureCosmosStore {
     }
 
     fn get_query(&self, key: &str) -> String {
-        let mut query = format!("SELECT * FROM c WHERE c.id='{}'", key);
+        let mut query = format!("SELECT * FROM c WHERE c.id='{key}'");
         self.append_store_id(&mut query, true);
         query
     }
@@ -459,7 +459,7 @@ impl AzureCosmosStore {
             .collect::<Vec<String>>()
             .join(", ");
 
-        let mut query = format!("SELECT * FROM c WHERE c.id IN ({})", in_clause);
+        let mut query = format!("SELECT * FROM c WHERE c.id IN ({in_clause})");
         self.append_store_id(&mut query, true);
         query
     }

--- a/crates/manifest/src/compat/allowed_http_hosts.rs
+++ b/crates/manifest/src/compat/allowed_http_hosts.rs
@@ -72,18 +72,17 @@ fn parse_allowed_http_host_from_unschemed(text: &str) -> Result<AllowedHttpHost,
     // Host name parsing is quite hairy (thanks, IPv6), so punt it off to the
     // Url type which gets paid big bucks to do it properly. (But preserve the
     // original un-URL-ified string for use in error messages.)
-    let urlised = format!("http://{}", text);
+    let urlised = format!("http://{text}");
     let fake_url = Url::parse(&urlised)
-        .map_err(|_| format!("{} isn't a valid host or host:port string", text))?;
+        .map_err(|_| format!("{text} isn't a valid host or host:port string"))?;
     parse_allowed_http_host_from_http_url(&fake_url, text)
 }
 
 fn parse_allowed_http_host_from_schemed(text: &str) -> Result<AllowedHttpHost, String> {
-    let url =
-        Url::parse(text).map_err(|e| format!("{} isn't a valid HTTP host URL: {}", text, e))?;
+    let url = Url::parse(text).map_err(|e| format!("{text} isn't a valid HTTP host URL: {e}"))?;
 
     if !matches!(url.scheme(), "http" | "https") {
-        return Err(format!("{} isn't a valid host or host:port string", text));
+        return Err(format!("{text} isn't a valid host or host:port string"));
     }
 
     parse_allowed_http_host_from_http_url(&url, text)
@@ -92,13 +91,12 @@ fn parse_allowed_http_host_from_schemed(text: &str) -> Result<AllowedHttpHost, S
 fn parse_allowed_http_host_from_http_url(url: &Url, text: &str) -> Result<AllowedHttpHost, String> {
     let host = url
         .host_str()
-        .ok_or_else(|| format!("{} doesn't contain a host name", text))?;
+        .ok_or_else(|| format!("{text} doesn't contain a host name"))?;
 
     let has_path = url.path().len() > 1; // allow "/"
     if has_path {
         return Err(format!(
-            "{} contains a path, should be host and optional port only",
-            text
+            "{text} contains a path, should be host and optional port only"
         ));
     }
 

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -443,8 +443,7 @@ impl Client {
         let archive_path = crate::utils::archive(source, &working_dir.into_path())
             .await
             .context(format!(
-                "Unable to create compressed archive for source {:?}",
-                source
+                "Unable to create compressed archive for source {source:?}"
             ))?;
         let layer = Self::data_layer(archive_path.as_path(), ARCHIVE_MEDIATYPE.to_string()).await?;
         layers.push(layer);

--- a/crates/plugins/src/lookup.rs
+++ b/crates/plugins/src/lookup.rs
@@ -150,7 +150,7 @@ fn plugin_manifests_repo_path(plugins_dir: &Path) -> PathBuf {
 // Given a name and option version, outputs expected file name for the plugin.
 fn manifest_file_name_version(plugin_name: &str, version: &Option<semver::Version>) -> String {
     match version {
-        Some(v) => format!("{}@{}.json", plugin_name, v),
+        Some(v) => format!("{plugin_name}@{v}.json"),
         None => manifest_file_name(plugin_name),
     }
 }

--- a/crates/routes/src/lib.rs
+++ b/crates/routes/src/lib.rs
@@ -217,8 +217,8 @@ impl ParsedRoute {
 impl fmt::Display for ParsedRoute {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
-            ParsedRoute::Exact(path) => write!(f, "{}", path),
-            ParsedRoute::TrailingWildcard(pattern) => write!(f, "{} (wildcard)", pattern),
+            ParsedRoute::Exact(path) => write!(f, "{path}"),
+            ParsedRoute::TrailingWildcard(pattern) => write!(f, "{pattern} (wildcard)"),
         }
     }
 }

--- a/crates/serde/src/version.rs
+++ b/crates/serde/src/version.rs
@@ -18,7 +18,7 @@ impl<const V: usize> TryFrom<usize> for FixedVersion<V> {
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
         if value != V {
-            return Err(format!("invalid version {} != {}", value, V));
+            return Err(format!("invalid version {value} != {V}"));
         }
         Ok(Self)
     }
@@ -42,7 +42,7 @@ impl<const V: usize> TryFrom<usize> for FixedVersionBackwardCompatible<V> {
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
         if value > V {
-            return Err(format!("invalid version {} > {}", value, V));
+            return Err(format!("invalid version {value} > {V}"));
         }
         Ok(Self)
     }

--- a/crates/templates/src/environment.rs
+++ b/crates/templates/src/environment.rs
@@ -81,7 +81,7 @@ pub(crate) async fn get_authors() -> Result<Authors> {
 
     let author = match discover_author().await? {
         (name, Some(email)) => Authors {
-            author: format!("{} <{}>", name, email),
+            author: format!("{name} <{email}>"),
             username: name,
         },
         (name, None) => Authors {

--- a/crates/templates/src/interaction.rs
+++ b/crates/templates/src/interaction.rs
@@ -121,11 +121,11 @@ pub(crate) fn prompt_parameter(parameter: &TemplateParameter) -> Option<String> 
             Ok(text) => match parameter.validate_value(text) {
                 Ok(text) => return Some(text),
                 Err(e) => {
-                    println!("Invalid value: {}", e);
+                    println!("Invalid value: {e}");
                 }
             },
             Err(e) => {
-                println!("Invalid value: {}", e);
+                println!("Invalid value: {e}");
             }
         }
     }

--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -173,7 +173,7 @@ impl TemplateManager {
                     .file_name()
                     .map(|s| s.to_string_lossy().to_string())
                     .unwrap_or_else(|| format!("{}", source_dir.display()));
-                let message = format!("{}", e);
+                let message = format!("{e}");
                 return Ok(InstallationResult::Skipped(
                     fake_id,
                     SkippedReason::InvalidManifest(message),
@@ -182,7 +182,7 @@ impl TemplateManager {
         };
         let id = template.id();
 
-        let message = format!("Installing template {}...", id);
+        let message = format!("Installing template {id}...");
         reporter.report(&message);
 
         let dest_dir = self.store.get_directory(id);
@@ -424,7 +424,7 @@ fn build_list_warning(
                 .file_name()
                 .map(|s| s.to_string_lossy().to_string())
                 .unwrap_or_else(|| format!("{}", source_dir.display()));
-            let message = format!("{}", load_err);
+            let message = format!("{load_err}");
             Ok((fake_id, InstalledTemplateWarning::InvalidManifest(message)))
         }
         None => Err(load_err).context("Failed to load template but unable to determine which one"),

--- a/crates/templates/src/run.rs
+++ b/crates/templates/src/run.rs
@@ -224,7 +224,7 @@ impl Run {
             Ok(())
         } else {
             // TODO: better to provide this as a structured object and let the caller choose how to present it
-            let errors_msg = errors.iter().map(|s| format!("- {}", s)).join("\n");
+            let errors_msg = errors.iter().map(|s| format!("- {s}")).join("\n");
             Err(anyhow!(
                 "The following provided value(s) are invalid according to the template:\n{}",
                 errors_msg
@@ -235,12 +235,11 @@ impl Run {
     fn validate_value(&self, name: &str, value: &str) -> Option<String> {
         match self.template.parameter(name) {
             None => Some(format!(
-                "Template does not contain a parameter named '{}'",
-                name
+                "Template does not contain a parameter named '{name}'"
             )),
             Some(p) => match p.validate_value(value) {
                 Ok(_) => None,
-                Err(e) => Some(format!("{}: {}", name, e)),
+                Err(e) => Some(format!("{name}: {e}")),
             },
         }
     }
@@ -286,9 +285,9 @@ impl Run {
             .ok_or_else(|| anyhow::anyhow!("Template snippets directory not found"))?;
         let abs_snippet_file = snippets_dir.join(snippet_file);
         let file_content = std::fs::read(abs_snippet_file)
-            .with_context(|| format!("Error reading snippet file {}", snippet_file))?;
+            .with_context(|| format!("Error reading snippet file {snippet_file}"))?;
         let content = TemplateContent::infer_from_bytes(file_content, parser)
-            .with_context(|| format!("Error parsing snippet file {}", snippet_file))?;
+            .with_context(|| format!("Error parsing snippet file {snippet_file}"))?;
 
         match id {
             "component" => {

--- a/crates/templates/src/source.rs
+++ b/crates/templates/src/source.rs
@@ -55,7 +55,7 @@ impl TemplateSource {
     ) -> anyhow::Result<Self> {
         let url_str = git_url.as_ref();
         let url =
-            Url::parse(url_str).with_context(|| format!("Failed to parse {} as URL", url_str))?;
+            Url::parse(url_str).with_context(|| format!("Failed to parse {url_str} as URL"))?;
         Ok(Self::Git(GitTemplateSource {
             url,
             branch: branch.clone(),
@@ -123,10 +123,7 @@ impl LocalTemplateSource {
         let templates_root = self.root.join(TEMPLATE_SOURCE_DIR);
         if templates_root.exists() {
             subdirectories(&templates_root).with_context(|| {
-                format!(
-                    "Failed to read contents of '{}' directory",
-                    TEMPLATE_SOURCE_DIR
-                )
+                format!("Failed to read contents of '{TEMPLATE_SOURCE_DIR}' directory")
             })
         } else {
             Err(anyhow!(
@@ -189,7 +186,7 @@ fn version_preferred_tag(text: &str) -> String {
         Ok(version) => format!("{}.{}", version.major, version.minor),
         Err(_) => text.to_owned(),
     };
-    format!("{}{}", TEMPLATE_VERSION_TAG_PREFIX, mm_version)
+    format!("{TEMPLATE_VERSION_TAG_PREFIX}{mm_version}")
 }
 
 async fn check_local(path: &Path) -> anyhow::Result<LocalTemplateSource> {

--- a/crates/trigger-http/src/headers.rs
+++ b/crates/trigger-http/src/headers.rs
@@ -57,7 +57,7 @@ pub fn compute_default_headers<'a>(
 
     let scheme = uri.scheme_str().unwrap_or("http");
 
-    let full_url = format!("{}://{}{}", scheme, host, abs_path);
+    let full_url = format!("{scheme}://{host}{abs_path}");
 
     res.push((owned_path_info, path_info));
     res.push((owned_full_url, full_url.into()));

--- a/crates/trigger-http/src/instrument.rs
+++ b/crates/trigger-http/src/instrument.rs
@@ -69,7 +69,7 @@ pub(crate) fn finalize_http_span(
 pub(crate) fn instrument_error(err: &anyhow::Error) {
     let span = tracing::Span::current();
     tracing::event!(target:module_path!(), Level::INFO, error = %err);
-    span.record("error.type", format!("{:?}", err));
+    span.record("error.type", format!("{err:?}"));
 }
 
 /// MatchedRoute is used as a response extension to track the route that was matched for OTel

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -413,10 +413,10 @@ impl<F: RuntimeFactors> HttpServer<F> {
 
         println!("Available Routes:");
         for (route, component_id) in self.router.routes() {
-            println!("  {}: {}{}", component_id, base_url, route);
+            println!("  {component_id}: {base_url}{route}");
             if let Some(component) = self.trigger_app.app().get_component(component_id) {
                 if let Some(description) = component.get_metadata(APP_DESCRIPTION_KEY)? {
-                    println!("    {}", description);
+                    println!("    {description}");
                 }
             }
         }


### PR DESCRIPTION
So, this is embarrassing and I apologise for the churn.  What happened is, Clippy has a `--fix` mode.  And I used it in #3178 because moving all these format positional args by hand seemed like it would be tedious.  And it succeeded.  And so I foolishly assumed that it had fixed the warnings.  And I did not check my assumption by re-running `cargo clippy`.

And inevitably it was wrong.  It turns out that there were 20-odd files where `cargo clippy` reported a warning but `cargo clippy --fix` could not fix the warning but did not mention it.

So here are the _remaining_ 1.88 Clippy fixes, again I think all "must use interpolation instead of positional args," but these are all hand-cranked so please be extra eagle-eyed for mistakes.  And apologies again!
