### PR TITLE
Build profiles

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -16,14 +16,18 @@ use subprocess::{Exec, Redirection};
 
 use crate::manifest::component_build_configs;
 
+const LAST_BUILD_PROFILE_FILE: &str = "last-build.txt";
+const LAST_BUILD_ANON_VALUE: &str = "<anonymous>";
+
 /// If present, run the build command of each component.
 pub async fn build(
     manifest_file: &Path,
+    profile: Option<&str>,
     component_ids: &[String],
     target_checks: TargetChecking,
     cache_root: Option<PathBuf>,
 ) -> Result<()> {
-    let build_info = component_build_configs(manifest_file)
+    let build_info = component_build_configs(manifest_file, profile)
         .await
         .with_context(|| {
             format!(
@@ -54,6 +58,10 @@ pub async fn build(
     // If the build failed, exit with an error at this point.
     build_result?;
 
+    if let Err(e) = save_last_build_profile(&app_dir, profile) {
+        tracing::warn!("Failed to save build profile: {e:?}");
+    }
+
     let Some(manifest) = build_info.manifest() else {
         // We can't proceed to checking (because that needs a full healthy manifest), and we've
         // already emitted any necessary warning, so quit.
@@ -63,6 +71,7 @@ pub async fn build(
     if target_checks.check() {
         let application = spin_environments::ApplicationToValidate::new(
             manifest.clone(),
+            profile,
             manifest_file.parent().unwrap(),
         )
         .await
@@ -90,8 +99,19 @@ pub async fn build(
 /// Run all component build commands, using the default options (build all
 /// components, perform target checking). We run a "default build" in several
 /// places and this centralises the logic of what such a "default build" means.
-pub async fn build_default(manifest_file: &Path, cache_root: Option<PathBuf>) -> Result<()> {
-    build(manifest_file, &[], TargetChecking::Check, cache_root).await
+pub async fn build_default(
+    manifest_file: &Path,
+    profile: Option<&str>,
+    cache_root: Option<PathBuf>,
+) -> Result<()> {
+    build(
+        manifest_file,
+        profile,
+        &[],
+        TargetChecking::Check,
+        cache_root,
+    )
+    .await
 }
 
 fn build_components(
@@ -316,6 +336,69 @@ fn sort(components: Vec<ComponentBuildInfo>) -> (Vec<ComponentBuildInfo>, bool) 
     }
 }
 
+/// Saves the build profile to the "last build profile" file.
+pub fn save_last_build_profile(app_dir: &Path, profile: Option<&str>) -> anyhow::Result<()> {
+    let app_stash_dir = app_dir.join(".spin");
+    let last_build_profile_file = app_stash_dir.join(LAST_BUILD_PROFILE_FILE);
+
+    // This way, if the user never uses build profiles, they won't see a
+    // weird savefile that they have no idea what it is.
+    if profile.is_none() && !last_build_profile_file.exists() {
+        return Ok(());
+    }
+
+    std::fs::create_dir_all(&app_stash_dir)?;
+    std::fs::write(
+        &last_build_profile_file,
+        profile.unwrap_or(LAST_BUILD_ANON_VALUE),
+    )?;
+
+    Ok(())
+}
+
+/// Reads the last build profile from the "last build profile" file.
+pub fn read_last_build_profile(app_dir: &Path) -> anyhow::Result<Option<String>> {
+    let app_stash_dir = app_dir.join(".spin");
+    let last_build_profile_file = app_stash_dir.join(LAST_BUILD_PROFILE_FILE);
+    if !last_build_profile_file.exists() {
+        return Ok(None);
+    }
+
+    let last_build_str = std::fs::read_to_string(&last_build_profile_file)?;
+
+    if last_build_str == LAST_BUILD_ANON_VALUE {
+        Ok(None)
+    } else {
+        Ok(Some(last_build_str))
+    }
+}
+
+/// Prints a warning to stderr if the given profile is not the same
+/// as the most recent build in the given application directory.
+pub fn warn_if_not_latest_build(manifest_path: &Path, profile: Option<&str>) {
+    let Some(app_dir) = manifest_path.parent() else {
+        return;
+    };
+
+    let latest_build = match read_last_build_profile(app_dir) {
+        Ok(profile) => profile,
+        Err(e) => {
+            tracing::warn!(
+                "Failed to read last build profile: using anonymous profile. Error was {e:?}"
+            );
+            None
+        }
+    };
+
+    if profile != latest_build.as_deref() {
+        let profile_opt = match profile {
+            Some(p) => format!(" --profile {p}"),
+            None => "".to_string(),
+        };
+        terminal::warn!("You built a different profile more recently than the one you are running. If the app appears to be behaving like an older version then run `spin up --build{profile_opt}`.");
+    }
+}
+
 /// Specifies target environment checking behaviour
 pub enum TargetChecking {
     /// The build should check that all components are compatible with all target environments.
@@ -343,7 +426,7 @@ mod tests {
     #[tokio::test]
     async fn can_load_even_if_trigger_invalid() {
         let bad_trigger_file = test_data_root().join("bad_trigger.toml");
-        build(&bad_trigger_file, &[], TargetChecking::Skip, None)
+        build(&bad_trigger_file, None, &[], TargetChecking::Skip, None)
             .await
             .unwrap();
     }
@@ -351,7 +434,7 @@ mod tests {
     #[tokio::test]
     async fn succeeds_if_target_env_matches() {
         let manifest_path = test_data_root().join("good_target_env.toml");
-        build(&manifest_path, &[], TargetChecking::Check, None)
+        build(&manifest_path, None, &[], TargetChecking::Check, None)
             .await
             .unwrap();
     }
@@ -359,7 +442,7 @@ mod tests {
     #[tokio::test]
     async fn fails_if_target_env_does_not_match() {
         let manifest_path = test_data_root().join("bad_target_env.toml");
-        let err = build(&manifest_path, &[], TargetChecking::Check, None)
+        let err = build(&manifest_path, None, &[], TargetChecking::Check, None)
             .await
             .expect_err("should have failed")
             .to_string();
@@ -374,9 +457,11 @@ mod tests {
     #[tokio::test]
     async fn has_meaningful_error_if_target_env_does_not_match() {
         let manifest_file = test_data_root().join("bad_target_env.toml");
-        let manifest = spin_manifest::manifest_from_file(&manifest_file).unwrap();
+        let mut manifest = spin_manifest::manifest_from_file(&manifest_file).unwrap();
+        spin_manifest::normalize::normalize_manifest(&mut manifest, None).unwrap();
         let application = spin_environments::ApplicationToValidate::new(
             manifest.clone(),
+            None,
             manifest_file.parent().unwrap(),
         )
         .await

--- a/crates/build/src/manifest.rs
+++ b/crates/build/src/manifest.rs
@@ -77,11 +77,16 @@ impl ManifestBuildInfo {
 /// given (v1 or v2) manifest path. If the manifest cannot be loaded, the
 /// function attempts fallback: if fallback succeeds, result is Ok but the load error
 /// is also returned via the second part of the return value tuple.
-pub async fn component_build_configs(manifest_file: impl AsRef<Path>) -> Result<ManifestBuildInfo> {
+pub async fn component_build_configs(
+    manifest_file: impl AsRef<Path>,
+    profile: Option<&str>,
+) -> Result<ManifestBuildInfo> {
     let manifest = spin_manifest::manifest_from_file(&manifest_file);
     match manifest {
         Ok(mut manifest) => {
-            spin_manifest::normalize::normalize_manifest(&mut manifest)?;
+            manifest.ensure_profile(profile)?;
+
+            spin_manifest::normalize::normalize_manifest(&mut manifest, profile)?;
             let components = build_configs_from_manifest(&manifest);
             let deployment_targets = deployment_targets_from_manifest(&manifest);
             Ok(ManifestBuildInfo::Loadable {

--- a/crates/environments/src/environment.rs
+++ b/crates/environments/src/environment.rs
@@ -391,7 +391,7 @@ mod test {
         )
         .unwrap();
 
-        let application = crate::ApplicationToValidate::new(manifest, temp_dir.path())
+        let application = crate::ApplicationToValidate::new(manifest, None, temp_dir.path())
             .await
             .unwrap();
 
@@ -457,7 +457,7 @@ mod test {
         )
         .unwrap();
 
-        let application = crate::ApplicationToValidate::new(manifest, temp_dir.path())
+        let application = crate::ApplicationToValidate::new(manifest, None, temp_dir.path())
             .await
             .unwrap();
 

--- a/crates/environments/src/loader.rs
+++ b/crates/environments/src/loader.rs
@@ -54,9 +54,10 @@ pub struct ApplicationToValidate {
 impl ApplicationToValidate {
     pub async fn new(
         mut manifest: spin_manifest::schema::v2::AppManifest,
+        profile: Option<&str>,
         base_dir: impl AsRef<Path>,
     ) -> anyhow::Result<Self> {
-        spin_manifest::normalize::normalize_manifest(&mut manifest)?;
+        spin_manifest::normalize::normalize_manifest(&mut manifest, profile)?;
         let wasm_loader =
             spin_loader::WasmLoader::new(base_dir.as_ref().to_owned(), None, None).await?;
         Ok(Self {

--- a/crates/factors-test/src/lib.rs
+++ b/crates/factors-test/src/lib.rs
@@ -102,5 +102,5 @@ pub async fn build_locked_app(manifest: &toml::Table) -> anyhow::Result<LockedAp
     let dir = tempfile::tempdir().context("failed creating tempdir")?;
     let path = dir.path().join("spin.toml");
     std::fs::write(&path, toml_str).context("failed writing manifest")?;
-    spin_loader::from_file(&path, FilesMountStrategy::Direct, None).await
+    spin_loader::from_file(&path, FilesMountStrategy::Direct, None, None).await
 }

--- a/crates/loader/src/lib.rs
+++ b/crates/loader/src/lib.rs
@@ -35,11 +35,12 @@ pub(crate) const MAX_FILE_LOADING_CONCURRENCY: usize = 16;
 pub async fn from_file(
     manifest_path: impl AsRef<Path>,
     files_mount_strategy: FilesMountStrategy,
+    profile: Option<&str>,
     cache_root: Option<PathBuf>,
 ) -> Result<LockedApp> {
     let path = manifest_path.as_ref();
     let app_root = parent_dir(path).context("manifest path has no parent directory")?;
-    let loader = LocalLoader::new(&app_root, files_mount_strategy, cache_root).await?;
+    let loader = LocalLoader::new(&app_root, files_mount_strategy, profile, cache_root).await?;
     loader.load_file(path).await
 }
 
@@ -47,8 +48,8 @@ pub async fn from_file(
 pub async fn from_wasm_file(wasm_path: impl AsRef<Path>) -> Result<LockedApp> {
     let app_root = std::env::current_dir()?;
     let manifest = single_file_manifest(wasm_path)?;
-    let loader = LocalLoader::new(&app_root, FilesMountStrategy::Direct, None).await?;
-    loader.load_manifest(manifest).await
+    let loader = LocalLoader::new(&app_root, FilesMountStrategy::Direct, None, None).await?;
+    loader.load_manifest(manifest, None).await
 }
 
 /// The strategy to use for mounting WASI files into a guest.

--- a/crates/loader/tests/ui.rs
+++ b/crates/loader/tests/ui.rs
@@ -50,6 +50,7 @@ fn run_test(input: &Path, normalizer: &mut Normalizer) -> Result<String, Failed>
             input,
             spin_loader::FilesMountStrategy::Copy(files_mount_root),
             None,
+            None,
         )
         .await
         .map_err(|err| format!("{err:?}"))?;

--- a/crates/manifest/src/compat.rs
+++ b/crates/manifest/src/compat.rs
@@ -74,6 +74,7 @@ pub fn v1_to_v2_app(manifest: v1::AppManifestV1) -> Result<v2::AppManifest, Erro
                 allowed_http_hosts: Vec::new(),
                 dependencies_inherit_configuration: false,
                 dependencies: Default::default(),
+                profile: Default::default(),
             },
         );
         triggers

--- a/crates/manifest/src/schema/common.rs
+++ b/crates/manifest/src/schema/common.rs
@@ -161,10 +161,10 @@ pub enum WasiFilesMount {
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ComponentBuildConfig {
-    /// The command or commands to build the application. If multiple commands
+    /// The command or commands to build the component. If multiple commands
     /// are specified, they are run sequentially from left to right.
     ///
-    /// Example: `command = "cargo build"`, `command = ["npm install", "npm run build"]`
+    /// Example: `command = "cargo build --release"`, `command = ["npm install", "npm run build"]`
     ///
     /// Learn more: https://spinframework.dev/build#setting-up-for-spin-build
     pub command: Commands,

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -52,6 +52,25 @@ impl AppManifest {
         }
         Ok(())
     }
+
+    /// Whether any component in the application defines the given profile.
+    /// Not every component defines every profile, and components intentionally
+    /// fall back to the anonymouse profile if they are asked for a profile
+    /// they don't define. So this can be used to detect that a user might have
+    /// mistyped a profile (e.g. `spin up --profile deugb`).
+    pub fn ensure_profile(&self, profile: Option<&str>) -> anyhow::Result<()> {
+        let Some(p) = profile else {
+            return Ok(());
+        };
+
+        let is_defined = self.components.values().any(|c| c.profile.contains_key(p));
+
+        if is_defined {
+            Ok(())
+        } else {
+            Err(anyhow!("Profile {p} is not defined in this application"))
+        }
+    }
 }
 
 /// App details
@@ -426,6 +445,59 @@ pub struct Component {
     /// Learn more: https://spinframework.dev/writing-apps#using-component-dependencies
     #[serde(default, skip_serializing_if = "ComponentDependencies::is_empty")]
     pub dependencies: ComponentDependencies,
+    /// Override values to use when building or running a named build profile.
+    ///
+    /// Example: `profile.debug.build.command = "npm run build-debug"`
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub(crate) profile: Map<String, ComponentProfileOverride>,
+}
+
+/// Customisations for a Spin component in a non-default profile.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ComponentProfileOverride {
+    /// The file, package, or URL containing the component Wasm binary.
+    ///
+    /// Example: `source = "bin/debug/cart.wasm"`
+    ///
+    /// Learn more: https://spinframework.dev/writing-apps#the-component-source
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) source: Option<ComponentSource>,
+
+    /// Environment variables for the Wasm module to be overridden in this profile.
+    /// Environment variables specified in the default profile will still be set
+    /// if not overridden here.
+    ///
+    /// `environment = { DB_URL = "mysql://spin:spin@localhost/dev" }`
+    #[serde(default, skip_serializing_if = "Map::is_empty")]
+    pub(crate) environment: Map<String, String>,
+
+    /// Wasm Component Model imports to be overridden in this profile.
+    /// Dependencies specified in the default profile will still be composed
+    /// if not overridden here.
+    ///
+    /// Learn more: https://spinframework.dev/writing-apps#using-component-dependencies
+    #[serde(default, skip_serializing_if = "ComponentDependencies::is_empty")]
+    pub(crate) dependencies: ComponentDependencies,
+
+    /// The command or commands for building the component in non-default profiles.
+    /// If a component has no special build instructions for a profile, the
+    /// default build command is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) build: Option<ComponentProfileBuildOverride>,
+}
+
+/// Customisations for a Spin component build in a non-default profile.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ComponentProfileBuildOverride {
+    /// The command or commands to build the component in a named profile. If multiple commands
+    /// are specified, they are run sequentially from left to right.
+    ///
+    /// Example: `build.command = "cargo build"`
+    ///
+    /// Learn more: https://spinframework.dev/build#setting-up-for-spin-build
+    pub(crate) command: super::common::Commands,
 }
 
 /// Component dependencies
@@ -797,6 +869,7 @@ mod tests {
             tool: Map::new(),
             dependencies_inherit_configuration: false,
             dependencies: Default::default(),
+            profile: Default::default(),
         }
     }
 
@@ -988,5 +1061,219 @@ mod tests {
         .unwrap()
         .validate()
         .is_err());
+    }
+
+    fn normalized_component(
+        manifest: &AppManifest,
+        component: &str,
+        profile: Option<&str>,
+    ) -> Component {
+        use crate::normalize::normalize_manifest;
+
+        let id =
+            KebabId::try_from(component.to_owned()).expect("component ID should have been kebab");
+
+        let mut manifest = manifest.clone();
+        normalize_manifest(&mut manifest, profile).expect("should have normalised");
+        manifest
+            .components
+            .get(&id)
+            .expect("should have compopnent with id profile-test")
+            .clone()
+    }
+
+    #[test]
+    fn profiles_override_source() {
+        let manifest = AppManifest::deserialize(toml! {
+            spin_manifest_version = 2
+            [application]
+            name = "trigger-configs"
+            [[trigger.fake]]
+            component = "profile-test"
+            [component.profile-test]
+            source = "original"
+            [component.profile-test.profile.fancy]
+            source = "fancy-schmancy"
+        })
+        .expect("manifest should be valid");
+
+        let id = "profile-test";
+
+        let component = normalized_component(&manifest, id, None);
+        assert!(matches!(&component.source, ComponentSource::Local(p) if p == "original"));
+
+        let component = normalized_component(&manifest, id, Some("fancy"));
+        assert!(matches!(&component.source, ComponentSource::Local(p) if p == "fancy-schmancy"));
+
+        let component = normalized_component(&manifest, id, Some("non-existent"));
+        assert!(matches!(&component.source, ComponentSource::Local(p) if p == "original"));
+    }
+
+    #[test]
+    fn profiles_override_build_command() {
+        let manifest = AppManifest::deserialize(toml! {
+            spin_manifest_version = 2
+            [application]
+            name = "trigger-configs"
+            [[trigger.fake]]
+            component = "profile-test"
+            [component.profile-test]
+            source = "original"
+            build.command = "buildme --release"
+            [component.profile-test.profile.fancy]
+            source = "fancy-schmancy"
+            build.command = ["buildme --fancy", "lintme"]
+        })
+        .expect("manifest should be valid");
+
+        let id = "profile-test";
+
+        let build = normalized_component(&manifest, id, None)
+            .build
+            .expect("should have default build");
+        assert_eq!(1, build.commands().len());
+        assert_eq!("buildme --release", build.commands().next().unwrap());
+
+        let build = normalized_component(&manifest, id, Some("fancy"))
+            .build
+            .expect("should have fancy build");
+        assert_eq!(2, build.commands().len());
+        assert_eq!("buildme --fancy", build.commands().next().unwrap());
+        assert_eq!("lintme", build.commands().nth(1).unwrap());
+
+        let build = normalized_component(&manifest, id, Some("non-existent"))
+            .build
+            .expect("should fall back to default build");
+        assert_eq!(1, build.commands().len());
+        assert_eq!("buildme --release", build.commands().next().unwrap());
+    }
+
+    #[test]
+    fn profiles_can_have_build_command_when_default_doesnt() {
+        let manifest = AppManifest::deserialize(toml! {
+            spin_manifest_version = 2
+            [application]
+            name = "trigger-configs"
+            [[trigger.fake]]
+            component = "profile-test"
+            [component.profile-test]
+            source = "original"
+            [component.profile-test.profile.fancy]
+            source = "fancy-schmancy"
+            build.command = ["buildme --fancy", "lintme"]
+        })
+        .expect("manifest should be valid");
+
+        let component = normalized_component(&manifest, "profile-test", None);
+        assert!(component.build.is_none(), "shouldn't have default build");
+
+        let component = normalized_component(&manifest, "profile-test", Some("fancy"));
+        assert!(component.build.is_some(), "should have fancy build");
+
+        let build = component.build.expect("should have fancy build");
+
+        assert_eq!(2, build.commands().len());
+        assert_eq!("buildme --fancy", build.commands().next().unwrap());
+        assert_eq!("lintme", build.commands().nth(1).unwrap());
+    }
+
+    #[test]
+    fn profiles_override_env_vars() {
+        let manifest = AppManifest::deserialize(toml! {
+            spin_manifest_version = 2
+            [application]
+            name = "trigger-configs"
+            [[trigger.fake]]
+            component = "profile-test"
+            [component.profile-test]
+            source = "original"
+            environment = { DB_URL = "pg://production" }
+            [component.profile-test.profile.fancy]
+            environment = { DB_URL = "pg://fancy", FANCINESS = "1" }
+        })
+        .expect("manifest should be valid");
+
+        let id = "profile-test";
+
+        let component = normalized_component(&manifest, id, None);
+
+        assert_eq!(1, component.environment.len());
+        assert_eq!(
+            "pg://production",
+            component
+                .environment
+                .get("DB_URL")
+                .expect("DB_URL should have been set")
+        );
+
+        let component = normalized_component(&manifest, id, Some("fancy"));
+
+        assert_eq!(2, component.environment.len());
+        assert_eq!(
+            "pg://fancy",
+            component
+                .environment
+                .get("DB_URL")
+                .expect("DB_URL should have been set")
+        );
+        assert_eq!(
+            "1",
+            component
+                .environment
+                .get("FANCINESS")
+                .expect("FANCINESS should have been set")
+        );
+    }
+
+    #[test]
+    fn profiles_dependencies() {
+        let manifest = AppManifest::deserialize(toml! {
+            spin_manifest_version = 2
+            [application]
+            name = "trigger-configs"
+            [[trigger.fake]]
+            component = "profile-test"
+            [component.profile-test]
+            source = "original"
+            [component.profile-test.dependencies]
+            "foo-bar" = "1.0.0"
+            [component.profile-test.profile.fancy]
+            dependencies = { "foo-bar" = { path = "local.wasm" }, "fancy-thing" = "1.2.3" }
+        })
+        .expect("manifest should be valid");
+
+        let id = "profile-test";
+
+        let component = normalized_component(&manifest, id, None);
+
+        assert_eq!(1, component.dependencies.inner.len());
+        assert!(matches!(
+            component
+                .dependencies
+                .inner
+                .get(&DependencyName::Plain(KebabId::try_from("foo-bar".to_owned()).unwrap()))
+                .expect("foo-bar dep should have been set"),
+            ComponentDependency::Version(v) if v == "1.0.0",
+        ));
+
+        let component = normalized_component(&manifest, id, Some("fancy"));
+
+        assert_eq!(2, component.dependencies.inner.len());
+        assert!(matches!(
+            component
+                .dependencies
+                .inner
+                .get(&DependencyName::Plain(KebabId::try_from("foo-bar".to_owned()).unwrap()))
+                .expect("foo-bar dep should have been set"),
+            ComponentDependency::Local { path, .. } if path == &PathBuf::from("local.wasm"),
+        ));
+        assert!(matches!(
+            component
+                .dependencies
+                .inner
+                .get(&DependencyName::Plain(KebabId::try_from("fancy-thing".to_owned()).unwrap()))
+                .expect("fancy-thing dep should have been set"),
+            ComponentDependency::Version(v) if v == "1.2.3",
+        ));
     }
 }

--- a/crates/manifest/tests/ui.rs
+++ b/crates/manifest/tests/ui.rs
@@ -45,6 +45,6 @@ fn run_v1_to_v2_test(input: &Path) -> Result<String, Failed> {
 
 fn run_normalization_test(input: impl AsRef<Path>) -> Result<String, Failed> {
     let mut manifest = spin_manifest::manifest_from_file(input)?;
-    normalize_manifest(&mut manifest)?;
+    normalize_manifest(&mut manifest, None)?;
     Ok(toml::to_string(&manifest).expect("serialization should work"))
 }

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -130,6 +130,7 @@ impl Client {
     pub async fn push(
         &mut self,
         manifest_path: &Path,
+        profile: Option<&str>,
         reference: impl AsRef<str>,
         annotations: Option<BTreeMap<String, String>>,
         infer_annotations: InferPredefinedAnnotations,
@@ -148,6 +149,7 @@ impl Client {
         let locked = spin_loader::from_file(
             manifest_path,
             FilesMountStrategy::Copy(working_dir.path().into()),
+            profile,
             None,
         )
         .await?;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -25,6 +25,11 @@ pub struct BuildCommand {
     )]
     pub app_source: Option<PathBuf>,
 
+    /// The build profile to build. The default is the anonymous profile (usually
+    /// the release build).
+    #[clap(long)]
+    pub profile: Option<String>,
+
     /// Component ID to build. This can be specified multiple times. The default is all components.
     #[clap(short = 'c', long)]
     pub component_id: Vec<String>,
@@ -55,6 +60,7 @@ impl BuildCommand {
 
         spin_build::build(
             &manifest_file,
+            self.profile(),
             &self.component_id,
             self.target_checking(),
             None,
@@ -82,5 +88,9 @@ impl BuildCommand {
         } else {
             spin_build::TargetChecking::Check
         }
+    }
+
+    fn profile(&self) -> Option<&str> {
+        self.profile.as_deref()
     }
 }

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -79,6 +79,11 @@ pub struct UpCommand {
     )]
     pub registry_source: Option<String>,
 
+    /// The build profile to run. The default is the anonymous profile (usually
+    /// the release build).
+    #[clap(long)]
+    pub profile: Option<String>,
+
     /// Ignore server certificate errors from a registry
     #[clap(
         name = INSECURE_OPT,
@@ -169,6 +174,8 @@ impl UpCommand {
             .context("Could not canonicalize working directory")?;
 
         let resolved_app_source = self.resolve_app_source(&app_source, &working_dir).await?;
+        resolved_app_source.ensure_profile(self.profile())?;
+
         if self.help {
             let trigger_cmds =
                 trigger_commands_for_trigger_types(resolved_app_source.trigger_types())
@@ -191,8 +198,11 @@ impl UpCommand {
         }
 
         if self.build {
-            app_source.build(&self.cache_dir).await?;
+            app_source.build(self.profile(), &self.cache_dir).await?;
+        } else {
+            app_source.warn_if_not_latest_build(self.profile());
         }
+
         let mut locked_app = self
             .load_resolved_app_source(resolved_app_source, &working_dir)
             .await
@@ -501,14 +511,19 @@ impl UpCommand {
                 } else {
                     FilesMountStrategy::Copy(working_dir.join("assets"))
                 };
-                spin_loader::from_file(&manifest_path, files_mount_strategy, self.cache_dir.clone())
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "Failed to load manifest from {}",
-                            quoted_path(&manifest_path)
-                        )
-                    })
+                spin_loader::from_file(
+                    &manifest_path,
+                    files_mount_strategy,
+                    self.profile(),
+                    self.cache_dir.clone(),
+                )
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to load manifest from {}",
+                        quoted_path(&manifest_path)
+                    )
+                })
             }
             ResolvedAppSource::OciRegistry { locked_app } => Ok(locked_app),
             ResolvedAppSource::BareWasm { wasm_path } => spin_loader::from_wasm_file(&wasm_path)
@@ -555,6 +570,10 @@ impl UpCommand {
         }
 
         groups
+    }
+
+    fn profile(&self) -> Option<&str> {
+        self.profile.as_deref()
     }
 }
 

--- a/src/commands/up/app_source.rs
+++ b/src/commands/up/app_source.rs
@@ -56,10 +56,20 @@ impl AppSource {
         }
     }
 
-    pub async fn build(&self, cache_root: &Option<PathBuf>) -> anyhow::Result<()> {
+    pub async fn build(
+        &self,
+        profile: Option<&str>,
+        cache_root: &Option<PathBuf>,
+    ) -> anyhow::Result<()> {
         match self {
-            Self::File(path) => spin_build::build_default(path, cache_root.clone()).await,
+            Self::File(path) => spin_build::build_default(path, profile, cache_root.clone()).await,
             _ => Ok(()),
+        }
+    }
+
+    pub fn warn_if_not_latest_build(&self, profile: Option<&str>) {
+        if let Self::File(path) = self {
+            spin_build::warn_if_not_latest_build(path, profile);
         }
     }
 }
@@ -115,5 +125,12 @@ impl ResolvedAppSource {
         };
 
         types.into_iter().collect()
+    }
+
+    pub fn ensure_profile(&self, profile: Option<&str>) -> anyhow::Result<()> {
+        match self {
+            Self::File { manifest, .. } => manifest.ensure_profile(profile),
+            _ => Ok(()),
+        }
     }
 }

--- a/src/commands/watch/buildifier.rs
+++ b/src/commands/watch/buildifier.rs
@@ -7,6 +7,7 @@ use super::uppificator::Pause;
 pub(crate) struct Buildifier {
     pub spin_bin: PathBuf,
     pub manifest: PathBuf,
+    pub profile: Option<String>,
     pub clear_screen: bool,
     pub has_ever_built: bool,
     pub watched_changes: tokio::sync::watch::Receiver<Uuid>, // TODO: refine which component(s) a change affects
@@ -49,6 +50,9 @@ impl Buildifier {
         loop {
             let mut cmd = tokio::process::Command::new(&self.spin_bin);
             cmd.arg("build").arg("-f").arg(&self.manifest);
+            if let Some(profile) = &self.profile {
+                cmd.arg("--profile").arg(profile);
+            }
             let mut child = cmd.group_spawn()?;
 
             tokio::select! {

--- a/src/commands/watch/uppificator.rs
+++ b/src/commands/watch/uppificator.rs
@@ -6,6 +6,7 @@ pub(crate) struct Uppificator {
     pub spin_bin: PathBuf,
     pub up_args: Vec<String>,
     pub manifest: PathBuf,
+    pub profile: Option<String>,
     pub clear_screen: bool,
     pub watched_changes: tokio::sync::watch::Receiver<Uuid>,
     pub pause_feed: tokio::sync::mpsc::Receiver<Pause>,
@@ -42,6 +43,9 @@ impl Uppificator {
                 .arg("-f")
                 .arg(&self.manifest)
                 .args(&self.up_args);
+            if let Some(profile) = &self.profile {
+                cmd.arg("--profile").arg(profile);
+            }
             let mut child = match cmd.group_spawn() {
                 Ok(ch) => ch,
                 Err(e) => {

--- a/tests/testing-framework/src/runtimes/in_process_spin.rs
+++ b/tests/testing-framework/src/runtimes/in_process_spin.rs
@@ -100,6 +100,7 @@ async fn initialize_trigger(
         env.path().join("spin.toml"),
         spin_loader::FilesMountStrategy::Direct,
         None,
+        None,
     )
     .await?;
 


### PR DESCRIPTION
Incomplete draft for discussion.  This diverges from [Till's draft SIP](https://github.com/spinframework/spin/pull/3075) in some ways, mostly cosmetic and open to change; but also somewhat in preferring to constrain variation between profiles.

Example:

```toml
[component.build-profile-test]
source = "target/wasm32-wasip1/release/build_profile_test.wasm"
profile.debug.source = "target/wasm32-wasip1/debug/build_profile_test.wasm"
allowed_outbound_hosts = []
[component.build-profile-test.build]
command = "cargo build --target wasm32-wasip1 --release"
profile.debug.command = "cargo build --target wasm32-wasip1"
watch = ["src/**/*.rs", "Cargo.toml"]
```

This proposal uses a partial approach to the possible "am I running the same profile I built" problem.  When you do a build, it records the built profile in a "last profile built" file.  When you do a run, it checks if the profile being run matches the last built one, and prints a warning if not.  This is certainly far from reliable: if you build both debug and release profiles, and then run both of them, you'll get a spurious warning.

If we're okay with this as a basis for further development, we need to look at what other fields should be allowed to vary by profile, e.g.:

* `allowed_outbound_hosts` - you should be able to specify additional hosts.  I'd be inclined not to say you can specify an entirely separate collection, because the 90% case is going to "I need to do sockets to a debugger."  (Things like "I want to talk to the dev database not the prod database" should be handled by variables.)
* `dependencies` - should be able to replace a dependency, e.g. to use its debug build or a stub/mock.  If I squint I can imagine use cases for extra dependencies, in case a component has debug-only imports, not sure
* `environment` - should be able to replace an EV or set additional EVs
* KV/SQLite/LLM - my inclination that varying these by profile is probably an anti-pattern but I am open to being talked round if someone has a concrete use case - otherwise propose deferring to later
* `variables` - not clear why you would, I guess there could be a knob to control profile-specific behaviour? Propose defer
* `files` - not clear why you would, but I guess I could imagine a special build needing some additional asset?  Again my inclination would be to defer until someone needs it

Possible further features:

* whole components being conditional on the profile - e.g. include KV explorer only in certain build configs
* this implies conditional triggers and I am not sure how much I love where this is going

Anyway here it is for discussion, please be gentle with me
