### PR TITLE
chore(ci): Restrict use of rust-cache to longest-running jobs

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -114,6 +114,7 @@ runs:
       if: ${{ inputs.rust-cache == 'true' }}
       with:
         shared-key: "${{ runner.os }}-full-${{ hashFiles('./Cargo.lock', './os-release') }}"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     ## Install nomad
     - name: Install nomad

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           rust: true
           rust-wasm: true
-          rust-cache: true
 
       - name: Run lints on main code
         run: BUILD_SPIN_EXAMPLES=0 make lint
@@ -64,7 +63,6 @@ jobs:
         with:
           rust: true
           rust-wasm: true
-          rust-cache: true
 
       - name: Cargo Build
         run: cargo build --workspace --release --all-targets --features openssl/vendored --features all-tests
@@ -99,7 +97,6 @@ jobs:
         with:
           rust: true
           rust-cross: true
-          rust-cache: true
 
       - name: Cargo Build
         run: cross build --target ${{ matrix.config.target }} --release --features openssl/vendored
@@ -127,7 +124,7 @@ jobs:
         with:
           rust: true
           rust-wasm: true
-          rust-cache: true
+          rust-cache: "${{ matrix.os == 'windows-latest' }} || ${{ matrix.os == 'macos-13' }}"
           openssl-windows: "${{ matrix.os == 'windows-latest' }}"
 
       - name: Cargo Build
@@ -156,7 +153,6 @@ jobs:
         with:
           rust: true
           rust-wasm: true
-          rust-cache: true
           nomad: true
 
       - name: Check disk space (Before)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -331,7 +331,6 @@ jobs:
         with:
           rust: true
           rust-cross: true
-          rust-cache: true
 
       - name: Cargo Build
         run: cross build --target ${{ matrix.config.target }} --release --features openssl/vendored


### PR DESCRIPTION
Spin CI currently always exceeds the 10GB cache quota. That means that between creating a cache entry and trying to use it, it has pretty much always been LRU evicted, so we pay for creating the entries, and never benefit from them.

Or rather, that would be the situation if GitHub strictly enforced the cache limits. They apparently are planning on doing so starting in mid-October. Currently, we sometimes get eviction before any use, sometimes not.

This change makes it so that only the two longest-running jobs use the cache, and that it's only saved on `main`. In combination, we should get much better hit rates for those two jobs, which should hopefully mean that CI most of the time completes in a bit more than 30 minutes, instead of frequently taking close to an hour.