### PR TITLE
chore: bump redis to v0.32.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,9 +994,9 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.5.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
 dependencies = [
  "fastrand 2.2.0",
 ]
@@ -2503,7 +2503,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4079,7 +4079,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -4214,7 +4214,7 @@ dependencies = [
  "http-body 1.0.1",
  "hyper 1.5.0",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -5401,7 +5401,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_json",
- "socket2",
+ "socket2 0.5.7",
  "thiserror 2.0.12",
  "tokio",
  "tokio-native-tls",
@@ -6771,7 +6771,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.18",
- "socket2",
+ "socket2 0.5.7",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
@@ -6803,7 +6803,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.7",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -7005,36 +7005,14 @@ checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
 name = "redis"
-version = "0.25.4"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
-dependencies = [
- "async-trait",
- "bytes",
- "combine",
- "futures-util",
- "itoa",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "sha1_smol",
- "socket2",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "redis"
-version = "0.29.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc42f3a12fd4408ce64d8efef67048a924e543bd35c6591c0447fda9054695f"
+checksum = "7cd3650deebc68526b304898b192fa4102a4ef0b9ada24da096559cb60e0eef8"
 dependencies = [
  "arc-swap",
  "backon",
  "bytes",
+ "cfg-if",
  "combine",
  "futures-channel",
  "futures-util",
@@ -7045,7 +7023,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2",
+ "socket2 0.6.0",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -8201,6 +8179,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spdx"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8276,7 +8264,7 @@ dependencies = [
  "openssl",
  "path-absolutize",
  "pretty_assertions",
- "redis 0.29.5",
+ "redis",
  "regex",
  "reqwest 0.12.9",
  "rpassword",
@@ -8627,7 +8615,7 @@ name = "spin-factor-outbound-redis"
 version = "3.5.0-pre0"
 dependencies = [
  "anyhow",
- "redis 0.25.4",
+ "redis",
  "spin-core",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
@@ -8796,7 +8784,7 @@ name = "spin-key-value-redis"
 version = "3.5.0-pre0"
 dependencies = [
  "anyhow",
- "redis 0.29.5",
+ "redis",
  "serde",
  "spin-core",
  "spin-factor-key-value",
@@ -9218,7 +9206,7 @@ version = "3.5.0-pre0"
 dependencies = [
  "anyhow",
  "futures",
- "redis 0.29.5",
+ "redis",
  "serde",
  "spin-factor-variables",
  "spin-factors",
@@ -9871,7 +9859,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.7",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -9917,7 +9905,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.8.5",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-util",
  "whoami",
@@ -10048,7 +10036,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.3",
- "socket2",
+ "socket2 0.5.7",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ lazy_static = "1.5"
 path-absolutize = "3"
 quote = "1"
 rand = "0.9"
-redis = "0.29"
+redis = "0.32.5"
 regex = "1"
 reqwest = { version = "0.12", features = ["stream", "blocking"] }
 rusqlite = "0.34"

--- a/crates/factor-outbound-redis/Cargo.toml
+++ b/crates/factor-outbound-redis/Cargo.toml
@@ -6,7 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-redis = { version = "0.25", features = ["tokio-comp", "tokio-native-tls-comp", "aio"] }
+redis = { workspace = true , features = ["tokio-comp", "tokio-native-tls-comp", "aio"] }
 spin-core = { path = "../core" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }


### PR DESCRIPTION
Bumps the dependency. Many of the `Value` types were renamed. For example `Value::Status` was renamed to `Value::SimpleString` in https://github.com/redis-rs/redis-rs/commit/30d573072136a0d1bde9866c972949f86ae53b16