### PR TITLE
outbound-http: Improve test assertion logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8517,6 +8517,7 @@ dependencies = [
  "reqwest 0.12.9",
  "rustls 0.23.18",
  "serde",
+ "spin-common",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
  "spin-factors",

--- a/crates/common/src/assert.rs
+++ b/crates/common/src/assert.rs
@@ -1,0 +1,33 @@
+//! Assertion macros.
+
+/// Asserts that the expression matches the pattern.
+///
+/// This is equivalent to `assert!(matches!(...))` except that it produces nicer
+/// errors.
+#[macro_export]
+macro_rules! assert_matches {
+    ($expr:expr, $pat:pat $(,)?) => {{
+        let val = $expr;
+        assert!(
+            matches!(val, $pat),
+            "expected {val:?} to match {}",
+            stringify!($pat),
+        )
+    }};
+}
+
+/// Asserts that the expression does not match the pattern.
+///
+/// This is equivalent to `assert!(!matches!(...))` except that it produces
+/// nicer errors.
+#[macro_export]
+macro_rules! assert_not_matches {
+    ($expr:expr, $pat:pat $(,)?) => {{
+        let val = $expr;
+        assert!(
+            !matches!(val, $pat),
+            "expected {val:?} to NOT match {}",
+            stringify!($pat),
+        )
+    }};
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -9,6 +9,7 @@
 // - Code should have at least 2 dependents
 
 pub mod arg_parser;
+pub mod assert;
 pub mod data_dir;
 pub mod paths;
 pub mod sha256;

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -27,6 +27,7 @@ wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 
 [dev-dependencies]
+spin-common = { path = "../common" }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factors-test = { path = "../factors-test" }
 


### PR DESCRIPTION
I give up; here's some better logging instead.

Sneakily introduce assert_matches! and assert_not_matches! macros.