### PR TITLE
Add opt-in to unstable wasip3 and warn when in use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8721,6 +8721,7 @@ dependencies = [
  "spin-app",
  "spin-factor-outbound-http",
  "spin-http-routes",
+ "terminal",
  "toml",
  "tracing",
  "wasmtime",

--- a/crates/http/Cargo.toml
+++ b/crates/http/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 spin-app = { path = "../app", optional = true }
 spin-factor-outbound-http = { path = "../factor-outbound-http" }
 spin-http-routes = { path = "../routes" }
+terminal = { path = "../terminal" }
 tracing = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }

--- a/crates/http/src/config.rs
+++ b/crates/http/src/config.rs
@@ -33,7 +33,7 @@ impl HttpTriggerConfig {
 ///
 /// If an executor is not specified, the inferred default is `HttpExecutor::Spin`.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-#[serde(deny_unknown_fields, rename_all = "lowercase", tag = "type")]
+#[serde(deny_unknown_fields, rename_all = "kebab-case", tag = "type")]
 pub enum HttpExecutorType {
     /// The component implements an HTTP based interface.
     ///
@@ -43,6 +43,8 @@ pub enum HttpExecutorType {
     Http,
     /// The component implements the Wagi CGI interface.
     Wagi(WagiTriggerConfig),
+    /// The component implements the WASIp3 HTTP interface (unstable).
+    Wasip3Unstable,
 }
 
 /// Wagi specific configuration for the http executor.

--- a/tests/testcases/wasi-http-p3-streaming/spin.toml
+++ b/tests/testcases/wasi-http-p3-streaming/spin.toml
@@ -9,6 +9,7 @@ version = "1.0.0"
 [[trigger.http]]
 route = "/..."
 component = "wasi-http-async"
+executor = { type = "wasip3-unstable" }
 
 [component.wasi-http-async]
 source = "%{source=integration-wasi-http-p3-streaming}"


### PR DESCRIPTION
Adds a new executor type for opting-in to `wasip3` (a la `wasip3-unstable`). 

Additionally a warning is added when running with the unstable feature enabled.