### PR TITLE
Expand wildcard service chaining during `spin up`

### DIFF
--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -94,6 +94,12 @@ impl Factor for OutboundNetworkingFactor {
             .instance_builder::<VariablesFactor>()?
             .expression_resolver()
             .clone();
+        let component_ids = ctx
+            .app_component()
+            .app
+            .components()
+            .map(|c| c.id().to_string())
+            .collect::<Vec<_>>();
         let allowed_hosts_future = async move {
             let prepared = resolver.prepare().await.inspect_err(|err| {
                 tracing::error!(
@@ -101,7 +107,7 @@ impl Factor for OutboundNetworkingFactor {
                     "Error resolving variables when checking request against allowed outbound hosts",
                 );
             })?;
-            AllowedHostsConfig::parse(&hosts, &prepared).inspect_err(|err| {
+            AllowedHostsConfig::parse(&hosts, &prepared, &component_ids).inspect_err(|err| {
                 tracing::error!(
                     %err, "error.type" = "invalid_allowed_hosts",
                     "Error parsing allowed outbound hosts",


### PR DESCRIPTION
Fixes #3264.

There are several ways to approach this.  I don't much love this but adopted it in order to preserve the error in app splitting scenarios.

An alternative would be to do it as part of TOML manifest normalisation before we even get to the locking stage: this would result in OCI artifacts having the wildcard pre-expanded which I dunno if it's a good thing or a bad thing or just a thing.  However it would result in app splitting giving an error like "component alice service chains to component bob which doesn't exist," which seems less clear and helpful than "you can't use a wildcard if you're gonna app split."

(Note that even if we did pre-expand OCI artifacts we'd still need to either do this as well, or deal with the possibility of wildcards at run time trigger, because existing OCI artifacts could contain star chains.)

Anyway open to feedback and discussion as ever
