### PR TITLE
Use temporary GITHUB_TOKEN for publishing to ghcr

### DIFF
--- a/.github/workflows/publish-wit.yml
+++ b/.github/workflows/publish-wit.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.REGISTRY_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish WIT package
         shell: bash


### PR DESCRIPTION
From what I read this seems to be the recommended way to authenticate with GHCR from a workflow.