### PR TITLE
selects only id when checking existence of data

### DIFF
--- a/crates/key-value-azure/src/store.rs
+++ b/crates/key-value-azure/src/store.rs
@@ -458,13 +458,19 @@ impl AzureCosmosStore {
     }
 
     fn get_id_query(&self, key: &str) -> String {
-        let mut query = format!("SELECT c.id, c.store_id FROM c WHERE c.id='{key}'");
+        let mut query = match self.store_id {
+            Some(_) => format!("SELECT c.id, c.store_id FROM c WHERE c.id='{key}'"),
+            None => format!("SELECT c.id FROM c WHERE c.id='{key}'"),
+        };
         self.append_store_id(&mut query, true);
         query
     }
 
     fn get_keys_query(&self) -> String {
-        let mut query = "SELECT c.id, c.store_id FROM c".to_owned();
+        let mut query = match self.store_id {
+            Some(_) => "SELECT c.id, c.store_id FROM c".to_owned(),
+            None => "SELECT c.id FROM c".to_owned(),
+        };
         self.append_store_id(&mut query, false);
         query
     }

--- a/crates/key-value-azure/src/store.rs
+++ b/crates/key-value-azure/src/store.rs
@@ -458,7 +458,7 @@ impl AzureCosmosStore {
     }
 
     fn get_id_query(&self, key: &str) -> String {
-        let mut query = format!("SELECT c.id FROM c WHERE c.id='{key}'");
+        let mut query = format!("SELECT c.id, c.store_id FROM c WHERE c.id='{key}'");
         self.append_store_id(&mut query, true);
         query
     }

--- a/crates/key-value-azure/src/store.rs
+++ b/crates/key-value-azure/src/store.rs
@@ -458,19 +458,13 @@ impl AzureCosmosStore {
     }
 
     fn get_id_query(&self, key: &str) -> String {
-        let mut query = match self.store_id {
-            Some(_) => format!("SELECT c.id, c.store_id FROM c WHERE c.id='{key}'"),
-            None => format!("SELECT c.id FROM c WHERE c.id='{key}'"),
-        };
+        let mut query = format!("SELECT c.id, c.store_id FROM c WHERE c.id='{key}'");
         self.append_store_id(&mut query, true);
         query
     }
 
     fn get_keys_query(&self) -> String {
-        let mut query = match self.store_id {
-            Some(_) => "SELECT c.id, c.store_id FROM c".to_owned(),
-            None => "SELECT c.id FROM c".to_owned(),
-        };
+        let mut query = "SELECT c.id, c.store_id FROM c".to_owned();
         self.append_store_id(&mut query, false);
         query
     }


### PR DESCRIPTION
Fixes #2921

PR sieves out redundant data, only checks for `id`.  Does the same for `get_keys_query`, only querying for `c.id` and `c.store_id` (needed for deserialising to `Key` struct), thereby excluding possible heavy data from `value` 