### PR TITLE
Use forked wkg to publish WITs for now

### DIFF
--- a/.github/workflows/publish-wit.yml
+++ b/.github/workflows/publish-wit.yml
@@ -15,8 +15,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@8aac5aa2bf0dfaa2863eccad9f43c68fe40e5ec8
+      - name: Set up Rust to build wkg
+        uses: ./.github/actions/spin-ci-dependencies
+        with:
+          rust: true
 
       - name: Install wasm-tools
         shell: bash
@@ -24,7 +26,7 @@ jobs:
 
       - name: Install wkg
         shell: bash
-        run: cargo binstall wkg
+        run: cargo install wkg --git https://github.com/itowlson/wasm-pkg-tools --branch docker-credential-does-not-play-nice-with-schemeful-urls
 
       - name: Login to the GitHub registry
         uses: docker/login-action@v3


### PR DESCRIPTION
We believe the auth errors when trying to publish WITs are down to an infelicity between `wkg` and `docker-credential`.

We have a candidate fix for this (https://github.com/bytecodealliance/wasm-pkg-tools/pull/176) but are dubious about whether it is safe to roll out for general use, due to different conventions across the Docker ecosystem.

In the interim, we believe the candidate fix works for _our specific case,_ so this PR proposes to use it as an interim solution, so that we can prove that it doesn't work after all and Ivan has been barking up the wrong tree all day.
