### PR TITLE
trigger-http: Don't panic on unknown service chaining component ID

### DIFF
--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -309,7 +309,10 @@ impl<F: RuntimeFactors> HttpServer<F> {
         outbound_http.set_request_interceptor(OutboundHttpInterceptor::new(self.clone()))?;
 
         // Prepare HTTP executor
-        let trigger_config = self.component_trigger_configs.get(component_id).unwrap();
+        let trigger_config = self
+            .component_trigger_configs
+            .get(component_id)
+            .with_context(|| format!("unknown component ID {component_id:?}"))?;
         let handler_type = self.component_handler_types.get(component_id).unwrap();
         let executor = trigger_config
             .executor


### PR DESCRIPTION
With `allowed_outbound_hosts = ["*.spin.internal"]` we don't have a component ID to validate until the actual service chaining request is attempted. In the non-service-chaining path the request ID must exist because it was routed to, so we `unwrap`ped instead of erroring.