### PR TITLE
Rev conformance-tests back to official

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 [[package]]
 name = "conformance-tests"
 version = "0.1.0"
-source = "git+https://github.com/itowlson/conformance-tests?rev=fa529a698616116beb024881cfd6fdeda7f39415#fa529a698616116beb024881cfd6fdeda7f39415"
+source = "git+https://github.com/fermyon/conformance-tests?rev=61f2799f92b5d85f342cc07e3f5dec5cd0a7bc9c#61f2799f92b5d85f342cc07e3f5dec5cd0a7bc9c"
 dependencies = [
  "anyhow",
  "flate2",
@@ -9569,7 +9569,7 @@ dependencies = [
 [[package]]
 name = "test-environment"
 version = "0.1.0"
-source = "git+https://github.com/itowlson/conformance-tests?rev=fa529a698616116beb024881cfd6fdeda7f39415#fa529a698616116beb024881cfd6fdeda7f39415"
+source = "git+https://github.com/fermyon/conformance-tests?rev=61f2799f92b5d85f342cc07e3f5dec5cd0a7bc9c#61f2799f92b5d85f342cc07e3f5dec5cd0a7bc9c"
 dependencies = [
  "anyhow",
  "fslock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ base64 = "0.22"
 bytes = "1"
 chrono = "0.4"
 clap = "3.2"
-conformance-tests = { git = "https://github.com/itowlson/conformance-tests", rev = "fa529a698616116beb024881cfd6fdeda7f39415" }
+conformance-tests = { git = "https://github.com/fermyon/conformance-tests", rev = "61f2799f92b5d85f342cc07e3f5dec5cd0a7bc9c" }
 ctrlc = { version = "3.4", features = ["termination"] }
 dialoguer = "0.11"
 dirs = "6.0"
@@ -158,7 +158,7 @@ sha2 = "0.10"
 syn = "2"
 tar = "0.4"
 tempfile = "3"
-test-environment = { git = "https://github.com/itowlson/conformance-tests", rev = "fa529a698616116beb024881cfd6fdeda7f39415" }
+test-environment = { git = "https://github.com/fermyon/conformance-tests", rev = "61f2799f92b5d85f342cc07e3f5dec5cd0a7bc9c" }
 thiserror = "2"
 tokio = "1"
 tokio-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"] }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -4856,6 +4856,7 @@ dependencies = [
  "hyper-util",
  "reqwest",
  "rustls 0.23.25",
+ "serde",
  "spin-factor-outbound-networking",
  "spin-factors",
  "spin-telemetry",


### PR DESCRIPTION
The tests for the `postgres@4.0.0` work were written as conformance tests.  To pick up those tests, I temporarily pointed Spin at my fork of the conformance-tests repo.  With the PG work now in Spin, I was able to merge the new conformance tests into the official repo.  So this PR changes the temporary references back.

If you enjoyed that PR description, like and subscribe for an absolute banger about a wolf, a goat, and a cabbage.
