### PR TITLE
enable connection pooling and reuse for outbound wasi-http

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,6 +194,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: setup dependencies
+        uses: ./.github/actions/spin-ci-dependencies
+        with:
+          rust: true
+
       # Install all the toolchain dependencies
       - name: Install Rust wasm target
         run: rustup target add wasm32-wasip1 wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8431,6 +8431,7 @@ dependencies = [
  "hyper-util",
  "reqwest 0.12.9",
  "rustls 0.23.18",
+ "serde",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
  "spin-factors",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8439,6 +8439,7 @@ dependencies = [
  "spin-world",
  "tokio",
  "tokio-rustls 0.26.0",
+ "tower-service",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,7 @@ tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }
 toml = "0.8"
 toml_edit = "0.22"
+tower-service = "0.3.3"
 tracing = { version = "0.1.41", features = ["log"] }
 url = "2"
 walkdir = "2"

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -19,6 +19,7 @@ spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
 tokio = { workspace = true, features = ["macros", "rt", "net"] }
 tokio-rustls = { workspace = true }
+tower-service = { workspace = true }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -13,6 +13,7 @@ hyper = { workspace = true }
 hyper-util = { workspace = true }
 reqwest = { workspace = true, features = ["gzip"] }
 rustls = { workspace = true }
+serde = { workspace = true }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }
@@ -28,6 +29,11 @@ wasmtime-wasi-http = { workspace = true }
 [dev-dependencies]
 spin-factor-variables = { path = "../factor-variables" }
 spin-factors-test = { path = "../factors-test" }
+
+[features]
+default = ["spin-cli"]
+# Includes the runtime configuration handling used by the Spin CLI
+spin-cli = []
 
 [lints]
 workspace = true

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -67,6 +67,7 @@ impl Factor for OutboundHttpFactor {
             self_request_origin: None,
             request_interceptor: None,
             spin_http_client: None,
+            wasi_http_clients: None,
         })
     }
 }
@@ -80,6 +81,8 @@ pub struct InstanceState {
     request_interceptor: Option<Arc<dyn OutboundHttpInterceptor>>,
     // Connection-pooling client for 'fermyon:spin/http' interface
     spin_http_client: Option<reqwest::Client>,
+    // Connection pooling client for `wasi:http/outgoing-handler` interface
+    wasi_http_clients: Option<wasi::HttpClients>,
 }
 
 impl InstanceState {

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod intercept;
+pub mod runtime_config;
 mod spin;
 mod wasi;
 pub mod wasi_2023_10_18;
@@ -12,6 +13,7 @@ use http::{
     HeaderValue, Uri,
 };
 use intercept::OutboundHttpInterceptor;
+use runtime_config::RuntimeConfig;
 use spin_factor_outbound_networking::{
     config::{allowed_hosts::OutboundAllowedHosts, blocked_networks::BlockedNetworks},
     ComponentTlsClientConfigs, OutboundNetworkingFactor,
@@ -34,8 +36,8 @@ pub struct OutboundHttpFactor {
 }
 
 impl Factor for OutboundHttpFactor {
-    type RuntimeConfig = ();
-    type AppState = ();
+    type RuntimeConfig = RuntimeConfig;
+    type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
     fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
@@ -46,9 +48,14 @@ impl Factor for OutboundHttpFactor {
 
     fn configure_app<T: RuntimeFactors>(
         &self,
-        _ctx: ConfigureAppContext<T, Self>,
+        mut ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
-        Ok(())
+        Ok(AppState {
+            connection_pooling: ctx
+                .take_runtime_config()
+                .unwrap_or_default()
+                .connection_pooling,
+        })
     }
 
     fn prepare<T: RuntimeFactors>(
@@ -68,6 +75,7 @@ impl Factor for OutboundHttpFactor {
             request_interceptor: None,
             spin_http_client: None,
             wasi_http_clients: None,
+            connection_pooling: ctx.app_state().connection_pooling,
         })
     }
 }
@@ -83,6 +91,7 @@ pub struct InstanceState {
     spin_http_client: Option<reqwest::Client>,
     // Connection pooling client for `wasi:http/outgoing-handler` interface
     wasi_http_clients: Option<wasi::HttpClients>,
+    connection_pooling: bool,
 }
 
 impl InstanceState {
@@ -159,4 +168,8 @@ impl std::fmt::Display for SelfRequestOrigin {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}://{}", self.scheme, self.authority)
     }
+}
+
+pub struct AppState {
+    connection_pooling: bool,
 }

--- a/crates/factor-outbound-http/src/runtime_config.rs
+++ b/crates/factor-outbound-http/src/runtime_config.rs
@@ -1,0 +1,17 @@
+#[cfg(feature = "spin-cli")]
+pub mod spin;
+
+/// Runtime configuration for outbound HTTP.
+#[derive(Debug)]
+pub struct RuntimeConfig {
+    /// If true, enable connection pooling and reuse.
+    pub connection_pooling: bool,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            connection_pooling: true,
+        }
+    }
+}

--- a/crates/factor-outbound-http/src/runtime_config/spin.rs
+++ b/crates/factor-outbound-http/src/runtime_config/spin.rs
@@ -1,0 +1,31 @@
+use serde::Deserialize;
+use spin_factors::runtime_config::toml::GetTomlValue;
+
+/// Get the runtime configuration for outbound HTTP from a TOML table.
+///
+/// Expects table to be in the format:
+/// ```toml
+/// [outbound_http]
+/// connection_pooling = true
+/// ```
+pub fn config_from_table(
+    table: &impl GetTomlValue,
+) -> anyhow::Result<Option<super::RuntimeConfig>> {
+    if let Some(outbound_http) = table.get("outbound_http") {
+        Ok(Some(super::RuntimeConfig {
+            connection_pooling: outbound_http
+                .clone()
+                .try_into::<OutboundHttpToml>()?
+                .connection_pooling,
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OutboundHttpToml {
+    #[serde(default)]
+    connection_pooling: bool,
+}

--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -1,23 +1,41 @@
-use std::{error::Error, future::Future, pin::Pin, sync::Arc, time::Duration};
+use std::{
+    error::Error,
+    future::Future,
+    io::IoSlice,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
 
-use anyhow::Context;
-use bytes::Bytes;
-use http::{header::HOST, Request};
-use http_body_util::{combinators::BoxBody, BodyExt};
-use hyper_util::rt::TokioExecutor;
+use anyhow::Context as _;
+use http::{header::HOST, Request, Uri};
+use http_body_util::BodyExt;
+use hyper_util::{
+    client::legacy::{
+        connect::{Connected, Connection},
+        Client,
+    },
+    rt::{TokioExecutor, TokioIo},
+};
 use spin_factor_outbound_networking::{
     config::{allowed_hosts::OutboundAllowedHosts, blocked_networks::BlockedNetworks},
     ComponentTlsClientConfigs, TlsClientConfig,
 };
 use spin_factors::{wasmtime::component::ResourceTable, RuntimeFactorsInstanceState};
-use tokio::{net::TcpStream, time::timeout};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::TcpStream,
+    time::timeout,
+};
+use tokio_rustls::client::TlsStream;
+use tower_service::Service;
 use tracing::{field::Empty, instrument, Instrument};
 use wasmtime::component::HasData;
 use wasmtime_wasi::p2::{IoImpl, IoView};
 use wasmtime_wasi_http::{
     bindings::http::types::ErrorCode,
     body::HyperOutgoingBody,
-    io::TokioIo,
     types::{HostFutureIncomingResponse, IncomingResponse},
     WasiHttpCtx, WasiHttpImpl, WasiHttpView,
 };
@@ -70,6 +88,19 @@ impl OutboundHttpFactor {
     }
 }
 
+type HttpClient = Client<HttpConnector, HyperOutgoingBody>;
+type HttpsClient = Client<HttpsConnector, HyperOutgoingBody>;
+
+#[derive(Clone)]
+pub(super) struct HttpClients {
+    /// Used for non-TLS HTTP/1 connections.
+    http1: HttpClient,
+    /// Used for non-TLS HTTP/2 connections (e.g. when h2 prior knowledge is available).
+    http2: HttpClient,
+    /// Used for HTTP-over-TLS connections, using ALPN to negotiate the HTTP version.
+    https: HttpsClient,
+}
+
 pub(crate) struct WasiHttpImplInner<'a> {
     state: &'a mut InstanceState,
     table: &'a mut ResourceTable,
@@ -104,6 +135,18 @@ impl WasiHttpView for WasiHttpImplInner<'_> {
         request: Request<wasmtime_wasi_http::body::HyperOutgoingBody>,
         config: wasmtime_wasi_http::types::OutgoingRequestConfig,
     ) -> wasmtime_wasi_http::HttpResult<wasmtime_wasi_http::types::HostFutureIncomingResponse> {
+        let http_clients = self
+            .state
+            .wasi_http_clients
+            .get_or_insert_with(|| HttpClients {
+                http1: Client::builder(TokioExecutor::new()).build(HttpConnector),
+                http2: Client::builder(TokioExecutor::new())
+                    .http2_only(true)
+                    .build(HttpConnector),
+                https: Client::builder(TokioExecutor::new()).build(HttpsConnector),
+            })
+            .clone();
+
         Ok(HostFutureIncomingResponse::Pending(
             wasmtime_wasi::runtime::spawn(
                 send_request_impl(
@@ -114,6 +157,7 @@ impl WasiHttpView for WasiHttpImplInner<'_> {
                     self.state.request_interceptor.clone(),
                     self.state.self_request_origin.clone(),
                     self.state.blocked_networks.clone(),
+                    http_clients,
                 )
                 .in_current_span(),
             ),
@@ -121,6 +165,190 @@ impl WasiHttpView for WasiHttpImplInner<'_> {
     }
 }
 
+#[derive(Clone)]
+struct ConnectOptions {
+    blocked_networks: BlockedNetworks,
+    connect_timeout: Duration,
+}
+
+// We must use task-local variables for these config options when using
+// `hyper_util::client::legacy::Client::request` because there's no way to plumb
+// them through as parameters.  Moreover, if there's already a pooled connection
+// ready, we'll reuse that and ignore these options anyway.
+tokio::task_local! {
+    static CONNECT_OPTIONS: ConnectOptions;
+    static TLS_CLIENT_CONFIG: TlsClientConfig;
+}
+
+async fn connect_tcp(uri: Uri, default_port: u16) -> Result<(TcpStream, String), ErrorCode> {
+    let authority_str = if let Some(authority) = uri.authority() {
+        if authority.port().is_some() {
+            authority.to_string()
+        } else {
+            format!("{authority}:{default_port}")
+        }
+    } else {
+        return Err(ErrorCode::HttpRequestUriInvalid);
+    };
+
+    let ConnectOptions {
+        blocked_networks,
+        connect_timeout,
+    } = CONNECT_OPTIONS.get();
+
+    let mut socket_addrs = tokio::net::lookup_host(&authority_str)
+        .await
+        .map_err(|_| dns_error("address not available".into(), 0))?
+        .collect::<Vec<_>>();
+
+    // Remove blocked IPs
+    let blocked_addrs = blocked_networks.remove_blocked(&mut socket_addrs);
+    if socket_addrs.is_empty() && !blocked_addrs.is_empty() {
+        tracing::error!(
+            "error.type" = "destination_ip_prohibited",
+            ?blocked_addrs,
+            "all destination IP(s) prohibited by runtime config"
+        );
+        return Err(ErrorCode::DestinationIpProhibited);
+    }
+
+    Ok((
+        timeout(connect_timeout, TcpStream::connect(socket_addrs.as_slice()))
+            .await
+            .map_err(|_| ErrorCode::ConnectionTimeout)?
+            .map_err(|err| match err.kind() {
+                std::io::ErrorKind::AddrNotAvailable => {
+                    dns_error("address not available".into(), 0)
+                }
+                _ => ErrorCode::ConnectionRefused,
+            })?,
+        authority_str,
+    ))
+}
+
+#[derive(Clone)]
+struct HttpConnector;
+
+impl HttpConnector {
+    async fn connect(uri: Uri) -> Result<TokioIo<TcpStream>, ErrorCode> {
+        Ok(TokioIo::new(connect_tcp(uri, 80).await?.0))
+    }
+}
+
+impl Service<Uri> for HttpConnector {
+    type Response = TokioIo<TcpStream>;
+    type Error = ErrorCode;
+    type Future = Pin<Box<dyn Future<Output = Result<TokioIo<TcpStream>, ErrorCode>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        Box::pin(async move { Self::connect(uri).await })
+    }
+}
+
+struct RustlsStream(TlsStream<TcpStream>);
+
+impl Connection for RustlsStream {
+    fn connected(&self) -> Connected {
+        if self.0.get_ref().1.alpn_protocol() == Some(b"h2") {
+            self.0.get_ref().0.connected().negotiated_h2()
+        } else {
+            self.0.get_ref().0.connected()
+        }
+    }
+}
+
+impl AsyncRead for RustlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for RustlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.get_mut().0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut self.get_mut().0).poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
+    }
+}
+
+#[derive(Clone)]
+struct HttpsConnector;
+
+impl HttpsConnector {
+    async fn connect(uri: Uri) -> Result<TokioIo<RustlsStream>, ErrorCode> {
+        use rustls::pki_types::ServerName;
+
+        let (tcp_stream, authority_str) = connect_tcp(uri, 443).await?;
+
+        let mut tls_client_config = (*TLS_CLIENT_CONFIG.get()).clone();
+        tls_client_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_client_config));
+        let mut parts = authority_str.split(':');
+        let host = parts.next().unwrap_or(&authority_str);
+        let domain = ServerName::try_from(host)
+            .map_err(|e| {
+                tracing::warn!("dns lookup error: {e:?}");
+                dns_error("invalid dns name".to_string(), 0)
+            })?
+            .to_owned();
+        let stream = connector.connect(domain, tcp_stream).await.map_err(|e| {
+            tracing::warn!("tls protocol error: {e:?}");
+            ErrorCode::TlsProtocolError
+        })?;
+
+        Ok(TokioIo::new(RustlsStream(stream)))
+    }
+}
+
+impl Service<Uri> for HttpsConnector {
+    type Response = TokioIo<RustlsStream>;
+    type Error = ErrorCode;
+    type Future = Pin<Box<dyn Future<Output = Result<TokioIo<RustlsStream>, ErrorCode>> + Send>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, uri: Uri) -> Self::Future {
+        Box::pin(async move { Self::connect(uri).await })
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn send_request_impl(
     mut request: Request<wasmtime_wasi_http::body::HyperOutgoingBody>,
     mut config: wasmtime_wasi_http::types::OutgoingRequestConfig,
@@ -129,6 +357,7 @@ async fn send_request_impl(
     request_interceptor: Option<Arc<dyn OutboundHttpInterceptor>>,
     self_request_origin: Option<SelfRequestOrigin>,
     blocked_networks: BlockedNetworks,
+    http_clients: HttpClients,
 ) -> anyhow::Result<Result<IncomingResponse, ErrorCode>> {
     // wasmtime-wasi-http fills in scheme and authority for relative URLs
     // (e.g. https://:443/<path>), which makes them hard to reason about.
@@ -212,12 +441,16 @@ async fn send_request_impl(
         span.record("server.port", port.as_u16());
     }
 
-    Ok(send_request_handler(request, config, tls_client_config, blocked_networks).await)
+    Ok(send_request_handler(
+        request,
+        config,
+        tls_client_config,
+        blocked_networks,
+        http_clients,
+    )
+    .await)
 }
 
-/// This is a fork of wasmtime_wasi_http::default_send_request_handler function
-/// forked from bytecodealliance/wasmtime commit-sha 29a76b68200fcfa69c8fb18ce6c850754279a05b
-/// This fork provides the ability to configure client cert auth for mTLS
 async fn send_request_handler(
     mut request: http::Request<HyperOutgoingBody>,
     wasmtime_wasi_http::types::OutgoingRequestConfig {
@@ -228,212 +461,73 @@ async fn send_request_handler(
     }: wasmtime_wasi_http::types::OutgoingRequestConfig,
     tls_client_config: TlsClientConfig,
     blocked_networks: BlockedNetworks,
+    http_clients: HttpClients,
 ) -> Result<wasmtime_wasi_http::types::IncomingResponse, ErrorCode> {
-    let authority_str = if let Some(authority) = request.uri().authority() {
-        if authority.port().is_some() {
-            authority.to_string()
-        } else {
-            let port = if use_tls { 443 } else { 80 };
-            format!("{authority}:{port}")
-        }
-    } else {
-        return Err(ErrorCode::HttpRequestUriInvalid);
-    };
+    // Some servers (looking at you nginx) don't like a host header even though
+    // http/2 allows it: https://github.com/hyperium/hyper/issues/3298
+    request.headers_mut().remove(HOST);
 
-    // Resolve the authority to IP addresses
-    let mut socket_addrs = tokio::net::lookup_host(&authority_str)
-        .await
-        .map_err(|_| dns_error("address not available".into(), 0))?
-        .collect::<Vec<_>>();
+    let resp = CONNECT_OPTIONS.scope(
+        ConnectOptions {
+            blocked_networks,
+            connect_timeout,
+        },
+        async move {
+            if use_tls {
+                TLS_CLIENT_CONFIG
+                    .scope(tls_client_config, async move {
+                        http_clients.https.request(request).await
+                    })
+                    .await
+            } else {
+                let use_http2 =
+                    std::env::var_os("SPIN_OUTBOUND_H2C_PRIOR_KNOWLEDGE").is_some_and(|v| {
+                        request
+                            .uri()
+                            .authority()
+                            .is_some_and(|authority| authority.as_str() == v)
+                    });
 
-    // Remove blocked IPs
-    let blocked_addrs = blocked_networks.remove_blocked(&mut socket_addrs);
-    if socket_addrs.is_empty() && !blocked_addrs.is_empty() {
-        tracing::error!(
-            "error.type" = "destination_ip_prohibited",
-            ?blocked_addrs,
-            "all destination IP(s) prohibited by runtime config"
-        );
-        return Err(ErrorCode::DestinationIpProhibited);
-    }
-
-    let tcp_stream = timeout(connect_timeout, TcpStream::connect(socket_addrs.as_slice()))
-        .await
-        .map_err(|_| ErrorCode::ConnectionTimeout)?
-        .map_err(|err| match err.kind() {
-            std::io::ErrorKind::AddrNotAvailable => dns_error("address not available".into(), 0),
-            _ => ErrorCode::ConnectionRefused,
-        })?;
-
-    let (mut sender, worker, is_http2) = if use_tls {
-        #[cfg(any(target_arch = "riscv64", target_arch = "s390x"))]
-        {
-            return Err(ErrorCode::InternalError(Some(
-                "unsupported architecture for SSL".to_string(),
-            )));
-        }
-
-        #[cfg(not(any(target_arch = "riscv64", target_arch = "s390x")))]
-        {
-            use rustls::pki_types::ServerName;
-
-            let mut tls_client_config = (*tls_client_config).clone();
-            tls_client_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-
-            let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_client_config));
-            let mut parts = authority_str.split(':');
-            let host = parts.next().unwrap_or(&authority_str);
-            let domain = ServerName::try_from(host)
-                .map_err(|e| {
-                    tracing::warn!("dns lookup error: {e:?}");
-                    dns_error("invalid dns name".to_string(), 0)
-                })?
-                .to_owned();
-            let stream = connector.connect(domain, tcp_stream).await.map_err(|e| {
-                tracing::warn!("tls protocol error: {e:?}");
-                ErrorCode::TlsProtocolError
-            })?;
-
-            let is_http2 = stream.get_ref().1.alpn_protocol() == Some(b"h2");
-
-            let stream = TokioIo::new(stream);
-
-            let (sender, conn) = new_sender_and_conn(stream, is_http2, connect_timeout).await?;
-
-            let worker = wasmtime_wasi::runtime::spawn(async move {
-                match conn.await {
-                    Ok(()) => {}
-                    // TODO: shouldn't throw away this error and ideally should
-                    // surface somewhere.
-                    Err(e) => tracing::warn!("dropping error {e}"),
+                if use_http2 {
+                    http_clients.http2.request(request).await
+                } else {
+                    http_clients.http1.request(request).await
                 }
-            });
-
-            (sender, worker, is_http2)
-        }
-    } else {
-        let tcp_stream = TokioIo::new(tcp_stream);
-
-        let is_http2 = std::env::var_os("SPIN_OUTBOUND_H2C_PRIOR_KNOWLEDGE").is_some_and(|v| {
-            request
-                .uri()
-                .authority()
-                .is_some_and(|authority| authority.as_str() == v)
-        });
-
-        let (sender, conn) = new_sender_and_conn(tcp_stream, is_http2, connect_timeout).await?;
-
-        let worker = wasmtime_wasi::runtime::spawn(async move {
-            match conn.await {
-                Ok(()) => {}
-                // TODO: same as above, shouldn't throw this error away.
-                Err(e) => tracing::warn!("dropping error {e}"),
             }
-        });
+        },
+    );
 
-        (sender, worker, is_http2)
-    };
-
-    if is_http2 {
-        // Some servers (looking at you nginx) don't like a host header even though
-        // http/2 allows it: https://github.com/hyperium/hyper/issues/3298
-        request.headers_mut().remove(HOST);
-    } else {
-        // at this point, the request contains the scheme and the authority, but
-        // the http packet should only include those if addressing a proxy, so
-        // remove them here, since SendRequest::send_request does not do it for us
-        *request.uri_mut() = http::Uri::builder()
-            .path_and_query(
-                request
-                    .uri()
-                    .path_and_query()
-                    .map(|p| p.as_str())
-                    .unwrap_or("/"),
-            )
-            .build()
-            .expect("comes from valid request");
-    }
-
-    let resp = timeout(first_byte_timeout, sender.send_request(request))
+    let resp = timeout(first_byte_timeout, resp)
         .await
         .map_err(|_| ErrorCode::ConnectionReadTimeout)?
-        .map_err(hyper_request_error)?
+        .map_err(hyper_legacy_request_error)?
         .map(|body| body.map_err(hyper_request_error).boxed());
 
     tracing::Span::current().record("http.response.status_code", resp.status().as_u16());
 
     Ok(wasmtime_wasi_http::types::IncomingResponse {
         resp,
-        worker: Some(worker),
+        worker: None,
         between_bytes_timeout,
     })
 }
 
-async fn new_sender_and_conn<T: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static>(
-    stream: T,
-    is_http2: bool,
-    connect_timeout: Duration,
-) -> Result<(HttpSender, HttpConn<T>), ErrorCode> {
-    if is_http2 {
-        timeout(
-            connect_timeout,
-            hyper::client::conn::http2::handshake(TokioExecutor::default(), stream),
-        )
-        .await
-        .map_err(|_| ErrorCode::ConnectionTimeout)?
-        .map_err(hyper_request_error)
-        .map(|(sender, conn)| (HttpSender::Http2(sender), HttpConn::Http2(conn)))
-    } else {
-        timeout(
-            connect_timeout,
-            hyper::client::conn::http1::handshake(stream),
-        )
-        .await
-        .map_err(|_| ErrorCode::ConnectionTimeout)?
-        .map_err(hyper_request_error)
-        .map(|(sender, conn)| (HttpSender::Http1(sender), HttpConn::Http1(conn)))
-    }
-}
-
-enum HttpSender {
-    Http1(hyper::client::conn::http1::SendRequest<BoxBody<Bytes, ErrorCode>>),
-    Http2(hyper::client::conn::http2::SendRequest<BoxBody<Bytes, ErrorCode>>),
-}
-
-#[allow(clippy::large_enum_variant)]
-enum HttpConn<T: hyper::rt::Read + hyper::rt::Write + Unpin + Send + 'static> {
-    Http1(hyper::client::conn::http1::Connection<T, BoxBody<Bytes, ErrorCode>>),
-    Http2(hyper::client::conn::http2::Connection<T, BoxBody<Bytes, ErrorCode>, TokioExecutor>),
-}
-
-impl<T: hyper::rt::Read + hyper::rt::Write + Unpin + Send> Future for HttpConn<T> {
-    type Output = Result<(), hyper::Error>;
-
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        match self.get_mut() {
-            HttpConn::Http1(conn) => Pin::new(conn).poll(cx),
-            HttpConn::Http2(conn) => Pin::new(conn).poll(cx),
-        }
-    }
-}
-
-impl HttpSender {
-    async fn send_request(
-        &mut self,
-        request: http::Request<BoxBody<Bytes, ErrorCode>>,
-    ) -> Result<http::Response<hyper::body::Incoming>, hyper::Error> {
-        match self {
-            HttpSender::Http1(sender) => sender.send_request(request).await,
-            HttpSender::Http2(sender) => sender.send_request(request).await,
-        }
-    }
-}
-
 /// Translate a [`hyper::Error`] to a wasi-http `ErrorCode` in the context of a request.
 fn hyper_request_error(err: hyper::Error) -> ErrorCode {
+    // If there's a source, we might be able to extract a wasi-http error from it.
+    if let Some(cause) = err.source() {
+        if let Some(err) = cause.downcast_ref::<ErrorCode>() {
+            return err.clone();
+        }
+    }
+
+    tracing::warn!("hyper request error: {err:?}");
+
+    ErrorCode::HttpProtocolError
+}
+
+/// Translate a [`hyper_util::client::legacy::Error`] to a wasi-http `ErrorCode` in the context of a request.
+fn hyper_legacy_request_error(err: hyper_util::client::legacy::Error) -> ErrorCode {
     // If there's a source, we might be able to extract a wasi-http error from it.
     if let Some(cause) = err.source() {
         if let Some(err) = cause.downcast_ref::<ErrorCode>() {

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -379,8 +379,10 @@ impl FactorRuntimeConfigSource<WasiFactor> for TomlRuntimeConfigSource<'_, '_> {
 }
 
 impl FactorRuntimeConfigSource<OutboundHttpFactor> for TomlRuntimeConfigSource<'_, '_> {
-    fn get_runtime_config(&mut self) -> anyhow::Result<Option<()>> {
-        Ok(None)
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<Option<<OutboundHttpFactor as spin_factors::Factor>::RuntimeConfig>> {
+        spin_factor_outbound_http::runtime_config::spin::config_from_table(&self.toml.table)
     }
 }
 

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.15",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +81,12 @@ name = "arc-swap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-channel"
@@ -817,6 +834,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +868,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "borsh-derive",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd1d3c0c2f5833f22386f252fe8ed005c7f59fdcddeef025c01b4c3b9fd9ac3"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "btoi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -854,6 +906,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 dependencies = [
  "allocator-api2",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1720,6 +1794,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +2060,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3458,6 +3541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres_range"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6dce28dc5ba143d8eb157b62aac01ae5a1c585c40792158b720e86a87642101"
+dependencies = [
+ "postgres-protocol",
+ "postgres-types",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +3563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -3549,6 +3651,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3642,6 +3764,12 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3918,6 +4046,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,6 +4122,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rumqttc"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4015,6 +4181,23 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "postgres-types",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4320,6 +4503,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4487,6 +4676,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4667,6 +4862,7 @@ dependencies = [
  "spin-world",
  "tokio",
  "tokio-rustls 0.26.2",
+ "tower-service",
  "tracing",
  "wasmtime",
  "wasmtime-wasi",
@@ -4732,11 +4928,14 @@ name = "spin-factor-outbound-pg"
 version = "3.4.0-pre0"
 dependencies = [
  "anyhow",
+ "bytes",
  "chrono",
  "deadpool-postgres",
  "moka",
  "native-tls",
  "postgres-native-tls",
+ "postgres_range",
+ "rust_decimal",
  "serde_json",
  "spin-core",
  "spin-factor-outbound-networking",
@@ -5004,6 +5203,7 @@ dependencies = [
  "spin-factors-executor",
  "spin-runtime-config",
  "spin-trigger",
+ "spin-variables-static",
  "terminal",
  "tracing",
 ]
@@ -5130,8 +5330,11 @@ name = "spin-variables-static"
 version = "3.4.0-pre0"
 dependencies = [
  "serde",
+ "serde_json",
+ "spin-common",
  "spin-expressions",
  "spin-factors",
+ "toml",
 ]
 
 [[package]]
@@ -5288,6 +5491,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -7088,6 +7297,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xmlparser"


### PR DESCRIPTION
This updates `factor-outbound-http/wasi.rs` to use `hyper_util::client::legacy::Client`, which does connection pooling by default. `Client` requires a `tower_service::Service` implementation for creating new connections, which in turn required moving code around to accomodate a different flow of control.  It also forces us to work at a slightly higher level of abstraction, so we don't have as much fine-grained control as before, notably:

- We can't make HTTP/2-specific request tweaks like we did before (e.g. removing or adding `host` headers, or tweaking the path-with-query).  I'm mainly leaving it up to `hyper-util` to do the right thing here :crossed_fingers:.

- We can't provide an `AbortOnDropJoinHandle` when constructing an `IncomingResponse` object, which may mean the connection continues to exist after the response is dropped, but that's kind of the point of connection pooling anyway.

Open questions: do we want to make this configurable, and if so, should it be enabled or disabled by default?