### PR TITLE
Pin Zig CI to the version against which the template was written

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,7 +197,9 @@ jobs:
       # Install all the toolchain dependencies
       - name: Install Rust wasm target
         run: rustup target add wasm32-wasip1 wasm32-unknown-unknown
-      - uses: goto-bus-stop/setup-zig@v2
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: '0.14.1'
       - uses: actions/setup-go@v4
         with:
           go-version: '1.23'


### PR DESCRIPTION
This is based on @seun-ja's investigation of the Zig CI errors and his work in #3192.  The motivation for creating a separate PR was to uncouple it from the signals work.  I also switched Zig CI over from the unmaintained `goto-bus-stop` action to the `mlugg` action recommended as a replacement.

I've followed @seun-ja in pinning the version in CI rather than updating the template, because the "writergate" changes (https://github.com/ziglang/zig/pull/24329) are not yet in a release.  We could instead track `latest` in the action, which would have the same effect for now but alert us when writergate went live, so that we were prompted to update the template, but that would make us a hostage to fortune in terms of CI suddenly going red!
