### PR TITLE
[Backport v3.5] chore(rust-templates): bump Spin Rust SDK to v5.1.0

### DIFF
--- a/templates/http-rust/content/Cargo.toml.tmpl
+++ b/templates/http-rust/content/Cargo.toml.tmpl
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-spin-sdk = "5.0.0"
+spin-sdk = "5.1.0"
 
 [workspace]

--- a/templates/redis-rust/content/Cargo.toml.tmpl
+++ b/templates/redis-rust/content/Cargo.toml.tmpl
@@ -15,6 +15,6 @@ anyhow = "1"
 # Crate to simplify working with bytes.
 bytes = "1"
 # The Spin SDK.
-spin-sdk = "5.0.0"
+spin-sdk = "5.1.0"
 
 [workspace]


### PR DESCRIPTION
Backporting #3339 to v3.5