### PR TITLE
Make KeyValueRedis type public

### DIFF
--- a/crates/key-value-redis/src/lib.rs
+++ b/crates/key-value-redis/src/lib.rs
@@ -2,7 +2,7 @@ mod store;
 
 use serde::Deserialize;
 use spin_factor_key_value::runtime_config::spin::MakeKeyValueStore;
-use store::KeyValueRedis;
+pub use store::KeyValueRedis;
 
 /// A key-value store that uses Redis as the backend.
 #[derive(Default)]


### PR DESCRIPTION
Enables runtime implementors to pull in and configure this factor without needing to deserialize from a `runtime-config.toml` and use the `MakeKeyValueStore` abstraction.