### PR TITLE
Test reverting GH cache changes to see if there is any correlation with Ubuntu builds getting killed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         with:
           rust: true
           rust-wasm: true
-          rust-cache: true
+          # rust-cache: true
           nomad: true
 
       - name: Check disk space (Before)


### PR DESCRIPTION
We have been having a PLAGUE of Ubuntu builds getting killed without explanation by the GH action runner.

This is a test to see if the PLAGUE could possibly be correlated with the workflow cache changes in #3277.

DO NOT MERGE - the changes in #3277 are necessary for reasons explained there, this is just testing for correlation in the hope of getting a better understanding of what is happening

