### PR TITLE
MacOS 13 retirement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-13, macos-14]
+        os: [windows-latest, macos-14]
     steps:
       - uses: actions/checkout@v3
 
@@ -124,7 +124,7 @@ jobs:
         with:
           rust: true
           rust-wasm: true
-          rust-cache: "${{ matrix.os == 'windows-latest' }} || ${{ matrix.os == 'macos-13' }}"
+          rust-cache: "${{ matrix.os == 'windows-latest' }}"
           openssl-windows: "${{ matrix.os == 'windows-latest' }}"
 
       - name: Cargo Build
@@ -245,14 +245,6 @@ jobs:
               extraArgs: "--features openssl/vendored --target aarch64-unknown-linux-gnu",
               target: "aarch64-unknown-linux-gnu",
               targetDir: "target/aarch64-unknown-linux-gnu/release",
-            }
-          - {
-              os: "macos-13",
-              arch: "amd64",
-              extension: "",
-              extraArgs: "",
-              target: "",
-              targetDir: "target/release",
             }
           - {
               os: "macos-14",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,14 +45,6 @@ jobs:
               targetDir: "target/aarch64-unknown-linux-gnu/release",
             }
           - {
-              os: "macos-13",
-              arch: "amd64",
-              extension: "",
-              extraArgs: "",
-              target: "",
-              targetDir: "target/release",
-            }
-          - {
               os: "macos-14",
               arch: "aarch64",
               extension: "",


### PR DESCRIPTION
GitHub is retiring its MacOS 13 runner.  The process will start in about a month: at that point, GitHub will start doing "brownouts" during which they will randomly fail jobs that use it.  Planned brownout periods are:

* November 4, 14:00 UTC - November 5, 00:00 UTC
* November 11, 14:00 UTC - November 12, 00:00 UTC 
* November 18, 14:00 UTC - November 19, 00:00 UTC   
* November 25, 14:00 UTC - November 26, 00:00 UTC

The image will be fully retired "by December 4th."

The first two periods are in the run-up or around Kubecon, which is a likely target time for releases.  We have had previous experience of trying to push out a release while a brownout OS was in play and well let's not do that again eh.

**The impact of this change as currently implemented will be that we do not ship MacOS x64 builds going forward.**  If we want to keep doing Mac x64 builds, GitHub says we can use the `macos-15-intel` runner, which will see us out another couple of years.  My inclination is to use this opportunity to drop Mac x64 now, so that if anyone is relying on it we find out about _before_ the MacOS 15 escape hatch closes for good.  But other folks may find that too aggressive.  If we would rather change this PR to move to the MacOS 15 runner then let me know and I can do that.
