### PR TITLE
Make `spin deploy` breaking change warning more emphatic

### DIFF
--- a/crates/terminal/src/lib.rs
+++ b/crates/terminal/src/lib.rs
@@ -110,32 +110,32 @@ macro_rules! einfo {
 
 #[macro_export]
 macro_rules! cprint {
-    ($color:expr, $($arg:tt)*) => {
+    ($color:expr, $($arg:tt)*) => {{
         use std::io::Write;
         let mut out = $crate::ColorText::stdout($color);
         let _ = write!(out, $($arg)*);
         drop(out); // Reset colors
-    };
+    }};
 }
 
 #[macro_export]
 macro_rules! ceprint {
-    ($color:expr, $($arg:tt)*) => {
+    ($color:expr, $($arg:tt)*) => {{
         use std::io::Write;
         let mut out = $crate::ColorText::stderr($color);
         let _ = write!(out, $($arg)*);
-        drop(out); // Reset colors
-    };
+        drop(out); // Reset color}s
+    }};
 }
 
 #[macro_export]
 macro_rules! ceprintln {
-    ($color:expr, $($arg:tt)*) => {
+    ($color:expr, $($arg:tt)*) => {{
         use std::io::Write;
         let mut out = $crate::ColorText::stderr($color);
         let _ = writeln!(out, $($arg)*);
         drop(out); // Reset colors
-    };
+    }};
 }
 
 pub mod colors {

--- a/src/commands/cloud.rs
+++ b/src/commands/cloud.rs
@@ -60,7 +60,19 @@ fn deployment_plugin(cmd: &str) -> anyhow::Result<String> {
     match std::env::var(DEPLOY_PLUGIN_ENV) {
         Ok(v) => Ok(v),
         Err(std::env::VarError::NotPresent) => {
-            terminal::warn!("`spin {cmd}` will soon need to be told which deployment plugin to use.\nRun a plugin command (e.g. `spin {DEFAULT_DEPLOY_PLUGIN} {cmd}`), or set the `{DEPLOY_PLUGIN_ENV}` environment variable, instead.\nDefaulting to `{DEFAULT_DEPLOY_PLUGIN}` plugin.");
+            terminal::ceprintln!(terminal::colors::bold_red(), "******** IMPORTANT! ********");
+            terminal::ceprint!(terminal::colors::bold_red(), "Future breaking change: ");
+            eprintln!("`spin {cmd}` needs to be told which deployment plugin to use. Either:");
+            terminal::step!(
+                "*",
+                "Run a plugin command (e.g. `spin {DEFAULT_DEPLOY_PLUGIN} {cmd}`); or"
+            );
+            terminal::step!("*", "Set the `{DEPLOY_PLUGIN_ENV}` environment variable.");
+            eprintln!("For now, Spin will default to the `{DEFAULT_DEPLOY_PLUGIN}` plugin.");
+            terminal::ceprintln!(
+                terminal::colors::bold_red(),
+                "This will be a hard error in a future version."
+            );
             Ok(DEFAULT_DEPLOY_PLUGIN.to_string())
         }
         Err(_) => anyhow::bail!("{DEPLOY_PLUGIN_ENV} was defined but its value could not be read"),


### PR DESCRIPTION
Follows up https://github.com/spinframework/spin/pull/3173, making the deprecation warning more emphatic.

<img width="867" height="156" alt="image" src="https://github.com/user-attachments/assets/c3547dfd-ad83-44bf-8cfb-6f8d7a85e661" />


If there's a Spin 3.6 I confidently expect to devote some time to perfecting an ASCII art skull and crossbones.
