### PR TITLE
Bump `spin-sdk` version in rust templates to `5.0.0`

### DIFF
--- a/templates/http-rust/content/Cargo.toml.tmpl
+++ b/templates/http-rust/content/Cargo.toml.tmpl
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-spin-sdk = "3.1.0"
+spin-sdk = "5.0.0"
 
 [workspace]

--- a/templates/redis-rust/content/Cargo.toml.tmpl
+++ b/templates/redis-rust/content/Cargo.toml.tmpl
@@ -15,6 +15,6 @@ anyhow = "1"
 # Crate to simplify working with bytes.
 bytes = "1"
 # The Spin SDK.
-spin-sdk = "3.1.0"
+spin-sdk = "5.0.0"
 
 [workspace]


### PR DESCRIPTION
This PR updates the `spin-sdk` dependency to `5.0.0` in both rust templates `http-rust` & `redis-rust`.
