### PR TITLE
Try Rust 1.90 to fix CI woe

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -8,7 +8,7 @@ inputs:
     type: bool
   rust-version:
     description: 'Rust version to setup'
-    default: '1.87'
+    default: '1.90'
     required: false
     type: string
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.87
+  RUST_VERSION: '1.90'
 
 jobs:
   dependency-review:
@@ -153,7 +153,6 @@ jobs:
         with:
           rust: true
           rust-wasm: true
-          rust-cache: true
           nomad: true
 
       - name: Check disk space (Before)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  RUST_VERSION: 1.87
+  RUST_VERSION: '1.90'
 
 jobs:
   build-and-sign:

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -83,7 +83,7 @@ impl<F: RuntimeFactors> HttpServer<F> {
             .app()
             .trigger_configs::<HttpTriggerConfig>("http")?
             .into_iter()
-            .map(|(trigger_id, config)| (config.lookup_key(trigger_id).map(|k| (k, config))))
+            .map(|(trigger_id, config)| config.lookup_key(trigger_id).map(|k| (k, config)))
             .collect::<Result<Vec<_>, _>>()?;
 
         // Build router

--- a/examples/spin-timer/src/lib.rs
+++ b/examples/spin-timer/src/lib.rs
@@ -27,6 +27,7 @@ pub struct TimerTrigger {
 }
 
 // Picks out the timer entry from the application-level trigger settings
+#[allow(dead_code)]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 struct TriggerMetadataParent {
     timer: Option<TriggerMetadata>,


### PR DESCRIPTION
In support of the ongoing Project Do Not Enrage Ivan By Making Him Re-run The Ubuntu Tests Three Times For Every PR.

@tschneidereit suggested that the new linker in Rust 1.90 might help us with our woes, and so this tries it.  The rest is Clippy (and a revert of a previous failed fix).
