### PR TITLE
Update Go templates to `spinframework` SDK

### DIFF
--- a/templates/http-go/content/go.mod
+++ b/templates/http-go/content/go.mod
@@ -2,6 +2,6 @@ module github.com/{{project-name | snake_case}}
 
 go 1.22
 
-require github.com/fermyon/spin/sdk/go/v2 v2.2.0
+require github.com/spinframework/spin-go-sdk/v2 v2.2.1
 
 require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/templates/http-go/content/go.sum
+++ b/templates/http-go/content/go.sum
@@ -1,4 +1,4 @@
-github.com/fermyon/spin/sdk/go/v2 v2.2.0 h1:zHZdIqjbUwyxiwdygHItnM+vUUNSZ3CX43jbIUemBI4=
-github.com/fermyon/spin/sdk/go/v2 v2.2.0/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
+github.com/spinframework/spin-go-sdk/v2 v2.2.1 h1:ceAbRU+D3xmyZ8ScDLeFoT763ikFIUEmSjgsrD11v8k=
+github.com/spinframework/spin-go-sdk/v2 v2.2.1/go.mod h1:vocVZB4qlTG8C5yoliKIAJCuv4x7sqK0GmVkWeD9N/A=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/templates/http-go/content/main.go
+++ b/templates/http-go/content/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	spinhttp "github.com/fermyon/spin/sdk/go/v2/http"
+	spinhttp "github.com/spinframework/spin-go-sdk/v2/http"
 )
 
 func init() {

--- a/templates/redis-go/content/go.mod
+++ b/templates/redis-go/content/go.mod
@@ -2,4 +2,4 @@ module github.com/{{project-name | snake_case}}
 
 go 1.22
 
-require github.com/fermyon/spin/sdk/go/v2 v2.2.0
+require github.com/spinframework/spin-go-sdk/v2 v2.2.1

--- a/templates/redis-go/content/go.sum
+++ b/templates/redis-go/content/go.sum
@@ -1,2 +1,2 @@
-github.com/fermyon/spin/sdk/go/v2 v2.2.0 h1:zHZdIqjbUwyxiwdygHItnM+vUUNSZ3CX43jbIUemBI4=
-github.com/fermyon/spin/sdk/go/v2 v2.2.0/go.mod h1:kfJ+gdf/xIaKrsC6JHCUDYMv2Bzib1ohFIYUzvP+SCw=
+github.com/spinframework/spin-go-sdk/v2 v2.2.1 h1:ceAbRU+D3xmyZ8ScDLeFoT763ikFIUEmSjgsrD11v8k=
+github.com/spinframework/spin-go-sdk/v2 v2.2.1/go.mod h1:vocVZB4qlTG8C5yoliKIAJCuv4x7sqK0GmVkWeD9N/A=

--- a/templates/redis-go/content/main.go
+++ b/templates/redis-go/content/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/fermyon/spin/sdk/go/v2/redis"
+	"github.com/spinframework/spin-go-sdk/v2/redis"
 )
 
 func init() {


### PR DESCRIPTION
Fixes #3106.

Co-authored by the "I have no idea what I'm doing" dog - knowledgeable folks please review carefully.  It did appear to work on my machine though.
