### PR TITLE
ignore `Trap::AsyncDeadlock` when running WASIp3 handlers

### DIFF
--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -36,6 +36,7 @@ terminal = { path = "../terminal" }
 tokio = { workspace = true, features = ["full"] }
 tokio-rustls = { workspace = true }
 tracing = { workspace = true }
+wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }
 


### PR DESCRIPTION
That's a harmless error specific to Wasmtime 37, so no need to log it; we can remove the check once we've upgraded to Wasmtime 38.