### PR TITLE
outbound-networking: More BlockedNetworks integration

### DIFF
--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -587,15 +587,7 @@ impl ConnectOptions {
         };
 
         // Remove blocked IPs
-        let blocked_addrs = self.blocked_networks.remove_blocked(&mut socket_addrs);
-        if socket_addrs.is_empty() && !blocked_addrs.is_empty() {
-            tracing::error!(
-                "error.type" = "destination_ip_prohibited",
-                ?blocked_addrs,
-                "all destination IP(s) prohibited by runtime config"
-            );
-            return Err(ErrorCode::DestinationIpProhibited);
-        }
+        crate::remove_blocked_addrs(&self.blocked_networks, &mut socket_addrs)?;
 
         // If we're limiting concurrent outbound requests, acquire a permit
         let permit = match &self.concurrent_outbound_connections_semaphore {

--- a/crates/factor-outbound-redis/Cargo.toml
+++ b/crates/factor-outbound-redis/Cargo.toml
@@ -12,6 +12,7 @@ spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-resource-table = { path = "../table" }
 spin-world = { path = "../world" }
+tokio = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/factor-outbound-redis/src/lib.rs
+++ b/crates/factor-outbound-redis/src/lib.rs
@@ -41,11 +41,10 @@ impl Factor for OutboundRedisFactor {
         &self,
         mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
-        let allowed_hosts = ctx
-            .instance_builder::<OutboundNetworkingFactor>()?
-            .allowed_hosts();
+        let outbound_networking = ctx.instance_builder::<OutboundNetworkingFactor>()?;
         Ok(InstanceState {
-            allowed_hosts,
+            allowed_hosts: outbound_networking.allowed_hosts(),
+            blocked_networks: outbound_networking.blocked_networks(),
             connections: spin_resource_table::Table::new(1024),
         })
     }


### PR DESCRIPTION
Some low(er)-hanging fruit for #3323:

- Dedupe error logic in Outbound HTTP for use with Spin interface
- Outbound Redis enforcement