### PR TITLE
Fix Ubuntu tests often failing first time...

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,7 @@ jobs:
         with:
           rust: true
           rust-wasm: true
+          rust-cache: true
           nomad: true
 
       - name: Check disk space (Before)


### PR DESCRIPTION
…hopefully.

This was the line that seemed to make the difference between green and red in #3296.  I'm creating a new PR so as to preserve the #3296 history while we evaluate/test, but also get a cleanish run to reassure myself that this does make the necessary difference.

If it does, @tschneidereit or other GH cache experts need to make a call on whether it's going to mess up our billing or whatever.  But the current situation is untenable so if this isn't an acceptable solution then we'll need to figure out what is.
