### PR TITLE
Workflow for publishing spin:up WIT package

### DIFF
--- a/.github/workflows/publish-wit.yml
+++ b/.github/workflows/publish-wit.yml
@@ -1,0 +1,39 @@
+name: Publish WIT to registry
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-wit:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      packages: write
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall
+
+      - name: Install wasm-tools
+        shell: bash
+        run: cargo binstall wasm-tools
+
+      - name: Install wkg
+        shell: bash
+        run: cargo binstall wkg
+
+      - name: Login to the GitHub registry
+        uses: docker/login-action
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.REGISTRY_PAT }}
+
+      - name: Build and publish WIT package
+        shell: bash
+        run: ./scripts/build-and-publish-wit.sh
+

--- a/scripts/build-and-publish-wit.sh
+++ b/scripts/build-and-publish-wit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script builds and publishes the spin:up WIT package
+# NOTE: The package name and version are inferred from the
+# encoded wasm binary.
+set -euo pipefail 
+
+# Build the package
+wasm-tools component wit wit/ -w -o spin_up_wit.wasm
+
+# Publish to registry
+wkg publish --registry spinframework.dev spin_up_wit.wasm


### PR DESCRIPTION
Simple manual dispatch workflow for publishing the `spin:up` WIT package. 

~Draft for now until I amend the release notes.~

Will follow up with separate PR amending the release notes once the first release is done.