### PR TITLE
trigger-http: Fix otel context propagation

### DIFF
--- a/crates/trigger-http/src/wasi.rs
+++ b/crates/trigger-http/src/wasi.rs
@@ -93,7 +93,6 @@ impl HttpExecutor for WasiHttpExecutor<'_> {
             HandlerType::Wagi(_) => unreachable!("should have used WagiExecutor instead"),
         };
 
-        let span = tracing::debug_span!("execute_wasi");
         let handle = task::spawn(
             async move {
                 let result = match handler {
@@ -101,21 +100,21 @@ impl HttpExecutor for WasiHttpExecutor<'_> {
                         handler
                             .wasi_http_incoming_handler()
                             .call_handle(&mut store, request, response)
-                            .instrument(span)
+                            .in_current_span()
                             .await
                     }
                     Handler::Handler2023_10_18(handler) => {
                         handler
                             .wasi_http0_2_0_rc_2023_10_18_incoming_handler()
                             .call_handle(&mut store, request, response)
-                            .instrument(span)
+                            .in_current_span()
                             .await
                     }
                     Handler::Handler2023_11_10(handler) => {
                         handler
                             .wasi_http0_2_0_rc_2023_11_10_incoming_handler()
                             .call_handle(&mut store, request, response)
-                            .instrument(span)
+                            .in_current_span()
                             .await
                     }
                 };


### PR DESCRIPTION
The debug_span! was disabled by default tracing config, preventing otel context from being propagated through it.

Couldn't figure out how to push to Lann's PR so I'm hijacking it with this PR.