### PR TITLE
Static HTTP responses

### DIFF
--- a/crates/trigger-http/src/headers.rs
+++ b/crates/trigger-http/src/headers.rs
@@ -187,7 +187,14 @@ mod tests {
             .uri(req_uri)
             .body("")?;
 
-        let router = Router::build("/", [("DUMMY", &trigger_route.into())], None)?;
+        let router = Router::build(
+            "/",
+            [(
+                &spin_http::routes::TriggerLookupKey::Component("DUMMY".into()),
+                &trigger_route.into(),
+            )],
+            None,
+        )?;
         let route_match = router.route("/foo/bar")?;
 
         let default_headers = compute_default_headers(req.uri(), host, &route_match, client_addr)?;
@@ -243,7 +250,14 @@ mod tests {
             .uri(req_uri)
             .body("")?;
 
-        let router = Router::build("/", [("DUMMY", &trigger_route.into())], None)?;
+        let router = Router::build(
+            "/",
+            [(
+                &spin_http::routes::TriggerLookupKey::Component("DUMMY".into()),
+                &trigger_route.into(),
+            )],
+            None,
+        )?;
         let route_match = router.route("/foo/42/bar")?;
 
         let default_headers = compute_default_headers(req.uri(), host, &route_match, client_addr)?;

--- a/crates/trigger-http/src/spin.rs
+++ b/crates/trigger-http/src/spin.rs
@@ -20,7 +20,7 @@ use crate::{
 pub struct SpinHttpExecutor;
 
 impl HttpExecutor for SpinHttpExecutor {
-    #[instrument(name = "spin_trigger_http.execute_wasm", skip_all, err(level = Level::INFO), fields(otel.name = format!("execute_wasm_component {}", route_match.component_id())))]
+    #[instrument(name = "spin_trigger_http.execute_wasm", skip_all, err(level = Level::INFO), fields(otel.name = format!("execute_wasm_component {}", route_match.lookup_key().to_string())))]
     async fn execute<F: RuntimeFactors>(
         &self,
         instance_builder: TriggerInstanceBuilder<'_, F>,
@@ -28,7 +28,10 @@ impl HttpExecutor for SpinHttpExecutor {
         req: Request<Body>,
         client_addr: SocketAddr,
     ) -> Result<Response<Body>> {
-        let component_id = route_match.component_id();
+        let spin_http::routes::TriggerLookupKey::Component(component_id) = route_match.lookup_key()
+        else {
+            anyhow::bail!("INCONCEIVABLE");
+        };
 
         tracing::trace!("Executing request using the Spin executor for component {component_id}");
 

--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -19,7 +19,7 @@ pub struct WagiHttpExecutor<'a> {
 }
 
 impl HttpExecutor for WagiHttpExecutor<'_> {
-    #[instrument(name = "spin_trigger_http.execute_wagi", skip_all, err(level = Level::INFO), fields(otel.name = format!("execute_wagi_component {}", route_match.component_id())))]
+    #[instrument(name = "spin_trigger_http.execute_wagi", skip_all, err(level = Level::INFO), fields(otel.name = format!("execute_wagi_component {}", route_match.lookup_key().to_string())))]
     async fn execute<F: RuntimeFactors>(
         &self,
         mut instance_builder: TriggerInstanceBuilder<'_, F>,
@@ -27,7 +27,10 @@ impl HttpExecutor for WagiHttpExecutor<'_> {
         req: Request<Body>,
         client_addr: SocketAddr,
     ) -> Result<Response<Body>> {
-        let component = route_match.component_id();
+        let spin_http::routes::TriggerLookupKey::Component(component) = route_match.lookup_key()
+        else {
+            anyhow::bail!("INCONCEIVABLE");
+        };
 
         tracing::trace!(
             "Executing request using the Wagi executor for component {}",

--- a/crates/trigger-http/src/wasi.rs
+++ b/crates/trigger-http/src/wasi.rs
@@ -23,7 +23,7 @@ pub struct WasiHttpExecutor<'a> {
 }
 
 impl HttpExecutor for WasiHttpExecutor<'_> {
-    #[instrument(name = "spin_trigger_http.execute_wasm", skip_all, err(level = Level::INFO), fields(otel.name = format!("execute_wasm_component {}", route_match.component_id())))]
+    #[instrument(name = "spin_trigger_http.execute_wasm", skip_all, err(level = Level::INFO), fields(otel.name = format!("execute_wasm_component {}", route_match.lookup_key().to_string())))]
     async fn execute<F: RuntimeFactors>(
         &self,
         instance_builder: TriggerInstanceBuilder<'_, F>,
@@ -31,7 +31,10 @@ impl HttpExecutor for WasiHttpExecutor<'_> {
         mut req: Request<Body>,
         client_addr: SocketAddr,
     ) -> Result<Response<Body>> {
-        let component_id = route_match.component_id();
+        let spin_http::routes::TriggerLookupKey::Component(component_id) = route_match.lookup_key()
+        else {
+            anyhow::bail!("INCONCEIVABLE");
+        };
 
         tracing::trace!("Executing request using the Wasi executor for component {component_id}");
 

--- a/tests/testcases/static-response/spin.toml
+++ b/tests/testcases/static-response/spin.toml
@@ -1,0 +1,25 @@
+spin_manifest_version = 2
+
+[application]
+name = "static-response"
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+version = "0.1.0"
+
+[[trigger.http]]
+route = "/users/:userid/..."
+component = "http-routing"
+
+[component.http-routing]
+source = "%{source=http-routing}"
+
+[[trigger.http]]
+route = "/..."
+static_response = { status_code = 404, body = "not found" }
+
+[[trigger.http]]
+route = "/default-code"
+static_response = { body = "should be 200" }
+
+[[trigger.http]]
+route = "/bob"
+static_response = { status_code = 302, headers = { location = "/users/bob" } }


### PR DESCRIPTION
Fixes #3242.  Example `spin.toml` fragment:

```toml
[[trigger.http]]
route = "/test"
static_response = { body = "hello!\n\nand more hello!\n" }

[[trigger.http]]
route = "/fermyon-me-up"
static_response = { status_code = 302, headers = { location = "https://www.fermyon.com" } }
```

This is, in some ways, a bit unwieldy, because the assumption that a trigger maps to a component is fairly deeply embedded.  We seem to need a new handler type that can never be executed, and there is some faff around assigning a fake component ID, because everything currently depends on component IDs for lookup.  If folks feel we should attempt a larger refactor then I can give it a go before fleeing into the hills.

An implication of this is that applications with static responses can't reliably interact with selective deployment (`spin up -c`).  I believe that `spin up -c` retains triggers associated with the selected components, and static response triggers are associated with no component.  An alternative design that would avoid this would be to have static responses as a pseudo-component type rather than a trigger behaviour (that is, the trigger still points to a named component, but the component is... not a component! ha ha!) - however, this feels extremely can-of-worms-tastic, as the component schema is embedded fairly deeply through Spin.  Again, I can investigate it if that's something we want to explore.

I did consider synthesising an in-memory (or temporary filesystem) component that would respond with the static response, but that seemed like it just created large amounts of hairiness elsewhere.  However, it would allow applications that used static responses to be deployed to existing hosts.

As it is, I think we need a `host_requirements` entry in the lockfile to ensure that hosts understand the new field.  (And this field is app level because we don't have trigger-level `must_understand`, so it won't be bypassed by selective deployment, even though selective deployment exterminates static response triggers.)  Although maybe I am wrong because this is a schema change so hosts will automatically fail by syntax rather than needing to be warned about semantics?  I've put it in a separate commit in case we can back it out.

Draft because I need to write tests because I always forget to do those first, but ready for initial feedback on the approach and on the host-requirements stuff.
