### PR TITLE
Workflow to bump rust templates sdk dependency

### DIFF
--- a/.github/workflows/rust-sdk-release.yml
+++ b/.github/workflows/rust-sdk-release.yml
@@ -1,0 +1,39 @@
+name: Bump Spin Rust Templates SDK Dependency
+
+on:
+  repository_dispatch:
+    types:
+      - rust-sdk-release
+
+jobs:
+  create-pr:
+    name: Create PR with Spin Rust Templates SDK Dependency Bump
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump Rust Templates SDK Dependency
+        shell: bash
+        run: ./scripts/bump-rust-template-sdk.sh ${{ github.event.client_payload.version }}
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "chore(rust-templates): bump Spin Rust SDK to ${{ github.event.client_payload.version }}"
+          title: "chore(rust-templates): bump Spin Rust SDK to ${{ github.event.client_payload.version }}"
+          body: Update the Spin Rust Templates SDK dependency to ${{ github.event.client_payload.version }}
+          branch: bump-spin-rust-sdk-${{ github.event.client_payload.version }}
+          base: main
+          delete-branch: true
+          committer: spinframeworkbot <202838904+spinframeworkbot@users.noreply.github.com>
+          author: spinframeworkbot <202838904+spinframeworkbot@users.noreply.github.com>
+          signoff: true
+          token: ${{ secrets.PAT }}

--- a/scripts/bump-rust-template-sdk.sh
+++ b/scripts/bump-rust-template-sdk.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This script updates the `spin-sdk` dependency in Rust template
+# `Cargo.toml.tmpl` files under the `templates` directory.
+set -euo pipefail
+
+VERSION=$1
+
+# -i syntax differs between GNU and Mac sed; this usage is supported by both
+SED_INPLACE='sed -i.bak'
+
+# cleanup
+trap 'find templates -name "*.bak" -delete' EXIT
+
+usage() {
+  echo "Usage: $0 <VERSION>"
+  echo "Updates the Rust templates SDK dependency to the specified version"
+  echo "Example: $0 6.0.0"
+}
+
+if [[ $# -ne 1 ]]
+then
+  usage
+  exit 1
+fi
+
+# Ensure version is an 'official' release
+if [[ ! "${VERSION}" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]
+then
+  echo "VERSION doesn't match [0-9]+.[0-9]+.[0-9]+ and may be a prerelease; skipping."
+  exit 1
+fi
+
+
+# Update the version in the Cargo.toml.tmpl files for each Rust template
+find templates -type f -path "templates/*-rust/content/Cargo.toml.tmpl" -exec $SED_INPLACE "/^\[dependencies\]/,/^\[/ s/^spin-sdk = \".*\"/spin-sdk = \"${VERSION}\"/" {} +


### PR DESCRIPTION
The other half of https://github.com/spinframework/spin-rust-sdk/pull/84 so we don't forget to bump the rust templates when an sdk is released. A good follow up would be to extend this to support other languages (alternatively we could have one of these for the finite set of sdk languages we support).