### PR TITLE
WASI OTel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite 2.5.0",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +371,33 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite 2.5.0",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2760,6 +2802,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fake-opentelemetry-collector"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce713bed1dfc379216421ebf0c4ee2268b5cb4d7894bed8a96d267834590916"
+dependencies = [
+ "futures",
+ "hex",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "serde",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3719,6 +3780,18 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4779,6 +4852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5050,6 +5132,9 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "logos"
@@ -5959,7 +6044,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
@@ -5980,6 +6064,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
+ "async-std",
  "async-trait",
  "futures-channel",
  "futures-executor",
@@ -8278,6 +8363,7 @@ dependencies = [
  "conformance-tests",
  "ctrlc",
  "dialoguer",
+ "fake-opentelemetry-collector",
  "futures",
  "hex",
  "http 1.3.1",
@@ -8489,6 +8575,7 @@ dependencies = [
  "anyhow",
  "serde",
  "spin-core",
+ "spin-factor-otel",
  "spin-factors",
  "spin-factors-test",
  "spin-key-value-redis",
@@ -8511,6 +8598,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "serde",
+ "spin-factor-otel",
  "spin-factors",
  "spin-factors-test",
  "spin-llm-local",
@@ -8522,6 +8610,25 @@ dependencies = [
  "toml 0.8.19",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "spin-factor-otel"
+version = "3.6.0-pre0"
+dependencies = [
+ "anyhow",
+ "indexmap 2.12.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "spin-core",
+ "spin-factors",
+ "spin-resource-table",
+ "spin-telemetry",
+ "spin-world",
+ "toml 0.5.11",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -8540,6 +8647,7 @@ dependencies = [
  "rustls 0.23.18",
  "serde",
  "spin-common",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
  "spin-factors",
@@ -8562,6 +8670,7 @@ dependencies = [
  "anyhow",
  "rumqttc",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
  "spin-factors",
@@ -8579,6 +8688,7 @@ dependencies = [
  "anyhow",
  "mysql_async",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
  "spin-factors",
@@ -8633,6 +8743,7 @@ dependencies = [
  "rust_decimal",
  "serde_json",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
  "spin-factors",
@@ -8652,6 +8763,7 @@ dependencies = [
  "anyhow",
  "redis",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
  "spin-factors",
@@ -8667,6 +8779,7 @@ name = "spin-factor-sqlite"
 version = "3.6.0-pre0"
 dependencies = [
  "async-trait",
+ "spin-factor-otel",
  "spin-factors",
  "spin-factors-test",
  "spin-locked-app",
@@ -8681,6 +8794,7 @@ name = "spin-factor-variables"
 version = "3.6.0-pre0"
 dependencies = [
  "spin-expressions",
+ "spin-factor-otel",
  "spin-factors",
  "spin-factors-test",
  "spin-telemetry",
@@ -9026,6 +9140,7 @@ dependencies = [
  "spin-expressions",
  "spin-factor-key-value",
  "spin-factor-llm",
+ "spin-factor-otel",
  "spin-factor-outbound-http",
  "spin-factor-outbound-mqtt",
  "spin-factor-outbound-mysql",
@@ -9062,6 +9177,7 @@ dependencies = [
  "spin-common",
  "spin-factor-key-value",
  "spin-factor-llm",
+ "spin-factor-otel",
  "spin-factor-outbound-http",
  "spin-factor-outbound-mqtt",
  "spin-factor-outbound-mysql",
@@ -9228,6 +9344,7 @@ dependencies = [
  "serde_json",
  "spin-app",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-http",
  "spin-factor-outbound-networking",
  "spin-factor-wasi",
@@ -9318,7 +9435,13 @@ dependencies = [
 name = "spin-world"
 version = "3.6.0-pre0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "base64 0.22.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "serde",
+ "serde_json",
  "wasmtime",
 ]
 
@@ -10014,6 +10137,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
@@ -10513,6 +10645,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vaultrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ openssl = { version = "0.10" }
 anyhow = { workspace = true, features = ["backtrace"] }
 conformance = { path = "tests/conformance-tests" }
 conformance-tests = { workspace = true }
+fake-opentelemetry-collector = "0.26"
 hex = "0.4"
 http-body-util = { workspace = true }
 hyper = { workspace = true }
@@ -149,6 +150,15 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 indexmap = "2"
 itertools = "0.14"
 lazy_static = "1.5"
+opentelemetry = "0.28"
+# The default `reqwest-blocking-client` causes a runtime panic
+opentelemetry-otlp = { version = "0.28", default-features = false, features = ["http-proto", "reqwest-client", "logs"]}
+opentelemetry_sdk = {version = "0.28", features = [
+  "experimental_metrics_periodicreader_with_async_runtime", 
+  "experimental_trace_batch_span_processor_with_async_runtime", 
+  "experimental_logs_batch_log_processor_with_async_runtime", 
+  "experimental_async_runtime"
+]}
 path-absolutize = "3"
 pin-project-lite = "0.2.16"
 quote = "1"
@@ -177,6 +187,7 @@ toml_edit = "0.22"
 tower-service = "0.3.3"
 tracing = { version = "0.1.41", features = ["log"] }
 url = "2.5.7"
+tracing-opentelemetry = "0.29"
 walkdir = "2"
 wac-graph = "0.8.1"
 wasm-encoder = "0.244.0"

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 spin-core = { path = "../core" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }
 spin-resource-table = { path = "../table" }

--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -1,6 +1,7 @@
 use super::{Cas, SwapError};
 use anyhow::{Context, Result};
 use spin_core::{async_trait, wasmtime::component::Resource};
+use spin_factor_otel::OtelFactorState;
 use spin_resource_table::Table;
 use spin_telemetry::traces::{self, Blame};
 use spin_world::v2::key_value;
@@ -49,23 +50,31 @@ pub struct KeyValueDispatch {
     manager: Arc<dyn StoreManager>,
     stores: Table<Arc<dyn Store>>,
     compare_and_swaps: Table<Arc<dyn Cas>>,
+    otel: OtelFactorState,
 }
 
 impl KeyValueDispatch {
     pub fn new(allowed_stores: HashSet<String>, manager: Arc<dyn StoreManager>) -> Self {
-        Self::new_with_capacity(allowed_stores, manager, DEFAULT_STORE_TABLE_CAPACITY)
+        Self::new_with_capacity(
+            allowed_stores,
+            manager,
+            DEFAULT_STORE_TABLE_CAPACITY,
+            Default::default(),
+        )
     }
 
     pub fn new_with_capacity(
         allowed_stores: HashSet<String>,
         manager: Arc<dyn StoreManager>,
         capacity: u32,
+        otel: OtelFactorState,
     ) -> Self {
         Self {
             allowed_stores,
             manager,
             stores: Table::new(capacity),
             compare_and_swaps: Table::new(capacity),
+            otel,
         }
     }
 
@@ -113,6 +122,7 @@ impl key_value::Host for KeyValueDispatch {}
 impl key_value::HostStore for KeyValueDispatch {
     #[instrument(name = "spin_key_value.open", skip(self), err, fields(otel.kind = "client", kv.backend=self.manager.summary(&name).unwrap_or("unknown".to_string())))]
     async fn open(&mut self, name: String) -> Result<Result<Resource<key_value::Store>, Error>> {
+        self.otel.reparent_tracing_span();
         Ok(async {
             if self.allowed_stores.contains(&name) {
                 let store = self.manager.get(&name).await?;
@@ -135,6 +145,7 @@ impl key_value::HostStore for KeyValueDispatch {
         store: Resource<key_value::Store>,
         key: String,
     ) -> Result<Result<Option<Vec<u8>>, Error>> {
+        self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
         Ok(store.get(&key).await.map_err(track_error_on_span))
     }
@@ -146,6 +157,7 @@ impl key_value::HostStore for KeyValueDispatch {
         key: String,
         value: Vec<u8>,
     ) -> Result<Result<(), Error>> {
+        self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
         Ok(store.set(&key, &value).await.map_err(track_error_on_span))
     }
@@ -156,6 +168,7 @@ impl key_value::HostStore for KeyValueDispatch {
         store: Resource<key_value::Store>,
         key: String,
     ) -> Result<Result<(), Error>> {
+        self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
         Ok(store.delete(&key).await.map_err(track_error_on_span))
     }
@@ -166,6 +179,7 @@ impl key_value::HostStore for KeyValueDispatch {
         store: Resource<key_value::Store>,
         key: String,
     ) -> Result<Result<bool, Error>> {
+        self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
         Ok(store.exists(&key).await.map_err(track_error_on_span))
     }
@@ -175,6 +189,7 @@ impl key_value::HostStore for KeyValueDispatch {
         &mut self,
         store: Resource<key_value::Store>,
     ) -> Result<Result<Vec<String>, Error>> {
+        self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
         Ok(store.get_keys().await.map_err(track_error_on_span))
     }

--- a/crates/factor-llm/Cargo.toml
+++ b/crates/factor-llm/Cargo.toml
@@ -17,6 +17,7 @@ llm-cublas = ["llm", "spin-llm-local/cublas"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factors = { path = "../factors" }
 spin-llm-local = { path = "../llm-local", optional = true }
 spin-llm-remote-http = { path = "../llm-remote-http" }

--- a/crates/factor-llm/src/host.rs
+++ b/crates/factor-llm/src/host.rs
@@ -13,6 +13,8 @@ impl v2::Host for InstanceState {
         prompt: String,
         params: Option<v2::InferencingParams>,
     ) -> Result<v2::InferencingResult, v2::Error> {
+        self.otel.reparent_tracing_span();
+
         if !self.allowed_models.contains(&model) {
             return Err(access_denied_error(&model));
         }
@@ -40,6 +42,8 @@ impl v2::Host for InstanceState {
         model: v1::EmbeddingModel,
         data: Vec<String>,
     ) -> Result<v2::EmbeddingsResult, v2::Error> {
+        self.otel.reparent_tracing_span();
+
         if !self.allowed_models.contains(&model) {
             return Err(access_denied_error(&model));
         }

--- a/crates/factor-llm/src/lib.rs
+++ b/crates/factor-llm/src/lib.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use spin_factor_otel::OtelFactorState;
 use spin_factors::{
     ConfigureAppContext, Factor, FactorData, PrepareContext, RuntimeFactors, SelfInstanceBuilder,
 };
@@ -73,7 +74,7 @@ impl Factor for LlmFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        ctx: PrepareContext<T, Self>,
+        mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
         let allowed_models = ctx
             .app_state()
@@ -82,10 +83,12 @@ impl Factor for LlmFactor {
             .cloned()
             .unwrap_or_default();
         let engine = ctx.app_state().engine.clone();
+        let otel = OtelFactorState::from_prepare_context(&mut ctx)?;
 
         Ok(InstanceState {
             engine,
             allowed_models,
+            otel,
         })
     }
 }
@@ -100,6 +103,7 @@ pub struct AppState {
 pub struct InstanceState {
     engine: Arc<Mutex<dyn LlmEngine>>,
     pub allowed_models: Arc<HashSet<String>>,
+    otel: OtelFactorState,
 }
 
 /// The runtime configuration for the LLM factor.

--- a/crates/factor-otel/Cargo.toml
+++ b/crates/factor-otel/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "spin-factor-otel"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+indexmap = "2.2.6"
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+spin-core = { path = "../core" }
+spin-factors = { path = "../factors" }
+spin-resource-table = { path = "../table" }
+spin-telemetry = { path = "../telemetry" }
+spin-world = { path = "../world" }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+
+[dev-dependencies]
+toml = "0.5"
+
+[lints]
+workspace = true

--- a/crates/factor-otel/src/host.rs
+++ b/crates/factor-otel/src/host.rs
@@ -1,0 +1,120 @@
+use crate::InstanceState;
+use anyhow::anyhow;
+use anyhow::Result;
+use opentelemetry::trace::TraceContextExt;
+use opentelemetry_sdk::error::OTelSdkError;
+use opentelemetry_sdk::logs::LogProcessor;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+use opentelemetry_sdk::trace::SpanProcessor;
+use spin_world::wasi;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+impl wasi::otel::tracing::Host for InstanceState {
+    async fn on_start(&mut self, context: wasi::otel::tracing::SpanContext) -> Result<()> {
+        // If the host does not have tracing enabled we just no-op
+        let Some(tracing_state) = self.tracing_state.as_ref() else {
+            return Ok(());
+        };
+        let mut tracing_state = tracing_state.write().unwrap();
+
+        // Before we do anything make sure we track the original host span ID for reparenting
+        if tracing_state.original_host_span_id.is_none() {
+            tracing_state.original_host_span_id = Some(
+                tracing::Span::current()
+                    .context()
+                    .span()
+                    .span_context()
+                    .span_id(),
+            );
+        }
+
+        // Track the guest spans context in our ordered map
+        let span_context: opentelemetry::trace::SpanContext = context.into();
+        tracing_state
+            .guest_span_contexts
+            .insert(span_context.span_id(), span_context);
+
+        Ok(())
+    }
+
+    async fn on_end(&mut self, span_data: wasi::otel::tracing::SpanData) -> Result<()> {
+        // If the host does not have tracing enabled we just no-op
+        let Some(tracing_state) = self.tracing_state.as_ref() else {
+            return Ok(());
+        };
+        let mut tracing_state = tracing_state.write().unwrap();
+
+        let span_context: opentelemetry::trace::SpanContext = span_data.span_context.clone().into();
+        let span_id: opentelemetry::trace::SpanId = span_context.span_id();
+
+        if tracing_state
+            .guest_span_contexts
+            .shift_remove(&span_id)
+            .is_none()
+        {
+            Err(anyhow!("Trying to end a span that was not started"))?;
+        }
+
+        tracing_state.span_processor.on_end(span_data.into());
+
+        Ok(())
+    }
+
+    async fn outer_span_context(&mut self) -> Result<wasi::otel::tracing::SpanContext> {
+        Ok(tracing::Span::current()
+            .context()
+            .span()
+            .span_context()
+            .clone()
+            .into())
+    }
+}
+
+impl wasi::otel::metrics::Host for InstanceState {
+    async fn export(
+        &mut self,
+        metrics: wasi::otel::metrics::ResourceMetrics,
+    ) -> spin_core::wasmtime::Result<std::result::Result<(), wasi::otel::metrics::Error>> {
+        // If the host does not have metrics enabled we just no-op
+        let Some(metric_exporter) = self.metric_exporter.as_ref() else {
+            return Ok(Ok(()));
+        };
+
+        match metric_exporter.export(&mut metrics.into()).await {
+            Ok(_) => Ok(Ok(())),
+            Err(e) => match e {
+                OTelSdkError::AlreadyShutdown => {
+                    let msg = "Shutdown has already been invoked";
+                    tracing::error!(msg);
+                    Ok(Err(msg.to_string()))
+                }
+                OTelSdkError::InternalFailure(e) => {
+                    let detailed_msg = format!("Internal failure: {}", e);
+                    tracing::error!(detailed_msg);
+                    Ok(Err("Internal failure.".to_string()))
+                }
+                OTelSdkError::Timeout(d) => {
+                    let detailed_msg = format!("Operation timed out after {} seconds", d.as_secs());
+                    tracing::error!(detailed_msg);
+                    Ok(Err("Operation timed out.".to_string()))
+                }
+            },
+        }
+    }
+}
+
+impl wasi::otel::logs::Host for InstanceState {
+    async fn on_emit(
+        &mut self,
+        data: wasi::otel::logs::LogRecord,
+    ) -> spin_core::wasmtime::Result<()> {
+        // If the host does not have logs enabled we just no-op
+        let Some(log_processor) = self.log_processor.as_ref() else {
+            return Ok(());
+        };
+
+        let (mut record, scope) = spin_world::wasi_otel::parse_wasi_log_record(data);
+        log_processor.emit(&mut record, &scope);
+        Ok(())
+    }
+}

--- a/crates/factor-otel/src/lib.rs
+++ b/crates/factor-otel/src/lib.rs
@@ -1,0 +1,286 @@
+mod host;
+
+use anyhow::bail;
+use indexmap::IndexMap;
+use opentelemetry::{
+    trace::{SpanContext, SpanId, TraceContextExt},
+    Context,
+};
+use opentelemetry_otlp::MetricExporter;
+use opentelemetry_sdk::{
+    logs::{log_processor_with_async_runtime::BatchLogProcessor, LogProcessor},
+    resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
+    runtime::Tokio,
+    trace::{span_processor_with_async_runtime::BatchSpanProcessor, SpanProcessor},
+    Resource,
+};
+use spin_factors::{Factor, FactorData, PrepareContext, RuntimeFactors, SelfInstanceBuilder};
+use spin_telemetry::{
+    detector::SpinResourceDetector,
+    env::{otel_logs_enabled, otel_metrics_enabled, otel_tracing_enabled, OtlpProtocol},
+};
+use std::sync::{Arc, RwLock};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+pub struct OtelFactor {
+    span_processor: Option<Arc<BatchSpanProcessor<Tokio>>>,
+    metric_exporter: Option<Arc<MetricExporter>>,
+    log_processor: Option<Arc<BatchLogProcessor<Tokio>>>,
+    enable_interface: bool,
+}
+
+impl Factor for OtelFactor {
+    type RuntimeConfig = ();
+    type AppState = ();
+    type InstanceBuilder = InstanceState;
+
+    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+        // Only link the WASI OTel bindings if experimental support is enabled. This means that if
+        // the user tries to run a guest component that consumes the WASI OTel WIT without enabling
+        // experimental support they'll see an error like "component imports instance
+        // `wasi:otel/tracing@0.2.0-draft`"
+        if self.enable_interface {
+            ctx.link_bindings(
+                spin_world::wasi::otel::tracing::add_to_linker::<_, FactorData<Self>>,
+            )?;
+            ctx.link_bindings(
+                spin_world::wasi::otel::metrics::add_to_linker::<_, FactorData<Self>>,
+            )?;
+            ctx.link_bindings(spin_world::wasi::otel::logs::add_to_linker::<_, FactorData<Self>>)?;
+        }
+        Ok(())
+    }
+
+    fn configure_app<T: spin_factors::RuntimeFactors>(
+        &self,
+        _ctx: spin_factors::ConfigureAppContext<T, Self>,
+    ) -> anyhow::Result<Self::AppState> {
+        Ok(())
+    }
+
+    fn prepare<T: spin_factors::RuntimeFactors>(
+        &self,
+        _: spin_factors::PrepareContext<T, Self>,
+    ) -> anyhow::Result<Self::InstanceBuilder> {
+        if !self.enable_interface {
+            return Ok(InstanceState::default());
+        }
+
+        // Warn the user if they enabled experimental support but didn't supply any environment variables
+        if self.span_processor.is_none()
+            && self.metric_exporter.is_none()
+            && self.log_processor.is_none()
+        {
+            tracing::warn!("WASI OTel experimental support is enabled but no OTEL_EXPORTER_* environment variables were found. No telemetry will be exported.");
+        }
+
+        Ok(InstanceState {
+            tracing_state: self.span_processor.as_ref().map(|span_processor| {
+                Arc::new(RwLock::new(TracingState {
+                    guest_span_contexts: Default::default(),
+                    original_host_span_id: None,
+                    span_processor: span_processor.clone(),
+                }))
+            }),
+            metric_exporter: self.metric_exporter.clone(),
+            log_processor: self.log_processor.clone(),
+        })
+    }
+}
+
+impl OtelFactor {
+    pub fn new(spin_version: &str, enable_interface: bool) -> anyhow::Result<Self> {
+        if !enable_interface {
+            return Ok(Self {
+                span_processor: None,
+                metric_exporter: None,
+                log_processor: None,
+                enable_interface,
+            });
+        }
+
+        let resource = Resource::builder()
+            .with_detectors(&[
+                // Set service.name from env OTEL_SERVICE_NAME > env OTEL_RESOURCE_ATTRIBUTES > spin
+                // Set service.version from Spin metadata
+                Box::new(SpinResourceDetector::new(spin_version.to_string()))
+                    as Box<dyn ResourceDetector>,
+                // Sets fields from env OTEL_RESOURCE_ATTRIBUTES
+                Box::new(EnvResourceDetector::new()),
+                // Sets telemetry.sdk{name, language, version}
+                Box::new(TelemetryResourceDetector),
+            ])
+            .build();
+
+        let span_processor = if otel_tracing_enabled() {
+            // This will configure the exporter based on the OTEL_EXPORTER_* environment variables.
+            let span_exporter = match OtlpProtocol::traces_protocol_from_env() {
+                OtlpProtocol::Grpc => opentelemetry_otlp::SpanExporter::builder()
+                    .with_tonic()
+                    .build()?,
+                OtlpProtocol::HttpProtobuf => opentelemetry_otlp::SpanExporter::builder()
+                    .with_http()
+                    .build()?,
+                OtlpProtocol::HttpJson => bail!("http/json OTLP protocol is not supported"),
+            };
+
+            let mut span_processor = BatchSpanProcessor::builder(span_exporter, Tokio).build();
+            span_processor.set_resource(&resource);
+            Some(Arc::new(span_processor))
+        } else {
+            None
+        };
+
+        let metric_exporter = if otel_metrics_enabled() {
+            let metric_exporter = match OtlpProtocol::metrics_protocol_from_env() {
+                OtlpProtocol::Grpc => opentelemetry_otlp::MetricExporter::builder()
+                    .with_tonic()
+                    .build()?,
+                OtlpProtocol::HttpProtobuf => opentelemetry_otlp::MetricExporter::builder()
+                    .with_http()
+                    .build()?,
+                OtlpProtocol::HttpJson => bail!("http/json OTLP protocol is not supported"),
+            };
+            Some(Arc::new(metric_exporter))
+        } else {
+            None
+        };
+
+        let log_processor = if otel_logs_enabled() {
+            let log_exporter = match OtlpProtocol::logs_protocol_from_env() {
+                OtlpProtocol::Grpc => opentelemetry_otlp::LogExporter::builder()
+                    .with_tonic()
+                    .build()?,
+                OtlpProtocol::HttpProtobuf => opentelemetry_otlp::LogExporter::builder()
+                    .with_http()
+                    .build()?,
+                OtlpProtocol::HttpJson => bail!("http/json OTLP protocol is not supported"),
+            };
+
+            let log_processor = BatchLogProcessor::builder(log_exporter, Tokio).build();
+            log_processor.set_resource(&resource);
+            Some(Arc::new(log_processor))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            span_processor,
+            metric_exporter,
+            log_processor,
+            enable_interface,
+        })
+    }
+}
+
+#[derive(Default)]
+pub struct InstanceState {
+    tracing_state: Option<Arc<RwLock<TracingState>>>,
+    metric_exporter: Option<Arc<MetricExporter>>,
+    log_processor: Option<Arc<BatchLogProcessor<Tokio>>>,
+}
+
+impl SelfInstanceBuilder for InstanceState {}
+
+/// Internal tracing state of the OtelFactor InstanceState.
+///
+/// This data lives here rather than directly on InstanceState so that we can have multiple things
+/// take Arc references to it and so that if tracing is disabled we don't keep doing needless
+/// bookkeeping of host spans.
+pub(crate) struct TracingState {
+    /// An order-preserved mapping between immutable [SpanId]s of guest created spans and their
+    /// corresponding [SpanContext].
+    ///
+    /// The topmost [SpanId] is the last active span. When a span is ended it is removed from this
+    /// map (regardless of whether it is the active span) and all other spans are shifted back to
+    /// retain relative order.
+    pub(crate) guest_span_contexts: IndexMap<SpanId, SpanContext>,
+
+    /// Id of the last span emitted from within the host before entering the guest.
+    ///
+    /// We use this to avoid accidentally reparenting the original host span as a child of a guest
+    /// span.
+    pub(crate) original_host_span_id: Option<SpanId>,
+
+    /// The span processor used to export spans.
+    span_processor: Arc<BatchSpanProcessor<Tokio>>,
+}
+
+/// Manages access to the OtelFactor tracing state for the purpose of maintaining proper span
+/// parent/child relationships when WASI Otel spans are being created.
+#[derive(Default)]
+pub struct OtelFactorState {
+    pub(crate) tracing_state: Option<Arc<RwLock<TracingState>>>,
+}
+
+impl OtelFactorState {
+    /// Creates an [`OtelFactorState`] from a [`PrepareContext`].
+    ///
+    /// If [`RuntimeFactors`] does not contain an [`OtelFactor`], then calling
+    /// [`OtelFactorState::reparent_tracing_span`] will be a no-op.
+    pub fn from_prepare_context<T: RuntimeFactors, F: Factor>(
+        prepare_context: &mut PrepareContext<T, F>,
+    ) -> anyhow::Result<Self> {
+        let tracing_state = match prepare_context.instance_builder::<OtelFactor>() {
+            Ok(instance_state) => instance_state.tracing_state.clone(),
+            Err(spin_factors::Error::NoSuchFactor(_)) => None,
+            Err(e) => return Err(e.into()),
+        };
+        Ok(Self { tracing_state })
+    }
+
+    /// Reparents the current [tracing] span to be a child of the last active guest span.
+    ///
+    /// The otel factor enables guests to emit spans that should be part of the same trace as the
+    /// host is producing for a request. Below is an example trace. A request is made to an app, a
+    /// guest span is created and then the host is re-entered to fetch a key value.
+    ///
+    /// ```text
+    /// | GET /... _________________________________|
+    ///    | execute_wasm_component foo ___________|
+    ///       | my_guest_span ___________________|
+    ///          | spin_key_value.get |
+    /// ```
+    ///
+    /// Setting the guest spans parent as the host is enabled through current_span_context.
+    /// However, the more difficult task is having the host factor spans be children of the guest
+    /// span. [`OtelFactorState::reparent_tracing_span`] handles this by reparenting the current span to
+    /// be a child of the last active guest span (which is tracked internally in the otel factor).
+    ///
+    /// Note that if the otel factor is not in your [`RuntimeFactors`] than this is effectively a
+    /// no-op.
+    ///
+    /// This MUST only be called from a factor host implementation function that is instrumented.
+    ///
+    /// This MUST be called at the very start of the function before any awaits.
+    pub fn reparent_tracing_span(&self) {
+        // If tracing_state is None then tracing is not enabled so we should return early
+        let tracing_state = if let Some(state) = self.tracing_state.as_ref() {
+            state.read().unwrap()
+        } else {
+            return;
+        };
+
+        // If there are no active guest spans then there is nothing to do
+        let Some((_, active_span_context)) = tracing_state.guest_span_contexts.last() else {
+            return;
+        };
+
+        // Ensure that we are not reparenting the original host span
+        if let Some(original_host_span_id) = tracing_state.original_host_span_id {
+            debug_assert_ne!(
+                &original_host_span_id,
+                &tracing::Span::current()
+                    .context()
+                    .span()
+                    .span_context()
+                    .span_id(),
+                    "Incorrectly attempting to reparent the original host span. Likely `reparent_tracing_span` was called in an incorrect location."
+            );
+        }
+
+        // Now reparent the current span to the last active guest span
+        let parent_context = Context::new().with_remote_span_context(active_span_context.clone());
+        tracing::Span::current().set_parent(parent_context);
+    }
+}

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -16,6 +16,7 @@ pin-project-lite = { workspace = true }
 reqwest = { workspace = true, features = ["gzip"] }
 rustls = { workspace = true }
 serde = { workspace = true }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }

--- a/crates/factor-outbound-http/src/spin.rs
+++ b/crates/factor-outbound-http/src/spin.rs
@@ -15,6 +15,8 @@ impl spin_http::Host for crate::InstanceState {
         fields(otel.kind = "client", url.full = Empty, http.request.method = Empty,
         http.response.status_code = Empty, otel.name = Empty, server.address = Empty, server.port = Empty))]
     async fn send_request(&mut self, req: Request) -> Result<Response, HttpError> {
+        self.otel.reparent_tracing_span();
+
         let span = Span::current();
         record_request_fields(&span, &req);
 

--- a/crates/factor-outbound-mqtt/Cargo.toml
+++ b/crates/factor-outbound-mqtt/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 rumqttc = { version = "0.24", features = ["url"] }
 spin-core = { path = "../core" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-resource-table = { path = "../table" }

--- a/crates/factor-outbound-mqtt/src/host.rs
+++ b/crates/factor-outbound-mqtt/src/host.rs
@@ -2,6 +2,7 @@ use std::{sync::Arc, time::Duration};
 
 use anyhow::Result;
 use spin_core::{async_trait, wasmtime::component::Resource};
+use spin_factor_otel::OtelFactorState;
 use spin_factor_outbound_networking::config::allowed_hosts::OutboundAllowedHosts;
 use spin_world::v2::mqtt::{self as v2, Connection, Error, Qos};
 use tracing::{instrument, Level};
@@ -12,14 +13,20 @@ pub struct InstanceState {
     allowed_hosts: OutboundAllowedHosts,
     connections: spin_resource_table::Table<Arc<dyn MqttClient>>,
     create_client: Arc<dyn ClientCreator>,
+    otel: OtelFactorState,
 }
 
 impl InstanceState {
-    pub fn new(allowed_hosts: OutboundAllowedHosts, create_client: Arc<dyn ClientCreator>) -> Self {
+    pub fn new(
+        allowed_hosts: OutboundAllowedHosts,
+        create_client: Arc<dyn ClientCreator>,
+        otel: OtelFactorState,
+    ) -> Self {
         Self {
             allowed_hosts,
             create_client,
             connections: spin_resource_table::Table::new(1024),
+            otel,
         }
     }
 }
@@ -72,6 +79,8 @@ impl v2::HostConnection for InstanceState {
         password: String,
         keep_alive_interval: u64,
     ) -> Result<Resource<Connection>, Error> {
+        self.otel.reparent_tracing_span();
+
         if !self
             .is_address_allowed(&address)
             .await
@@ -105,6 +114,8 @@ impl v2::HostConnection for InstanceState {
         payload: Vec<u8>,
         qos: Qos,
     ) -> Result<(), Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
 
         conn.publish_bytes(topic, qos, payload).await?;

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -7,6 +7,7 @@ use host::other_error;
 use host::InstanceState;
 use rumqttc::{AsyncClient, Event, Incoming, Outgoing, QoS};
 use spin_core::async_trait;
+use spin_factor_otel::OtelFactorState;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factors::{
     ConfigureAppContext, Factor, FactorData, PrepareContext, RuntimeFactors, SelfInstanceBuilder,
@@ -50,9 +51,12 @@ impl Factor for OutboundMqttFactor {
         let allowed_hosts = ctx
             .instance_builder::<OutboundNetworkingFactor>()?
             .allowed_hosts();
+        let otel = OtelFactorState::from_prepare_context(&mut ctx)?;
+
         Ok(InstanceState::new(
             allowed_hosts,
             self.create_client.clone(),
+            otel,
         ))
     }
 }

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -14,6 +14,7 @@ mysql_async = { version = "0.35", default-features = false, features = [
   "native-tls-tls",
 ] }
 spin-core = { path = "../core" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-resource-table = { path = "../table" }

--- a/crates/factor-outbound-mysql/src/host.rs
+++ b/crates/factor-outbound-mysql/src/host.rs
@@ -38,6 +38,7 @@ impl<C: Client> v2::Host for InstanceState<C> {}
 impl<C: Client> v2::HostConnection for InstanceState<C> {
     #[instrument(name = "spin_outbound_mysql.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<Connection>, v2::Error> {
+        self.otel.reparent_tracing_span();
         spin_factor_outbound_networking::record_address_fields(&address);
 
         if !self
@@ -59,6 +60,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
         statement: String,
         params: Vec<ParameterValue>,
     ) -> Result<(), v2::Error> {
+        self.otel.reparent_tracing_span();
         self.get_client(connection)
             .await?
             .execute(statement, params)
@@ -72,6 +74,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
         statement: String,
         params: Vec<ParameterValue>,
     ) -> Result<v2_types::RowSet, v2::Error> {
+        self.otel.reparent_tracing_span();
         self.get_client(connection)
             .await?
             .query(statement, params)

--- a/crates/factor-outbound-pg/Cargo.toml
+++ b/crates/factor-outbound-pg/Cargo.toml
@@ -16,6 +16,7 @@ postgres_range = "0.11"
 rust_decimal = { version = "1.37", features = ["db-tokio-postgres"] }
 serde_json = { workspace = true }
 spin-core = { path = "../core" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-resource-table = { path = "../table" }

--- a/crates/factor-outbound-pg/src/host.rs
+++ b/crates/factor-outbound-pg/src/host.rs
@@ -219,6 +219,7 @@ impl<CF: ClientFactory> v2::Host for InstanceState<CF> {}
 impl<CF: ClientFactory> v2::HostConnection for InstanceState<CF> {
     #[instrument(name = "spin_outbound_pg.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<v2::Connection>, v2::Error> {
+        self.otel.reparent_tracing_span();
         spin_factor_outbound_networking::record_address_fields(&address);
 
         self.ensure_address_allowed(&address).await?;
@@ -233,6 +234,7 @@ impl<CF: ClientFactory> v2::HostConnection for InstanceState<CF> {
         statement: String,
         params: Vec<v2_types::ParameterValue>,
     ) -> Result<u64, v2::Error> {
+        self.otel.reparent_tracing_span();
         Ok(self
             .get_client(connection)
             .await?
@@ -247,6 +249,7 @@ impl<CF: ClientFactory> v2::HostConnection for InstanceState<CF> {
         statement: String,
         params: Vec<v2_types::ParameterValue>,
     ) -> Result<v2_types::RowSet, v2::Error> {
+        self.otel.reparent_tracing_span();
         Ok(self
             .get_client(connection)
             .await?

--- a/crates/factor-outbound-redis/Cargo.toml
+++ b/crates/factor-outbound-redis/Cargo.toml
@@ -8,6 +8,7 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 redis = { workspace = true , features = ["tokio-comp", "tokio-native-tls-comp", "aio"] }
 spin-core = { path = "../core" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-resource-table = { path = "../table" }

--- a/crates/factor-outbound-redis/src/host.rs
+++ b/crates/factor-outbound-redis/src/host.rs
@@ -5,6 +5,7 @@ use redis::io::AsyncDNSResolver;
 use redis::AsyncConnectionConfig;
 use redis::{aio::MultiplexedConnection, AsyncCommands, FromRedisValue, Value};
 use spin_core::wasmtime::component::Resource;
+use spin_factor_otel::OtelFactorState;
 use spin_factor_outbound_networking::config::allowed_hosts::OutboundAllowedHosts;
 use spin_factor_outbound_networking::config::blocked_networks::BlockedNetworks;
 use spin_world::v1::{redis as v1, redis_types};
@@ -18,6 +19,7 @@ pub struct InstanceState {
     pub allowed_hosts: OutboundAllowedHosts,
     pub blocked_networks: BlockedNetworks,
     pub connections: spin_resource_table::Table<MultiplexedConnection>,
+    pub otel: OtelFactorState,
 }
 
 impl InstanceState {
@@ -63,8 +65,7 @@ impl v2::Host for crate::InstanceState {
 impl v2::HostConnection for crate::InstanceState {
     #[instrument(name = "spin_outbound_redis.open_connection", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", db.address = Empty, server.port = Empty, db.namespace = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<RedisConnection>, Error> {
-        spin_factor_outbound_networking::record_address_fields(&address);
-
+        self.otel.reparent_tracing_span();
         if !self
             .is_address_allowed(&address)
             .await
@@ -83,6 +84,8 @@ impl v2::HostConnection for crate::InstanceState {
         channel: String,
         payload: Vec<u8>,
     ) -> Result<(), Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         // The `let () =` syntax is needed to suppress a warning when the result type is inferred.
         // You can read more about the issue here: <https://github.com/redis-rs/redis-rs/issues/1228>
@@ -99,6 +102,8 @@ impl v2::HostConnection for crate::InstanceState {
         connection: Resource<RedisConnection>,
         key: String,
     ) -> Result<Option<Vec<u8>>, Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         let value = conn.get(&key).await.map_err(other_error)?;
         Ok(value)
@@ -111,6 +116,8 @@ impl v2::HostConnection for crate::InstanceState {
         key: String,
         value: Vec<u8>,
     ) -> Result<(), Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         // The `let () =` syntax is needed to suppress a warning when the result type is inferred.
         // You can read more about the issue here: <https://github.com/redis-rs/redis-rs/issues/1228>
@@ -124,6 +131,8 @@ impl v2::HostConnection for crate::InstanceState {
         connection: Resource<RedisConnection>,
         key: String,
     ) -> Result<i64, Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         let value = conn.incr(&key, 1).await.map_err(other_error)?;
         Ok(value)
@@ -135,6 +144,8 @@ impl v2::HostConnection for crate::InstanceState {
         connection: Resource<RedisConnection>,
         keys: Vec<String>,
     ) -> Result<u32, Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         let value = conn.del(&keys).await.map_err(other_error)?;
         Ok(value)
@@ -147,6 +158,8 @@ impl v2::HostConnection for crate::InstanceState {
         key: String,
         values: Vec<String>,
     ) -> Result<u32, Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         let value = conn.sadd(&key, &values).await.map_err(|e| {
             if e.kind() == redis::ErrorKind::TypeError {
@@ -164,6 +177,8 @@ impl v2::HostConnection for crate::InstanceState {
         connection: Resource<RedisConnection>,
         key: String,
     ) -> Result<Vec<String>, Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         let value = conn.smembers(&key).await.map_err(other_error)?;
         Ok(value)
@@ -176,6 +191,8 @@ impl v2::HostConnection for crate::InstanceState {
         key: String,
         values: Vec<String>,
     ) -> Result<u32, Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await.map_err(other_error)?;
         let value = conn.srem(&key, &values).await.map_err(other_error)?;
         Ok(value)
@@ -188,6 +205,8 @@ impl v2::HostConnection for crate::InstanceState {
         command: String,
         arguments: Vec<RedisParameter>,
     ) -> Result<Vec<RedisResult>, Error> {
+        self.otel.reparent_tracing_span();
+
         let conn = self.get_conn(connection).await?;
         let mut cmd = redis::cmd(&command);
         arguments.iter().for_each(|value| match value {

--- a/crates/factor-outbound-redis/src/lib.rs
+++ b/crates/factor-outbound-redis/src/lib.rs
@@ -1,6 +1,7 @@
 mod host;
 
 use host::InstanceState;
+use spin_factor_otel::OtelFactorState;
 use spin_factor_outbound_networking::OutboundNetworkingFactor;
 use spin_factors::{
     anyhow, ConfigureAppContext, Factor, FactorData, PrepareContext, RuntimeFactors,
@@ -41,11 +42,14 @@ impl Factor for OutboundRedisFactor {
         &self,
         mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<Self::InstanceBuilder> {
+        let otel = OtelFactorState::from_prepare_context(&mut ctx)?;
         let outbound_networking = ctx.instance_builder::<OutboundNetworkingFactor>()?;
+
         Ok(InstanceState {
             allowed_hosts: outbound_networking.allowed_hosts(),
             blocked_networks: outbound_networking.blocked_networks(),
             connections: spin_resource_table::Table::new(1024),
+            otel,
         })
     }
 }

--- a/crates/factor-sqlite/Cargo.toml
+++ b/crates/factor-sqlite/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }
 spin-resource-table = { path = "../table" }

--- a/crates/factor-sqlite/src/host.rs
+++ b/crates/factor-sqlite/src/host.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use spin_factor_otel::OtelFactorState;
 use spin_factors::wasmtime::component::Resource;
 use spin_factors::{anyhow, SelfInstanceBuilder};
 use spin_world::spin::sqlite::sqlite as v3;
@@ -17,6 +18,7 @@ pub struct InstanceState {
     connections: spin_resource_table::Table<Box<dyn Connection>>,
     /// A map from database label to connection creators.
     connection_creators: HashMap<String, Arc<dyn ConnectionCreator>>,
+    otel: OtelFactorState,
 }
 
 impl InstanceState {
@@ -26,11 +28,13 @@ impl InstanceState {
     pub fn new(
         allowed_databases: Arc<HashSet<String>>,
         connection_creators: HashMap<String, Arc<dyn ConnectionCreator>>,
+        otel: OtelFactorState,
     ) -> Self {
         Self {
             allowed_databases,
             connections: spin_resource_table::Table::new(256),
             connection_creators,
+            otel,
         }
     }
 
@@ -154,6 +158,7 @@ impl v2::Host for InstanceState {
 impl v2::HostConnection for InstanceState {
     #[instrument(name = "spin_sqlite.open", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", sqlite.backend = Empty))]
     async fn open(&mut self, database: String) -> Result<Resource<v2::Connection>, v2::Error> {
+        self.otel.reparent_tracing_span();
         self.open_impl(database).await.map_err(to_v2_error)
     }
 
@@ -164,6 +169,7 @@ impl v2::HostConnection for InstanceState {
         query: String,
         parameters: Vec<v2::Value>,
     ) -> Result<v2::QueryResult, v2::Error> {
+        self.otel.reparent_tracing_span();
         self.execute_impl(
             connection,
             query,

--- a/crates/factor-variables/Cargo.toml
+++ b/crates/factor-variables/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 spin-expressions = { path = "../expressions" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }

--- a/crates/factor-variables/src/host.rs
+++ b/crates/factor-variables/src/host.rs
@@ -8,6 +8,7 @@ use crate::InstanceState;
 impl variables::Host for InstanceState {
     #[instrument(name = "spin_variables.get", skip(self), fields(otel.kind = "client"))]
     async fn get(&mut self, key: String) -> Result<String, variables::Error> {
+        self.otel.reparent_tracing_span();
         let key = spin_expressions::Key::new(&key).map_err(expressions_to_variables_err)?;
         self.expression_resolver
             .resolve(&self.component_id, key)

--- a/crates/factor-variables/src/lib.rs
+++ b/crates/factor-variables/src/lib.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use runtime_config::RuntimeConfig;
 use spin_expressions::{ProviderResolver as ExpressionResolver, Template};
+use spin_factor_otel::OtelFactorState;
 use spin_factors::{
     anyhow, ConfigureAppContext, Factor, FactorData, InitContext, PrepareContext, RuntimeFactors,
     SelfInstanceBuilder,
@@ -62,13 +63,15 @@ impl Factor for VariablesFactor {
 
     fn prepare<T: RuntimeFactors>(
         &self,
-        ctx: PrepareContext<T, Self>,
+        mut ctx: PrepareContext<T, Self>,
     ) -> anyhow::Result<InstanceState> {
         let component_id = ctx.app_component().id().to_string();
         let expression_resolver = ctx.app_state().expression_resolver.clone();
+        let otel = OtelFactorState::from_prepare_context(&mut ctx)?;
         Ok(InstanceState {
             component_id,
             expression_resolver,
+            otel,
         })
     }
 }
@@ -94,6 +97,7 @@ impl AppState {
 pub struct InstanceState {
     component_id: String,
     expression_resolver: Arc<ExpressionResolver>,
+    otel: OtelFactorState,
 }
 
 impl InstanceState {

--- a/crates/runtime-config/Cargo.toml
+++ b/crates/runtime-config/Cargo.toml
@@ -15,6 +15,7 @@ spin-common = { path = "../common" }
 spin-expressions = { path = "../expressions" }
 spin-factor-key-value = { path = "../factor-key-value" }
 spin-factor-llm = { path = "../factor-llm" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-http = { path = "../factor-outbound-http" }
 spin-factor-outbound-mqtt = { path = "../factor-outbound-mqtt" }
 spin-factor-outbound-mysql = { path = "../factor-outbound-mysql" }

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -5,6 +5,7 @@ use spin_common::ui::quoted_path;
 use spin_factor_key_value::runtime_config::spin::{self as key_value};
 use spin_factor_key_value::KeyValueFactor;
 use spin_factor_llm::{spin as llm, LlmFactor};
+use spin_factor_otel::OtelFactor;
 use spin_factor_outbound_http::OutboundHttpFactor;
 use spin_factor_outbound_mqtt::OutboundMqttFactor;
 use spin_factor_outbound_mysql::OutboundMysqlFactor;
@@ -395,6 +396,12 @@ impl FactorRuntimeConfigSource<OutboundMqttFactor> for TomlRuntimeConfigSource<'
 impl FactorRuntimeConfigSource<SqliteFactor> for TomlRuntimeConfigSource<'_, '_> {
     fn get_runtime_config(&mut self) -> anyhow::Result<Option<spin_factor_sqlite::RuntimeConfig>> {
         Ok(Some(self.sqlite.resolve(&self.toml.table)?))
+    }
+}
+
+impl FactorRuntimeConfigSource<OtelFactor> for TomlRuntimeConfigSource<'_, '_> {
+    fn get_runtime_config(&mut self) -> anyhow::Result<Option<()>> {
+        Ok(None)
     }
 }
 

--- a/crates/runtime-factors/Cargo.toml
+++ b/crates/runtime-factors/Cargo.toml
@@ -19,6 +19,7 @@ clap = { workspace = true, features = ["derive", "env"] }
 spin-common = { path = "../common" }
 spin-factor-key-value = { path = "../factor-key-value" }
 spin-factor-llm = { path = "../factor-llm" }
+spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-http = { path = "../factor-outbound-http" }
 spin-factor-outbound-mqtt = { path = "../factor-outbound-mqtt" }
 spin-factor-outbound-mysql = { path = "../factor-outbound-mysql" }

--- a/crates/runtime-factors/src/build.rs
+++ b/crates/runtime-factors/src/build.rs
@@ -46,10 +46,15 @@ impl RuntimeFactorsBuilder for FactorsBuilder {
 
         runtime_config.summarize(config.runtime_config_file.as_deref());
 
+        // This is a hack b/c we know the version of this crate will be the same as the version of Spin
+        let spin_version = env!("CARGO_PKG_VERSION");
+
         let factors = TriggerFactors::new(
             runtime_config.state_dir(),
             config.working_dir.clone(),
             args.allow_transient_write,
+            args.experimental_wasi_otel,
+            spin_version,
         )
         .context("failed to create factors")?;
         Ok((factors, runtime_config))

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -10,11 +10,11 @@ http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
 opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
 opentelemetry-appender-tracing = "0.28"
-opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.28", features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
+opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }
-tracing-opentelemetry = { version = "0.29", default-features = false, features = ["metrics"] }
+tracing-opentelemetry = { workspace = true, default-features = false, features = ["metrics"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["smallvec", "fmt", "ansi", "std", "env-filter", "json", "registry"] }
 
 [features]

--- a/crates/telemetry/src/env.rs
+++ b/crates/telemetry/src/env.rs
@@ -19,7 +19,7 @@ const SPIN_DISABLE_LOG_TO_TRACING: &str = "SPIN_DISABLE_LOG_TO_TRACING";
 /// - `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
 ///
 /// Note that this is overridden if OTEL_SDK_DISABLED is set and not empty.
-pub(crate) fn otel_tracing_enabled() -> bool {
+pub fn otel_tracing_enabled() -> bool {
     any_vars_set(&[
         OTEL_EXPORTER_OTLP_ENDPOINT,
         OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
@@ -33,7 +33,7 @@ pub(crate) fn otel_tracing_enabled() -> bool {
 /// - `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
 ///
 /// Note that this is overridden if OTEL_SDK_DISABLED is set and not empty.
-pub(crate) fn otel_metrics_enabled() -> bool {
+pub fn otel_metrics_enabled() -> bool {
     any_vars_set(&[
         OTEL_EXPORTER_OTLP_ENDPOINT,
         OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,
@@ -47,7 +47,7 @@ pub(crate) fn otel_metrics_enabled() -> bool {
 /// - `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`
 ///
 /// Note that this is overridden if OTEL_SDK_DISABLED is set and not empty.
-pub(crate) fn otel_logs_enabled() -> bool {
+pub fn otel_logs_enabled() -> bool {
     any_vars_set(&[
         OTEL_EXPORTER_OTLP_ENDPOINT,
         OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,
@@ -59,7 +59,7 @@ pub(crate) fn otel_logs_enabled() -> bool {
 ///
 /// It is considered disabled if the environment variable `SPIN_DISABLED_LOG_TO_TRACING` is set and not
 /// empty. By default the features is enabled.
-pub(crate) fn spin_disable_log_to_tracing() -> bool {
+pub fn spin_disable_log_to_tracing() -> bool {
     any_vars_set(&[SPIN_DISABLE_LOG_TO_TRACING])
 }
 
@@ -72,13 +72,13 @@ fn any_vars_set(enabling_vars: &[&str]) -> bool {
 /// Returns a boolean indicating if the OTEL SDK should be disabled for all signals.
 ///
 /// It is considered disabled if the environment variable `OTEL_SDK_DISABLED` is set and not empty.
-pub(crate) fn otel_sdk_disabled() -> bool {
+pub fn otel_sdk_disabled() -> bool {
     std::env::var_os(OTEL_SDK_DISABLED).is_some_and(|val| !val.is_empty())
 }
 
 /// The protocol to use for OTLP exporter.
 #[derive(Debug)]
-pub(crate) enum OtlpProtocol {
+pub enum OtlpProtocol {
     Grpc,
     HttpProtobuf,
     HttpJson,
@@ -86,7 +86,7 @@ pub(crate) enum OtlpProtocol {
 
 impl OtlpProtocol {
     /// Returns the protocol to be used for exporting traces as defined by the environment.
-    pub(crate) fn traces_protocol_from_env() -> Self {
+    pub fn traces_protocol_from_env() -> Self {
         Self::protocol_from_env(
             std::env::var(OTEL_EXPORTER_OTLP_TRACES_PROTOCOL),
             std::env::var(OTEL_EXPORTER_OTLP_PROTOCOL),
@@ -94,7 +94,7 @@ impl OtlpProtocol {
     }
 
     /// Returns the protocol to be used for exporting metrics as defined by the environment.
-    pub(crate) fn metrics_protocol_from_env() -> Self {
+    pub fn metrics_protocol_from_env() -> Self {
         Self::protocol_from_env(
             std::env::var(OTEL_EXPORTER_OTLP_METRICS_PROTOCOL),
             std::env::var(OTEL_EXPORTER_OTLP_PROTOCOL),
@@ -102,7 +102,7 @@ impl OtlpProtocol {
     }
 
     /// Returns the protocol to be used for exporting logs as defined by the environment.
-    pub(crate) fn logs_protocol_from_env() -> Self {
+    pub fn logs_protocol_from_env() -> Self {
         Self::protocol_from_env(
             std::env::var(OTEL_EXPORTER_OTLP_LOGS_PROTOCOL),
             std::env::var(OTEL_EXPORTER_OTLP_PROTOCOL),

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -9,7 +9,7 @@ use tracing_subscriber::{fmt, prelude::*, registry, EnvFilter, Layer};
 
 mod alert_in_dev;
 pub mod detector;
-mod env;
+pub mod env;
 pub mod logs;
 pub mod metrics;
 mod propagation;

--- a/crates/telemetry/src/logs.rs
+++ b/crates/telemetry/src/logs.rs
@@ -3,8 +3,9 @@ use std::{ascii::escape_default, sync::OnceLock};
 use anyhow::bail;
 use opentelemetry::logs::{LogRecord, Logger, LoggerProvider};
 use opentelemetry_sdk::{
-    logs::{BatchConfigBuilder, BatchLogProcessor, SdkLogger},
+    logs::{log_processor_with_async_runtime::BatchLogProcessor, BatchConfigBuilder, SdkLogger},
     resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
+    runtime::Tokio,
     Resource,
 };
 
@@ -97,7 +98,7 @@ pub(crate) fn init_otel_logging_backend(spin_version: String) -> anyhow::Result<
     let provider = opentelemetry_sdk::logs::SdkLoggerProvider::builder()
         .with_resource(resource)
         .with_log_processor(
-            BatchLogProcessor::builder(exporter)
+            BatchLogProcessor::builder(exporter, Tokio)
                 .with_batch_config(BatchConfigBuilder::default().build())
                 .build(),
         )

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1,8 +1,9 @@
 use anyhow::{bail, Result};
 use opentelemetry::global;
 use opentelemetry_sdk::{
-    metrics::{PeriodicReader, SdkMeterProvider},
+    metrics::{periodic_reader_with_async_runtime::PeriodicReader, SdkMeterProvider},
     resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
+    runtime::Tokio,
     Resource,
 };
 use tracing::Subscriber;
@@ -45,7 +46,7 @@ pub(crate) fn otel_metrics_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
         OtlpProtocol::HttpJson => bail!("http/json OTLP protocol is not supported"),
     };
 
-    let reader = PeriodicReader::builder(exporter).build();
+    let reader = PeriodicReader::builder(exporter, Tokio).build();
     let meter_provider = SdkMeterProvider::builder()
         .with_reader(reader)
         .with_resource(resource)

--- a/crates/telemetry/src/traces.rs
+++ b/crates/telemetry/src/traces.rs
@@ -2,6 +2,7 @@ use anyhow::bail;
 use opentelemetry::{global, trace::TracerProvider};
 use opentelemetry_sdk::{
     resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
+    runtime::Tokio,
     Resource,
 };
 use tracing::Subscriber;
@@ -42,7 +43,11 @@ pub(crate) fn otel_tracing_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
         OtlpProtocol::HttpJson => bail!("http/json OTLP protocol is not supported"),
     };
 
-    let span_processor = opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter).build();
+    let span_processor =
+        opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor::builder(
+            exporter, Tokio,
+        )
+        .build();
 
     let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
         .with_resource(resource)

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -33,6 +33,7 @@ spin-http = { path = "../http" }
 spin-telemetry = { path = "../telemetry" }
 spin-trigger = { path = "../trigger" }
 spin-world = { path = "../world" }
+spin-factor-otel = { path = "../factor-otel" }
 terminal = { path = "../terminal" }
 tokio = { workspace = true, features = ["full"] }
 tokio-rustls = { workspace = true }

--- a/crates/world/Cargo.toml
+++ b/crates/world/Cargo.toml
@@ -5,5 +5,11 @@ authors = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
+anyhow = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
+opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 wasmtime = { workspace = true }

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -47,3 +47,4 @@ pub use fermyon::spin as v1;
 pub use fermyon::spin2_0_0 as v2;
 
 mod conversions;
+pub mod wasi_otel;

--- a/crates/world/src/wasi_otel/common_conversions.rs
+++ b/crates/world/src/wasi_otel/common_conversions.rs
@@ -1,0 +1,254 @@
+use crate::wasi::{self, clocks0_2_0::wall_clock};
+use serde::{
+    de::{self, SeqAccess, Visitor},
+    Deserialize,
+};
+use std::{
+    fmt,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+impl From<wasi::otel::types::KeyValue> for opentelemetry::KeyValue {
+    fn from(kv: wasi::otel::types::KeyValue) -> Self {
+        let owned: OwnedValue = from_json(&kv.value);
+        let value: opentelemetry::Value = owned.into();
+        opentelemetry::KeyValue::new(kv.key, value)
+    }
+}
+
+impl From<&wasi::otel::types::KeyValue> for opentelemetry::KeyValue {
+    fn from(kv: &wasi::otel::types::KeyValue) -> Self {
+        let owned: OwnedValue = from_json(&kv.value);
+        let value: opentelemetry::Value = owned.into();
+        opentelemetry::KeyValue::new(kv.key.to_owned(), value)
+    }
+}
+
+impl From<OwnedValue> for opentelemetry::Value {
+    fn from(value: OwnedValue) -> Self {
+        match value {
+            OwnedValue::String(s) => opentelemetry::Value::String(s.into()),
+            OwnedValue::Bool(v) => opentelemetry::Value::Bool(v),
+            OwnedValue::F64(v) => opentelemetry::Value::F64(v),
+            OwnedValue::I64(v) => opentelemetry::Value::I64(v),
+            OwnedValue::Array(arr) => opentelemetry::Value::Array(match arr {
+                OwnedArray::Bool(v) => opentelemetry::Array::Bool(v),
+                OwnedArray::F64(v) => opentelemetry::Array::F64(v),
+                OwnedArray::I64(v) => opentelemetry::Array::I64(v),
+                OwnedArray::String(v) => opentelemetry::Array::String(
+                    v.iter()
+                        .map(|e| opentelemetry::StringValue::from(e.to_owned()))
+                        .collect(),
+                ),
+            }),
+        }
+    }
+}
+
+enum OwnedValue {
+    Bool(bool),
+    I64(i64),
+    F64(f64),
+    String(String),
+    Array(OwnedArray),
+}
+
+enum OwnedArray {
+    Bool(Vec<bool>),
+    I64(Vec<i64>),
+    F64(Vec<f64>),
+    String(Vec<String>),
+}
+
+impl<'de> Deserialize<'de> for OwnedValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = OwnedValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a boolean, number, string, or array")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(OwnedValue::Bool(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(OwnedValue::I64(value))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(OwnedValue::F64(value))
+            }
+
+            /// u64 isn't an option in the OpenTelemetry Rust SDK; however, Serde may interpret a JSON number as u64.
+            fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                i64::try_from(value)
+                    .map(|v| Ok(OwnedValue::I64(v)))
+                    .map_err(|_| de::Error::custom("Integer too large for i64"))?
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(OwnedValue::String(value.to_owned()))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut elements = Vec::new();
+
+                // Determine the type by looking at the first element
+                if let Some(first) = seq.next_element::<serde_json::Value>()? {
+                    elements.push(first);
+
+                    // Collect remaining elements
+                    while let Some(elem) = seq.next_element::<serde_json::Value>()? {
+                        elements.push(elem);
+                    }
+
+                    if elements.is_empty() {
+                        return Ok(OwnedValue::Array(OwnedArray::Bool(vec![])));
+                    }
+
+                    match &elements[0] {
+                        serde_json::Value::Bool(_) => {
+                            let bools: Result<Vec<bool>, _> = elements
+                                .iter()
+                                .map(|v| {
+                                    v.as_bool()
+                                        .ok_or_else(|| de::Error::custom("Mixed types in array"))
+                                })
+                                .collect();
+                            Ok(OwnedValue::Array(OwnedArray::Bool(bools?)))
+                        }
+                        serde_json::Value::Number(n) if n.is_i64() => {
+                            let ints: Result<Vec<i64>, _> = elements
+                                .iter()
+                                .map(|v| {
+                                    v.as_i64()
+                                        .ok_or_else(|| de::Error::custom("Mixed types in array"))
+                                })
+                                .collect();
+                            Ok(OwnedValue::Array(OwnedArray::I64(ints?)))
+                        }
+                        serde_json::Value::Number(n) if n.is_f64() => {
+                            let nums: Result<Vec<f64>, _> = elements
+                                .iter()
+                                .map(|v| {
+                                    v.as_f64()
+                                        .ok_or_else(|| de::Error::custom("Mixed types in array"))
+                                })
+                                .collect();
+                            Ok(OwnedValue::Array(OwnedArray::F64(nums?)))
+                        }
+                        serde_json::Value::String(_) => {
+                            let strings: Result<Vec<String>, _> = elements
+                                .iter()
+                                .map(|v| match v.as_str() {
+                                    Some(s) => Ok(s.to_string()),
+                                    None => Err(de::Error::custom("Mixed types in array")),
+                                })
+                                .collect();
+                            Ok(OwnedValue::Array(OwnedArray::String(strings?)))
+                        }
+                        _ => Err(de::Error::custom("Unsupported array element type")),
+                    }
+                } else {
+                    // Empty array using bool as the default
+                    Ok(OwnedValue::Array(OwnedArray::Bool(vec![])))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+// Deserialize a JSON string to a Serde-serializable struct
+pub(crate) fn from_json<T: for<'de> Deserialize<'de>>(json: &str) -> T {
+    serde_json::from_str(json).unwrap_or_else(|e| {
+        panic!(
+            "Failed to deserialize JSON to {}\
+             \n Input: {}\
+             \n Error: {}",
+            std::any::type_name::<T>(),
+            json,
+            e
+        )
+    })
+}
+
+impl From<wasi::otel::types::InstrumentationScope> for opentelemetry::InstrumentationScope {
+    fn from(value: wasi::otel::types::InstrumentationScope) -> Self {
+        let builder =
+            Self::builder(value.name).with_attributes(value.attributes.into_iter().map(Into::into));
+        match (value.version, value.schema_url) {
+            (Some(version), Some(schema_url)) => builder
+                .with_version(version)
+                .with_schema_url(schema_url)
+                .build(),
+            (Some(version), None) => builder.with_version(version).build(),
+            (None, Some(schema_url)) => builder.with_schema_url(schema_url).build(),
+            (None, None) => builder.build(),
+        }
+    }
+}
+
+impl From<wall_clock::Datetime> for SystemTime {
+    fn from(timestamp: wall_clock::Datetime) -> Self {
+        UNIX_EPOCH
+            + Duration::from_secs(timestamp.seconds)
+            + Duration::from_nanos(timestamp.nanoseconds as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! compare_json_and_literal {
+        ($json:expr, $literal:expr) => {{
+            let left: serde_json::Value = from_json($json);
+            let right: serde_json::Value = serde_json::json!($literal);
+            assert_eq!(left, right);
+        }};
+    }
+
+    #[test]
+    fn deserialize_from_json_to_otel_value() {
+        compare_json_and_literal!("false", false);
+        compare_json_and_literal!("[false,true,true]", vec![false, true, true]);
+        compare_json_and_literal!("6", 6);
+        compare_json_and_literal!("[1,2,3,4]", vec![1, 2, 3, 4]);
+        compare_json_and_literal!("-6", -6);
+        compare_json_and_literal!("[-1,-2,-3,-4]", vec![-1, -2, -3, -4]);
+        compare_json_and_literal!("123.456", 123.456);
+        compare_json_and_literal!("[1.0,2.1,3.2,4.3]", vec![1.0, 2.1, 3.2, 4.3]);
+        compare_json_and_literal!("\"test\"", "test");
+        compare_json_and_literal!(
+            "[\"Hello, world!\",\"Goodnight, moon.\"]",
+            vec!["Hello, world!", "Goodnight, moon."]
+        );
+    }
+}

--- a/crates/world/src/wasi_otel/log_conversions.rs
+++ b/crates/world/src/wasi_otel/log_conversions.rs
@@ -1,0 +1,263 @@
+use super::from_json;
+use crate::wasi;
+use base64::Engine;
+use opentelemetry::logs::{LogRecord, Logger, LoggerProvider};
+use opentelemetry_sdk::logs::SdkLoggerProvider;
+use serde::de::{SeqAccess, Visitor};
+use serde::{de, Deserialize};
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+
+pub fn parse_wasi_log_record(
+    wasi_log_record: wasi::otel::logs::LogRecord,
+) -> (
+    opentelemetry_sdk::logs::SdkLogRecord,
+    opentelemetry::InstrumentationScope,
+) {
+    let log_provider = {
+        let mut provider = SdkLoggerProvider::builder();
+        if let Some(resource) = wasi_log_record.resource {
+            let otel_resource = resource.into();
+            provider = provider.with_resource(otel_resource);
+        }
+        provider.build()
+    };
+
+    let logger = log_provider.logger("spin-logger");
+
+    // Parse LogRecord
+    let mut otel_log_record = logger.create_log_record();
+    if let Some(body) = wasi_log_record.body {
+        let owned: OwnedAnyValue = from_json(&body);
+        let otel_body: opentelemetry::logs::AnyValue = owned.into();
+        otel_log_record.set_body(otel_body);
+    }
+    if let Some(name) = wasi_log_record.event_name {
+        otel_log_record.set_event_name(Box::leak(name.into_boxed_str()));
+    }
+    if let Some(timestamp) = wasi_log_record.observed_timestamp {
+        otel_log_record.set_observed_timestamp(timestamp.into());
+    }
+    if let Some(number) = wasi_log_record.severity_number {
+        otel_log_record.set_severity_number(severity_from_u8(number));
+    }
+    if let Some(text) = wasi_log_record.severity_text {
+        otel_log_record.set_severity_text(Box::leak(text.into_boxed_str()));
+    }
+    if let Some(timestamp) = wasi_log_record.timestamp {
+        otel_log_record.set_timestamp(timestamp.into());
+    }
+    if let Some(trace_id) = wasi_log_record.trace_id {
+        if let Some(span_id) = wasi_log_record.span_id {
+            // Both the span ID and trace ID are required values to set trace context.
+            otel_log_record.set_trace_context(
+                opentelemetry::TraceId::from_hex(&trace_id).expect("Failed to parse trace ID"),
+                opentelemetry::SpanId::from_hex(&span_id).expect("Failed to parse span ID"),
+                wasi_log_record.trace_flags.map(Into::into),
+            );
+        }
+    }
+
+    // Parse InstrumentationScope
+    let otel_scope = if let Some(wasi_scope) = wasi_log_record.instrumentation_scope {
+        let attrs: Vec<opentelemetry::KeyValue> = wasi_scope
+            .attributes
+            .iter()
+            .map(|e| {
+                let kv: opentelemetry::KeyValue = e.into();
+                kv
+            })
+            .collect();
+        let mut scope = opentelemetry::InstrumentationScope::builder(Cow::Owned(wasi_scope.name))
+            .with_attributes(attrs);
+        if let Some(url) = wasi_scope.schema_url {
+            scope = scope.with_schema_url(Cow::Owned(url));
+        }
+        if let Some(version) = wasi_scope.version {
+            scope = scope.with_version(version);
+        }
+        scope.build()
+    } else {
+        opentelemetry::InstrumentationScope::default()
+    };
+
+    (otel_log_record, otel_scope)
+}
+
+fn severity_from_u8(n: u8) -> opentelemetry::logs::Severity {
+    use opentelemetry::logs::Severity::*;
+    match n {
+        0 => {
+            // In the spec, there is a brief mention of SeverityNumber=0 used to represent an unspecified severity;
+            // however, this version of OpenTelemetry Rust doesn't implement it.
+            // See https://opentelemetry.io/docs/specs/otel/logs/data-model/#comparing-severity
+            unimplemented!()
+        }
+        1 => Trace,
+        2 => Trace2,
+        3 => Trace3,
+        4 => Trace4,
+        5 => Debug,
+        6 => Debug2,
+        7 => Debug3,
+        8 => Debug4,
+        9 => Info,
+        10 => Info2,
+        11 => Info3,
+        12 => Info4,
+        13 => Warn,
+        14 => Warn2,
+        15 => Warn3,
+        16 => Warn4,
+        17 => Error,
+        18 => Error2,
+        19 => Error3,
+        20 => Error4,
+        21 => Fatal,
+        22 => Fatal2,
+        23 => Fatal3,
+        24 => Fatal4,
+        num => panic!("{num} is not a valid severity number"),
+    }
+}
+
+#[derive(Clone)]
+enum OwnedAnyValue {
+    Int(i64),
+    Double(f64),
+    String(String),
+    Boolean(bool),
+    Bytes(Vec<u8>),
+    ListAny(Vec<OwnedAnyValue>),
+    Map(HashMap<String, OwnedAnyValue>),
+}
+
+impl From<OwnedAnyValue> for opentelemetry::logs::AnyValue {
+    fn from(value: OwnedAnyValue) -> Self {
+        use opentelemetry::logs::AnyValue;
+        match value {
+            OwnedAnyValue::Boolean(v) => AnyValue::Boolean(v),
+            OwnedAnyValue::Bytes(v) => AnyValue::Bytes(Box::new(v.to_vec())),
+            OwnedAnyValue::Double(v) => AnyValue::Double(v),
+            OwnedAnyValue::Int(v) => AnyValue::Int(v),
+            OwnedAnyValue::String(v) => AnyValue::String(v.clone().into()),
+            OwnedAnyValue::ListAny(v) => {
+                AnyValue::ListAny(Box::new(v.iter().map(|e| e.clone().into()).collect()))
+            }
+            OwnedAnyValue::Map(v) => AnyValue::Map(Box::new(
+                v.iter()
+                    .map(|(k, v)| (k.clone().into(), v.clone().into()))
+                    .collect(),
+            )),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for OwnedAnyValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct AnyValueVisitor;
+
+        impl<'de> Visitor<'de> for AnyValueVisitor {
+            type Value = OwnedAnyValue;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a boolean, number, string, or array")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(OwnedAnyValue::Boolean(value))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(OwnedAnyValue::Int(value))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(OwnedAnyValue::Double(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                if let Some(stripped) = value.strip_prefix("data:application/octet-stream;base64,")
+                {
+                    // Handle byte array
+                    base64::engine::general_purpose::STANDARD
+                        .decode(stripped)
+                        .map(OwnedAnyValue::Bytes)
+                        .map_err(|e| de::Error::custom(e))
+                } else {
+                    // Handle String
+                    Ok(OwnedAnyValue::String(value.to_owned()))
+                }
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut result = HashMap::new();
+                // Recursively deserialize each key-value pair.
+                while let Some((key, value)) = map.next_entry::<String, OwnedAnyValue>()? {
+                    result.insert(key, value);
+                }
+
+                Ok(OwnedAnyValue::Map(result))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut elements = Vec::new();
+
+                // Recursively deserialize each element.
+                while let Some(elem) = seq.next_element::<OwnedAnyValue>()? {
+                    elements.push(elem);
+                }
+
+                Ok(OwnedAnyValue::ListAny(elements))
+            }
+        }
+
+        deserializer.deserialize_any(AnyValueVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_json_to_otel_log_any_value() {
+        let test_json = "{\"key1\": false, \"key2\": 123.456, \"key3\": 41, \"key4\": \"data:application/octet-stream;base64,SGVsbG8sIHdvcmxkIQ==\", \"key5\": \"This is a string\", \"key6\": [1, 2, 3], \"key7\": {\"nestedkey1\": \"Hello, from within!\"}}";
+        let expected: serde_json::Value = serde_json::json!({
+            "key1": false,
+            "key2": 123.456,
+            "key3": 41,
+            //'Hello, world!' encoded to base64
+            "key4": "data:application/octet-stream;base64,SGVsbG8sIHdvcmxkIQ==",
+            "key5": "This is a string",
+            "key6": [1, 2, 3],
+            "key7": {
+                "nestedkey1": "Hello, from within!"
+            }
+        });
+        let actual: serde_json::Value = from_json(test_json);
+        assert_eq!(expected, actual);
+    }
+}

--- a/crates/world/src/wasi_otel/metric_conversions.rs
+++ b/crates/world/src/wasi_otel/metric_conversions.rs
@@ -1,0 +1,271 @@
+use crate::wasi;
+use std::borrow::Cow;
+
+impl From<wasi::otel::metrics::ResourceMetrics>
+    for opentelemetry_sdk::metrics::data::ResourceMetrics
+{
+    fn from(value: wasi::otel::metrics::ResourceMetrics) -> Self {
+        Self {
+            resource: value.resource.into(),
+            scope_metrics: value.scope_metrics.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::Resource> for opentelemetry_sdk::Resource {
+    fn from(value: wasi::otel::metrics::Resource) -> Self {
+        let attributes: Vec<opentelemetry::KeyValue> =
+            value.attributes.into_iter().map(Into::into).collect();
+        let schema_url: Option<String> = value.schema_url;
+        match schema_url {
+            Some(url) => opentelemetry_sdk::resource::Resource::builder()
+                .with_schema_url(attributes, url)
+                .build(),
+            None => opentelemetry_sdk::resource::Resource::builder()
+                .with_attributes(attributes)
+                .build(),
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::ScopeMetrics> for opentelemetry_sdk::metrics::data::ScopeMetrics {
+    fn from(value: wasi::otel::metrics::ScopeMetrics) -> Self {
+        Self {
+            scope: value.scope.into(),
+            metrics: value.metrics.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::Metric> for opentelemetry_sdk::metrics::data::Metric {
+    fn from(value: wasi::otel::metrics::Metric) -> Self {
+        Self {
+            name: Cow::Owned(value.name),
+            description: Cow::Owned(value.description),
+            unit: Cow::Owned(value.unit),
+            data: value.data.into(),
+        }
+    }
+}
+
+/// Converts a Wasi exemplar to an OTel exemplar
+macro_rules! exemplars_to_otel {
+    (
+            $wasi_exemplar_list:expr,
+            $exemplar_type:ty
+        ) => {
+        $wasi_exemplar_list
+            .iter()
+            .map(|e| {
+                let span_id: [u8; 8] = e
+                    .span_id
+                    .as_bytes()
+                    .try_into()
+                    .expect("failed to parse span ID");
+                let trace_id: [u8; 16] = e
+                    .trace_id
+                    .as_bytes()
+                    .try_into()
+                    .expect("failed to parse trace ID");
+                opentelemetry_sdk::metrics::data::Exemplar::<$exemplar_type> {
+                    filtered_attributes: e
+                        .filtered_attributes
+                        .to_owned()
+                        .into_iter()
+                        .map(Into::into)
+                        .collect(),
+                    time: e.time.into(),
+                    value: e.value.into(),
+                    span_id,
+                    trace_id,
+                }
+            })
+            .collect()
+    };
+}
+
+/// Converts a WASI Gauge to an OTel Gauge
+macro_rules! wasi_gauge_to_otel {
+    ($gauge:expr, $number_type:ty) => {
+        Box::new(opentelemetry_sdk::metrics::data::Gauge {
+            data_points: $gauge
+                .data_points
+                .iter()
+                .map(|dp| opentelemetry_sdk::metrics::data::GaugeDataPoint {
+                    attributes: dp.attributes.iter().map(Into::into).collect(),
+                    value: dp.value.into(),
+                    exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
+                })
+                .collect(),
+            start_time: match $gauge.start_time {
+                Some(t) => Some(t.into()),
+                None => None,
+            },
+            time: $gauge.time.into(),
+        })
+    };
+}
+
+/// Converts a WASI Sum to an OTel Sum
+macro_rules! wasi_sum_to_otel {
+    ($sum:expr, $number_type:ty) => {
+        Box::new(opentelemetry_sdk::metrics::data::Sum {
+            data_points: $sum
+                .data_points
+                .iter()
+                .map(|dp| opentelemetry_sdk::metrics::data::SumDataPoint {
+                    attributes: dp.attributes.iter().map(Into::into).collect(),
+                    exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
+                    value: dp.value.into(),
+                })
+                .collect(),
+            start_time: $sum.start_time.into(),
+            time: $sum.time.into(),
+            temporality: $sum.temporality.into(),
+            is_monotonic: $sum.is_monotonic,
+        })
+    };
+}
+
+/// Converts a WASI Histogram to an OTel Histogram
+macro_rules! wasi_histogram_to_otel {
+    ($histogram:expr, $number_type:ty) => {
+        Box::new(opentelemetry_sdk::metrics::data::Histogram {
+            data_points: $histogram
+                .data_points
+                .iter()
+                .map(|dp| opentelemetry_sdk::metrics::data::HistogramDataPoint {
+                    attributes: dp.attributes.iter().map(Into::into).collect(),
+                    bounds: dp.bounds.to_owned(),
+                    bucket_counts: dp.bucket_counts.to_owned(),
+                    exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
+                    count: dp.count,
+                    max: match dp.max {
+                        Some(m) => Some(m.into()),
+                        None => None,
+                    },
+                    min: match dp.min {
+                        Some(m) => Some(m.into()),
+                        None => None,
+                    },
+                    sum: dp.sum.into(),
+                })
+                .collect(),
+            start_time: $histogram.start_time.into(),
+            time: $histogram.time.into(),
+            temporality: $histogram.temporality.into(),
+        })
+    };
+}
+
+/// Converts a WASI ExponentialHistogram to an OTel ExponentialHistogram
+macro_rules! wasi_exponential_histogram_to_otel {
+    ($histogram:expr, $number_type:ty) => {
+        Box::new(opentelemetry_sdk::metrics::data::ExponentialHistogram {
+            data_points: $histogram
+                .data_points
+                .iter()
+                .map(
+                    |dp| opentelemetry_sdk::metrics::data::ExponentialHistogramDataPoint {
+                        attributes: dp.attributes.iter().map(Into::into).collect(),
+                        exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
+                        count: dp.count as usize,
+                        max: match dp.max {
+                            Some(m) => Some(m.into()),
+                            None => None,
+                        },
+                        min: match dp.min {
+                            Some(m) => Some(m.into()),
+                            None => None,
+                        },
+                        sum: dp.sum.into(),
+                        scale: dp.scale,
+                        zero_count: dp.zero_count,
+                        positive_bucket: dp.positive_bucket.to_owned().into(),
+                        negative_bucket: dp.negative_bucket.to_owned().into(),
+                        zero_threshold: dp.zero_threshold,
+                    },
+                )
+                .collect(),
+            start_time: $histogram.start_time.into(),
+            time: $histogram.time.into(),
+            temporality: $histogram.temporality.into(),
+        })
+    };
+}
+
+impl From<wasi::otel::metrics::MetricData>
+    for Box<dyn opentelemetry_sdk::metrics::data::Aggregation>
+{
+    fn from(value: wasi::otel::metrics::MetricData) -> Self {
+        match value {
+            wasi::otel::metrics::MetricData::F64Sum(s) => wasi_sum_to_otel!(s, f64),
+            wasi::otel::metrics::MetricData::S64Sum(s) => wasi_sum_to_otel!(s, i64),
+            wasi::otel::metrics::MetricData::U64Sum(s) => wasi_sum_to_otel!(s, u64),
+            wasi::otel::metrics::MetricData::F64Gauge(g) => wasi_gauge_to_otel!(g, f64),
+            wasi::otel::metrics::MetricData::S64Gauge(g) => wasi_gauge_to_otel!(g, i64),
+            wasi::otel::metrics::MetricData::U64Gauge(g) => wasi_gauge_to_otel!(g, u64),
+            wasi::otel::metrics::MetricData::F64Histogram(h) => wasi_histogram_to_otel!(h, f64),
+            wasi::otel::metrics::MetricData::S64Histogram(h) => wasi_histogram_to_otel!(h, i64),
+            wasi::otel::metrics::MetricData::U64Histogram(h) => wasi_histogram_to_otel!(h, u64),
+            wasi::otel::metrics::MetricData::F64ExponentialHistogram(h) => {
+                wasi_exponential_histogram_to_otel!(h, f64)
+            }
+            wasi::otel::metrics::MetricData::S64ExponentialHistogram(h) => {
+                wasi_exponential_histogram_to_otel!(h, i64)
+            }
+            wasi::otel::metrics::MetricData::U64ExponentialHistogram(h) => {
+                wasi_exponential_histogram_to_otel!(h, u64)
+            }
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::MetricNumber> for f64 {
+    fn from(value: wasi::otel::metrics::MetricNumber) -> Self {
+        match value {
+            wasi::otel::metrics::MetricNumber::F64(n) => n,
+            _ => panic!("error converting WASI MetricNumber to f64"),
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::MetricNumber> for u64 {
+    fn from(value: wasi::otel::metrics::MetricNumber) -> Self {
+        match value {
+            wasi::otel::metrics::MetricNumber::U64(n) => n,
+            _ => panic!("error converting WASI MetricNumber to u64"),
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::MetricNumber> for i64 {
+    fn from(value: wasi::otel::metrics::MetricNumber) -> Self {
+        match value {
+            wasi::otel::metrics::MetricNumber::S64(n) => n,
+            _ => panic!("error converting WASI MetricNumber to i64"),
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::ExponentialBucket>
+    for opentelemetry_sdk::metrics::data::ExponentialBucket
+{
+    fn from(value: wasi::otel::metrics::ExponentialBucket) -> Self {
+        Self {
+            offset: value.offset,
+            counts: value.counts,
+        }
+    }
+}
+
+impl From<wasi::otel::metrics::Temporality> for opentelemetry_sdk::metrics::Temporality {
+    fn from(value: wasi::otel::metrics::Temporality) -> Self {
+        use opentelemetry_sdk::metrics::Temporality;
+        match value {
+            wasi::otel::metrics::Temporality::Cumulative => Temporality::Cumulative,
+            wasi::otel::metrics::Temporality::Delta => Temporality::Delta,
+            wasi::otel::metrics::Temporality::LowMemory => Temporality::LowMemory,
+        }
+    }
+}

--- a/crates/world/src/wasi_otel/mod.rs
+++ b/crates/world/src/wasi_otel/mod.rs
@@ -1,0 +1,7 @@
+mod common_conversions;
+mod log_conversions;
+mod metric_conversions;
+mod trace_conversions;
+
+use common_conversions::from_json;
+pub use log_conversions::parse_wasi_log_record;

--- a/crates/world/src/wasi_otel/trace_conversions.rs
+++ b/crates/world/src/wasi_otel/trace_conversions.rs
@@ -1,0 +1,155 @@
+use crate::wasi;
+use opentelemetry_sdk::trace::{SpanEvents, SpanLinks};
+
+impl From<wasi::otel::tracing::SpanData> for opentelemetry_sdk::trace::SpanData {
+    fn from(value: wasi::otel::tracing::SpanData) -> Self {
+        let mut span_events = SpanEvents::default();
+        span_events.events = value.events.into_iter().map(Into::into).collect();
+        span_events.dropped_count = value.dropped_events;
+        let mut span_links = SpanLinks::default();
+        span_links.links = value.links.into_iter().map(Into::into).collect();
+        span_links.dropped_count = value.dropped_links;
+        Self {
+            span_context: value.span_context.into(),
+            parent_span_id: opentelemetry::trace::SpanId::from_hex(&value.parent_span_id)
+                .unwrap_or(opentelemetry::trace::SpanId::INVALID),
+            span_kind: value.span_kind.into(),
+            name: value.name.into(),
+            start_time: value.start_time.into(),
+            end_time: value.end_time.into(),
+            attributes: value.attributes.into_iter().map(Into::into).collect(),
+            dropped_attributes_count: value.dropped_attributes,
+            events: span_events,
+            links: span_links,
+            status: value.status.into(),
+            instrumentation_scope: value.instrumentation_scope.into(),
+        }
+    }
+}
+
+impl From<wasi::otel::tracing::SpanContext> for opentelemetry::trace::SpanContext {
+    fn from(sc: wasi::otel::tracing::SpanContext) -> Self {
+        let trace_id = opentelemetry::trace::TraceId::from_hex(&sc.trace_id)
+            .unwrap_or(opentelemetry::trace::TraceId::INVALID);
+        let span_id = opentelemetry::trace::SpanId::from_hex(&sc.span_id)
+            .unwrap_or(opentelemetry::trace::SpanId::INVALID);
+        let trace_state = opentelemetry::trace::TraceState::from_key_value(sc.trace_state)
+            .unwrap_or_else(|_| opentelemetry::trace::TraceState::default());
+        Self::new(
+            trace_id,
+            span_id,
+            sc.trace_flags.into(),
+            sc.is_remote,
+            trace_state,
+        )
+    }
+}
+
+impl From<opentelemetry::trace::SpanContext> for wasi::otel::tracing::SpanContext {
+    fn from(sc: opentelemetry::trace::SpanContext) -> Self {
+        Self {
+            trace_id: format!("{:x}", sc.trace_id()),
+            span_id: format!("{:x}", sc.span_id()),
+            trace_flags: sc.trace_flags().into(),
+            is_remote: sc.is_remote(),
+            trace_state: sc
+                .trace_state()
+                .header()
+                .split(',')
+                .filter_map(|s| {
+                    if let Some((key, value)) = s.split_once('=') {
+                        Some((key.to_string(), value.to_string()))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+impl From<wasi::otel::tracing::TraceFlags> for opentelemetry::trace::TraceFlags {
+    fn from(flags: wasi::otel::tracing::TraceFlags) -> Self {
+        Self::new(flags.as_array()[0] as u8)
+    }
+}
+
+impl From<opentelemetry::trace::TraceFlags> for wasi::otel::tracing::TraceFlags {
+    fn from(flags: opentelemetry::trace::TraceFlags) -> Self {
+        if flags.is_sampled() {
+            wasi::otel::tracing::TraceFlags::SAMPLED
+        } else {
+            wasi::otel::tracing::TraceFlags::empty()
+        }
+    }
+}
+
+impl From<wasi::otel::tracing::SpanKind> for opentelemetry::trace::SpanKind {
+    fn from(kind: wasi::otel::tracing::SpanKind) -> Self {
+        match kind {
+            wasi::otel::tracing::SpanKind::Client => opentelemetry::trace::SpanKind::Client,
+            wasi::otel::tracing::SpanKind::Server => opentelemetry::trace::SpanKind::Server,
+            wasi::otel::tracing::SpanKind::Producer => opentelemetry::trace::SpanKind::Producer,
+            wasi::otel::tracing::SpanKind::Consumer => opentelemetry::trace::SpanKind::Consumer,
+            wasi::otel::tracing::SpanKind::Internal => opentelemetry::trace::SpanKind::Internal,
+        }
+    }
+}
+
+impl From<wasi::otel::tracing::Event> for opentelemetry::trace::Event {
+    fn from(event: wasi::otel::tracing::Event) -> Self {
+        Self::new(
+            event.name,
+            event.time.into(),
+            event.attributes.into_iter().map(Into::into).collect(),
+            0,
+        )
+    }
+}
+
+impl From<wasi::otel::tracing::Link> for opentelemetry::trace::Link {
+    fn from(link: wasi::otel::tracing::Link) -> Self {
+        Self::new(
+            link.span_context.into(),
+            link.attributes.into_iter().map(Into::into).collect(),
+            0,
+        )
+    }
+}
+
+impl From<wasi::otel::tracing::Status> for opentelemetry::trace::Status {
+    fn from(status: wasi::otel::tracing::Status) -> Self {
+        match status {
+            wasi::otel::tracing::Status::Unset => Self::Unset,
+            wasi::otel::tracing::Status::Ok => Self::Ok,
+            wasi::otel::tracing::Status::Error(s) => Self::Error {
+                description: s.into(),
+            },
+        }
+    }
+}
+
+mod test {
+    #[test]
+    fn trace_flags() {
+        let flags = opentelemetry::trace::TraceFlags::SAMPLED;
+        let flags2 = crate::wasi::otel::tracing::TraceFlags::from(flags);
+        let flags3 = opentelemetry::trace::TraceFlags::from(flags2);
+        assert_eq!(flags, flags3);
+    }
+
+    #[test]
+    fn span_context() {
+        let sc = opentelemetry::trace::SpanContext::new(
+            opentelemetry::trace::TraceId::from_hex("4fb34cb4484029f7881399b149e41e98").unwrap(),
+            opentelemetry::trace::SpanId::from_hex("9ffd58d3cd4dd90b").unwrap(),
+            opentelemetry::trace::TraceFlags::SAMPLED,
+            false,
+            opentelemetry::trace::TraceState::from_key_value(vec![("foo", "bar"), ("baz", "qux")])
+                .unwrap(),
+        );
+        let sc2 = crate::wasi::otel::tracing::SpanContext::from(sc.clone());
+        let sc3 = opentelemetry::trace::SpanContext::from(sc2);
+        assert_eq!(sc, sc3);
+    }
+}

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -3272,7 +3272,6 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
@@ -4875,6 +4874,7 @@ dependencies = [
  "anyhow",
  "serde",
  "spin-core",
+ "spin-factor-otel",
  "spin-factors",
  "spin-locked-app",
  "spin-resource-table",
@@ -4893,6 +4893,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "serde",
+ "spin-factor-otel",
  "spin-factors",
  "spin-llm-remote-http",
  "spin-locked-app",
@@ -4902,6 +4903,24 @@ dependencies = [
  "toml 0.8.20",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "spin-factor-otel"
+version = "3.6.0-pre0"
+dependencies = [
+ "anyhow",
+ "indexmap 2.9.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "spin-core",
+ "spin-factors",
+ "spin-resource-table",
+ "spin-telemetry",
+ "tracing",
+ "tracing-opentelemetry",
+ "wasi-otel",
 ]
 
 [[package]]
@@ -4919,6 +4938,7 @@ dependencies = [
  "reqwest",
  "rustls 0.23.25",
  "serde",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factors",
  "spin-telemetry",
@@ -4939,6 +4959,7 @@ dependencies = [
  "anyhow",
  "rumqttc",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factors",
  "spin-resource-table",
@@ -4954,6 +4975,7 @@ dependencies = [
  "anyhow",
  "mysql_async",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factors",
  "spin-resource-table",
@@ -5001,6 +5023,7 @@ dependencies = [
  "rust_decimal",
  "serde_json",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factors",
  "spin-resource-table",
@@ -5018,6 +5041,7 @@ dependencies = [
  "anyhow",
  "redis",
  "spin-core",
+ "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factors",
  "spin-resource-table",
@@ -5031,6 +5055,7 @@ name = "spin-factor-sqlite"
 version = "3.6.0-pre0"
 dependencies = [
  "async-trait",
+ "spin-factor-otel",
  "spin-factors",
  "spin-locked-app",
  "spin-resource-table",
@@ -5044,6 +5069,7 @@ name = "spin-factor-variables"
 version = "3.6.0-pre0"
 dependencies = [
  "spin-expressions",
+ "spin-factor-otel",
  "spin-factors",
  "spin-telemetry",
  "spin-world",
@@ -5224,6 +5250,7 @@ dependencies = [
  "spin-expressions",
  "spin-factor-key-value",
  "spin-factor-llm",
+ "spin-factor-otel",
  "spin-factor-outbound-http",
  "spin-factor-outbound-mqtt",
  "spin-factor-outbound-mysql",
@@ -5256,6 +5283,7 @@ dependencies = [
  "spin-common",
  "spin-factor-key-value",
  "spin-factor-llm",
+ "spin-factor-otel",
  "spin-factor-outbound-http",
  "spin-factor-outbound-mqtt",
  "spin-factor-outbound-mysql",
@@ -5419,7 +5447,10 @@ dependencies = [
 name = "spin-world"
 version = "3.6.0-pre0"
 dependencies = [
+ "anyhow",
  "async-trait",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "wasmtime",
 ]
 
@@ -6058,6 +6089,7 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -6345,6 +6377,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasi-otel"
+version = "3.6.0-pre0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "wasmtime",
 ]
 
 [[package]]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,7 @@
-mod testcases;
+pub mod testcases;
 
 mod integration_tests {
+    use anyhow::Context;
     use sha2::Digest;
     use std::collections::HashMap;
     use test_environment::{
@@ -9,13 +10,12 @@ mod integration_tests {
     };
     use testing_framework::runtimes::{spin_cli::SpinConfig, SpinAppType};
 
-    use super::testcases::{
+    pub use super::testcases::{
         assert_spin_request, bootstap_env, http_smoke_test_template, run_test, spin_binary,
     };
-    use anyhow::Context;
 
-    /// Helper macro to assert that a condition is true eventually
     #[cfg(feature = "extern-dependencies-tests")]
+    /// Helper macro to assert that a condition is true eventually
     macro_rules! assert_eventually {
         ($e:expr, $t:expr) => {
             let mut i = 0;
@@ -1714,6 +1714,534 @@ route = "/..."
                 Ok(())
             },
         )?;
+        Ok(())
+    }
+}
+
+mod otel_integration_tests {
+    use fake_opentelemetry_collector::FakeCollectorServer;
+    use std::time::Duration;
+    use test_environment::{
+        http::{Method, Request, Response},
+        services::ServicesConfig,
+    };
+    use testing_framework::runtimes::{spin_cli::SpinConfig, SpinAppType};
+
+    use crate::testcases::run_test_inited;
+
+    use super::testcases::{assert_spin_request, spin_binary};
+
+    #[test]
+    // Test that basic otel tracing and inbound/outbound context propagation works
+    fn otel_smoke_test() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "otel-smoke-test",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: Vec::new(),
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/hello"),
+                    Response::new_with_body(200, "Hello World!\n"),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(5, Duration::from_secs(5)));
+
+                assert_eq!(spans.len(), 2);
+
+                // They're all part of the same trace which implies context propagation is working
+                assert!(spans
+                    .iter()
+                    .map(|s| s.trace_id.clone())
+                    .all(|t| t == spans[0].trace_id));
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_nested_spans() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/nested-spans"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(4, Duration::from_secs(5)));
+
+                assert_eq!(spans.len(), 4);
+
+                let handle_request_span = spans
+                    .iter()
+                    .find(|s| s.name == "GET /...")
+                    .expect("'GET /...' span should exist");
+                let exec_component_span = spans
+                    .iter()
+                    .find(|s| s.name == "execute_wasm_component wasi-otel-tracing")
+                    .expect("'execute_wasm_component wasi-otel-tracing' span should exist");
+                let outer_span = spans
+                    .iter()
+                    .find(|s| s.name == "outer_func")
+                    .expect("'outer_func' span should exist");
+                let inner_span = spans
+                    .iter()
+                    .find(|s| s.name == "inner_func")
+                    .expect("'inner_func' span should exist");
+
+                assert!(
+                    handle_request_span.trace_id == exec_component_span.trace_id
+                        && exec_component_span.trace_id == outer_span.trace_id
+                        && outer_span.trace_id == inner_span.trace_id
+                );
+                assert_eq!(
+                    exec_component_span.parent_span_id,
+                    handle_request_span.span_id
+                );
+                assert_eq!(outer_span.parent_span_id, exec_component_span.span_id);
+                assert_eq!(inner_span.parent_span_id, outer_span.span_id);
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_setting_attributes() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/setting-attributes"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(3, Duration::from_secs(5)));
+
+                assert_eq!(spans.len(), 3);
+
+                let attr_span = spans
+                    .iter()
+                    .find(|s| s.name == "setting_attributes")
+                    .expect("'setting_attributes' span should exist");
+
+                // There are some other attributes already set on the span
+                assert_eq!(attr_span.attributes.len(), 2);
+
+                assert_eq!(
+                    attr_span
+                        .attributes
+                        .get("foo")
+                        .expect("'foo' attribute should exist"),
+                    "Some(AnyValue { value: Some(StringValue(\"baz\")) })"
+                );
+                assert_eq!(
+                        attr_span.attributes.get("qux").expect("'qux' attribute should exist"),
+                        "Some(AnyValue { value: Some(ArrayValue(ArrayValue { values: [AnyValue { value: Some(StringValue(\"qaz\")) }, AnyValue { value: Some(StringValue(\"thud\")) }] })) })"
+                    );
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_host_guest_host() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/host-guest-host"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(6, Duration::from_secs(5)));
+
+                assert_eq!(spans.len(), 6);
+
+                assert!(spans
+                    .iter()
+                    .map(|s| s.trace_id.clone())
+                    .all(|t| t == spans[0].trace_id));
+
+                let top_handle_get_span = spans
+                    .iter()
+                    .find(|s| s.name == "GET /..." && s.parent_span_id.is_empty())
+                    .expect("'GET /...' top-level span should exist");
+                let exec_component_span = spans
+                    .iter()
+                    .find(|s| {
+                        s.name == "execute_wasm_component wasi-otel-tracing"
+                            && s.parent_span_id == top_handle_get_span.span_id
+                    })
+                    .expect("'execute_wasm_component wasi-otel-tracing' span should exist");
+                let guest_span = spans
+                    .iter()
+                    .find(|s| s.name == "guest")
+                    .expect("'guest' span should exist");
+                let get_span = spans
+                    .iter()
+                    .find(|s| s.name == "GET")
+                    .expect("'GET' span should exist");
+
+                assert_eq!(guest_span.parent_span_id, exec_component_span.span_id);
+                assert_eq!(get_span.parent_span_id, guest_span.span_id);
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_events() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/events"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(3, Duration::from_secs(5)));
+
+                assert_eq!(spans.len(), 3);
+
+                let event_span = spans
+                    .iter()
+                    .find(|s| s.name == "events")
+                    .expect("'events' span should exist");
+
+                let events = event_span.events.clone();
+                assert_eq!(events.len(), 3);
+
+                let basic_event = events
+                    .iter()
+                    .find(|e| e.name == "basic-event")
+                    .expect("'basic' event should exist");
+                let event_with_attributes = events
+                    .iter()
+                    .find(|e| e.name == "event-with-attributes")
+                    .expect("'event_with_attributes' event should exist");
+                let event_with_timestamp = events
+                    .iter()
+                    .find(|e| e.name == "event-with-timestamp")
+                    .expect("'event_with_timestamp' event should exist");
+
+                assert!(basic_event.time_unix_nano < event_with_attributes.time_unix_nano);
+                assert_eq!(event_with_attributes.attributes.len(), 1);
+                assert!(event_with_attributes.time_unix_nano < event_with_timestamp.time_unix_nano);
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_links() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/links"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(4, Duration::from_secs(5)));
+
+                assert_eq!(spans.len(), 4);
+
+                let first_span = spans
+                    .iter()
+                    .find(|s| s.name == "first")
+                    .expect("'first' span should exist");
+                let second_span = spans
+                    .iter()
+                    .find(|s| s.name == "second")
+                    .expect("'second' span should exist");
+
+                assert_eq!(first_span.links.len(), 0);
+                assert_eq!(second_span.links.len(), 1);
+                assert_eq!(
+                    second_span.links.first().unwrap().span_id,
+                    first_span.span_id
+                );
+                assert_eq!(second_span.links.first().unwrap().attributes.len(), 1);
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_root_span() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/root-span"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(6, Duration::from_secs(5)));
+
+                assert_eq!(spans.len(), 6);
+
+                let root_span = spans
+                    .iter()
+                    .find(|s| s.name == "root")
+                    .expect("'root' span should exist");
+                let request_span = spans
+                    .iter()
+                    .find(|s| s.name == "GET")
+                    .expect("'GET' span should exist");
+
+                assert_eq!(root_span.trace_id, request_span.trace_id);
+                assert_eq!(root_span.span_id, request_span.parent_span_id);
+                assert_eq!(root_span.parent_span_id, "".to_string());
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_start_called_end_not_called() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/start-called-end-not-called"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(7, Duration::from_secs(5)));
+
+                assert!(spans
+                    .iter()
+                    .map(|s| s.trace_id.clone())
+                    .all(|t| t == spans[0].trace_id));
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn wasi_otel_child_span_outlives_parent() -> anyhow::Result<()> {
+        let rt = tokio::runtime::Runtime::new()?;
+        let mut collector = rt
+            .block_on(FakeCollectorServer::start())
+            .expect("fake collector server should start");
+        let collector_endpoint = collector.endpoint().clone();
+
+        run_test_inited(
+            "wasi-otel-tracing",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: vec!["--experimental-wasi-otel".into()],
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::none(),
+            |env| {
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", collector_endpoint);
+                env.set_env_var("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc");
+                env.set_env_var("OTEL_BSP_SCHEDULE_DELAY", "5");
+                Ok(())
+            },
+            move |env| {
+                let spin = env.runtime_mut();
+                assert_spin_request(
+                    spin,
+                    Request::new(Method::Get, "/child-span-outlives-parent"),
+                    Response::new(200),
+                )?;
+
+                let spans = rt.block_on(collector.exported_spans(7, Duration::from_secs(5)));
+
+                assert!(spans
+                    .iter()
+                    .map(|s| s.trace_id.clone())
+                    .all(|t| t == spans[0].trace_id));
+
+                Ok(())
+            },
+        )?;
+
         Ok(())
     }
 }

--- a/tests/test-components/components/Cargo.lock
+++ b/tests/test-components/components/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "ai"
 version = "0.1.0"
 dependencies = [
@@ -33,9 +45,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -83,9 +95,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -315,6 +327,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -399,12 +420,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -561,7 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
  "serde",
  "serde_core",
 ]
@@ -695,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +789,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,9 +808,65 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-wasi"
+version = "0.27.0"
+source = "git+https://github.com/calebschoepp/opentelemetry-wasi?rev=82eb583e3301860a976924de0fa305977f5ad1b0#82eb583e3301860a976924de0fa305977f5ad1b0"
+dependencies = [
+ "anyhow",
+ "base64",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "serde",
+ "serde_json",
+ "spin-sdk 5.1.1",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+ "wit-bindgen 0.47.0",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "otel-smoke-test"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "http 0.2.11",
+ "spin-sdk 2.2.0",
+]
 
 [[package]]
 name = "outbound-http-component"
@@ -958,9 +1049,9 @@ dependencies = [
 
 [[package]]
 name = "routefinder"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f8f99b10dedd317514253dda1fa7c14e344aac96e1f78149a64879ce282aca"
+checksum = "0971d3c8943a6267d6bd0d782fdc4afa7593e7381a92a3df950ff58897e066b5"
 dependencies = [
  "smartcow",
  "smartstring",
@@ -968,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.38.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8975fc98059f365204d635119cf9c5a60ae67b841ed49b5422a9a7e56cdfac0"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -996,9 +1087,9 @@ checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
 name = "serde"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1006,18 +1097,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.225"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1026,13 +1117,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
- "ryu",
+ "memchr",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1043,7 +1136,7 @@ checksum = "0431a35568651e363364210c91983c1da5eb29404d9f0928b67d4ebcfa7d330c"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.56",
 ]
 
 [[package]]
@@ -1055,6 +1148,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1109,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "spin-executor"
-version = "5.0.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde323c004c7d9d68fbccd1dd6caee6330aaefbcb40562587fc0356bd0ea8e5f"
+checksum = "dd83f9f07676e2a8a1e9eaccd245344a67296712c24828bd69f3d11c127cd59d"
 dependencies = [
  "futures",
  "once_cell",
@@ -1147,9 +1249,9 @@ dependencies = [
 
 [[package]]
 name = "spin-macro"
-version = "5.0.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1592d94530c032aa8676c8adee71022fba49504ae6d4d8961a454029d3bac6f"
+checksum = "607df2c3b413f7086fa47a5402daa0d51640ba9b9b8e8955c43a58bd4057d2f4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1183,7 +1285,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-macro 2.2.0",
- "thiserror",
+ "thiserror 1.0.56",
  "wit-bindgen 0.13.1",
 ]
 
@@ -1198,21 +1300,21 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures",
- "http 1.1.0",
+ "http 1.4.0",
  "once_cell",
  "routefinder",
  "serde",
  "serde_json",
  "spin-macro 3.0.0",
- "thiserror",
+ "thiserror 1.0.56",
  "wit-bindgen 0.16.0",
 ]
 
 [[package]]
 name = "spin-sdk"
-version = "5.0.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e9705e63f1e7f955b3c9bef754a6f957624d734c6091990a2dc6f1e135625d"
+checksum = "4952d7c69dbfbeff54d62f0e3b3e14c105b80871d2100557f7b1b1429beffc24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1220,7 +1322,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http 1.1.0",
+ "http 1.4.0",
  "once_cell",
  "postgres_range",
  "routefinder",
@@ -1228,8 +1330,8 @@ dependencies = [
  "serde",
  "serde_json",
  "spin-executor",
- "spin-macro 5.0.0",
- "thiserror",
+ "spin-macro 5.1.1",
+ "thiserror 2.0.18",
  "uuid",
  "wasi 0.13.1+wasi-0.2.0",
  "wit-bindgen 0.43.0",
@@ -1319,7 +1421,16 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.56",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -1331,6 +1442,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1357,6 +1488,79 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
 
 [[package]]
 name = "typenum"
@@ -1408,7 +1612,7 @@ name = "unsupported-import"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "spin-sdk 5.0.0",
+ "spin-sdk 5.1.1",
  "wit-bindgen 0.51.0",
 ]
 
@@ -1439,6 +1643,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "variables"
@@ -1520,6 +1730,19 @@ version = "0.1.0"
 dependencies = [
  "helper",
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasi-otel-tracing"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "http 0.2.11",
+ "opentelemetry",
+ "opentelemetry-wasi",
+ "opentelemetry_sdk",
+ "spin-sdk 5.1.1",
+ "wit-bindgen 0.30.0",
 ]
 
 [[package]]
@@ -1619,12 +1842,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.215.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb56df3e06b8e6b77e37d2969a50ba51281029a9aeb3855e76b7f49b6418847"
+dependencies = [
+ "leb128",
+ "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3bc393c395cb621367ff02d854179882b9a351b4e0c93d1397e6090b53a5c2a"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.235.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d642d8c5ecc083aafe9ceb32809276a304547a3a6eeecceb5d8152598bc71f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
@@ -1655,6 +1898,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
+version = "0.215.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6bb07c5576b608f7a2a9baa2294c1a3584a249965d695a9814a496cb6d232f"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.215.0",
+ "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wasm-metadata"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b055604ba04189d54b8c0ab2c2fc98848f208e103882d5c0b984f045d5ea4d20"
@@ -1663,6 +1922,18 @@ dependencies = [
  "indexmap",
  "wasm-encoder 0.235.0",
  "wasmparser 0.235.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee093e1e1ccffa005b9b778f7a10ccfd58e25a20eccad294a1a93168d076befb"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.240.0",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
@@ -1710,12 +1981,37 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
+version = "0.215.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fbde0881f24199b81cf49b6ff8f9c145ac8eb1b7fc439adb5c099734f7d90e"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b722dcf61e0ea47440b53ff83ccb5df8efec57a69d150e4f24882e4eba7e24a4"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
@@ -1727,9 +2023,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1792,6 +2098,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,6 +2128,16 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4bac478334a647374ff24a74b66737a4cb586dc8288bc3080a93252cd1105c"
+dependencies = [
+ "wit-bindgen-rt 0.30.0",
+ "wit-bindgen-rust-macro 0.30.0",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a18712ff1ec5bd09da500fe1e91dec11256b310da0ff33f8b4ec92b927cf0c6"
@@ -1826,6 +2151,16 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a374235c3c0dff10537040b437073d09f1e38f13216b5f3cbc809c6226814e5c"
+dependencies = [
+ "bitflags",
+ "wit-bindgen-rust-macro 0.47.0",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -1862,6 +2197,17 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7e3df01cd43cfa1cb52602e4fc05cb2b62217655f6705639b6953eb0a3fed2"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.215.0",
+]
+
+[[package]]
+name = "wit-bindgen-core"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c53468e077362201de11999c85c07c36e12048a990a3e0d69da2bd61da355d0"
@@ -1869,6 +2215,17 @@ dependencies = [
  "anyhow",
  "heck 0.5.0",
  "wit-parser 0.235.0",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdf62e62178415a705bda25dc01c54ed65c0f956e4efd00ca89447a9a84f4881"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "wit-parser 0.240.0",
 ]
 
 [[package]]
@@ -1887,6 +2244,15 @@ name = "wit-bindgen-rt"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0780cf7046630ed70f689a098cd8d56c5c3b22f2a7379bbdb088879963ff96"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2de7a3b06b9725d129b5cbd1beca968feed919c433305a23da46843185ecdd6"
 dependencies = [
  "bitflags",
 ]
@@ -1930,6 +2296,22 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a767d1a8eb4e908bfc53febc48b87ada545703b16fe0148ee7736a29a01417"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.98",
+ "wasm-metadata 0.215.0",
+ "wit-bindgen-core 0.30.0",
+ "wit-component 0.215.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "531ebfcec48e56473805285febdb450e270fa75b2dacb92816861d0473b4c15f"
@@ -1942,6 +2324,22 @@ dependencies = [
  "wasm-metadata 0.235.0",
  "wit-bindgen-core 0.43.0",
  "wit-component 0.235.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6d585319871ca18805056f69ddec7541770fc855820f9944029cb2b75ea108f"
+dependencies = [
+ "anyhow",
+ "heck 0.5.0",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.98",
+ "wasm-metadata 0.240.0",
+ "wit-bindgen-core 0.47.0",
+ "wit-component 0.240.0",
 ]
 
 [[package]]
@@ -1992,6 +2390,21 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b185c342d0d27bd83d4080f5a66cf3b4f247fa49d679bceb66e11cc7eb58b99"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "wit-bindgen-core 0.30.0",
+ "wit-bindgen-rust 0.30.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
 version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7852bf8a9d1ea80884d26b864ddebd7b0c7636697c6ca10f4c6c93945e023966"
@@ -2003,6 +2416,21 @@ dependencies = [
  "syn 2.0.98",
  "wit-bindgen-core 0.43.0",
  "wit-bindgen-rust 0.43.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde589435d322e88b8f708f70e313f60dfb7975ac4e7c623fef6f1e5685d90e8"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+ "wit-bindgen-core 0.47.0",
+ "wit-bindgen-rust 0.47.0",
 ]
 
 [[package]]
@@ -2060,6 +2488,25 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
+version = "0.215.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f725e3885fc5890648be5c5cbc1353b755dc932aa5f1aa7de968b912a3280743"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.215.0",
+ "wasm-metadata 0.215.0",
+ "wasmparser 0.215.0",
+ "wit-parser 0.215.0",
+]
+
+[[package]]
+name = "wit-component"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64a57a11109cc553396f89f3a38a158a97d0b1adaec113bd73e0f64d30fb601f"
@@ -2075,6 +2522,25 @@ dependencies = [
  "wasm-metadata 0.235.0",
  "wasmparser 0.235.0",
  "wit-parser 0.235.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dc5474b078addc5fe8a72736de8da3acfb3ff324c2491133f8b59594afa1a20"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.240.0",
+ "wasm-metadata 0.240.0",
+ "wasmparser 0.240.0",
+ "wit-parser 0.240.0",
 ]
 
 [[package]]
@@ -2132,6 +2598,24 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
+version = "0.215.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "935a97eaffd57c3b413aa510f8f0b550a4a9fe7d59e79cd8b89a83dcb860321f"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wit-parser"
 version = "0.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a1f95a87d03a33e259af286b857a95911eb46236a0f726cbaec1227b3dfc67a"
@@ -2146,6 +2630,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.235.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.240.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9875ea3fa272f57cc1fc50f225a7b94021a7878c484b33792bccad0d93223439"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.240.0",
 ]
 
 [[package]]
@@ -2269,3 +2771,9 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/tests/test-components/components/otel-smoke-test/Cargo.toml
+++ b/tests/test-components/components/otel-smoke-test/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "otel-smoke-test"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1"
+http = "0.2"
+spin-sdk = "2.2.0"

--- a/tests/test-components/components/otel-smoke-test/src/lib.rs
+++ b/tests/test-components/components/otel-smoke-test/src/lib.rs
@@ -1,0 +1,22 @@
+use spin_sdk::{
+    http::{Method, Params, Request, Response, Router},
+    http_component,
+};
+
+#[http_component]
+fn handle(req: http::Request<()>) -> Response {
+    let mut router = Router::new();
+    router.get_async("/one", one);
+    router.get_async("/two", two);
+    router.handle(req)
+}
+
+async fn one(_req: Request, _params: Params) -> Response {
+    let req = Request::builder().method(Method::Get).uri("/two").build();
+    let _res: Response = spin_sdk::http::send(req).await.unwrap();
+    Response::new(200, "")
+}
+
+async fn two(_req: Request, _params: Params) -> Response {
+    Response::new(201, "")
+}

--- a/tests/test-components/components/wasi-otel-tracing/Cargo.toml
+++ b/tests/test-components/components/wasi-otel-tracing/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wasi-otel-tracing"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1"
+http = "0.2"
+opentelemetry = "0.31.0"
+opentelemetry_sdk = "0.31.0"
+opentelemetry-wasi = { git = "https://github.com/calebschoepp/opentelemetry-wasi", rev = "82eb583e3301860a976924de0fa305977f5ad1b0" }
+spin-sdk = "5.1.1"
+wit-bindgen = "0.30.0"

--- a/tests/test-components/components/wasi-otel-tracing/src/lib.rs
+++ b/tests/test-components/components/wasi-otel-tracing/src/lib.rs
@@ -1,0 +1,146 @@
+use opentelemetry::{
+    global::{self, BoxedTracer, ObjectSafeSpan},
+    trace::{TraceContextExt, Tracer},
+    Array, Context, ContextGuard, KeyValue, Value,
+};
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use opentelemetry_wasi::WasiPropagator;
+use spin_sdk::{
+    http::{IntoResponse, Method, Params, Request, Response, Router},
+    http_component,
+};
+use std::time;
+
+#[http_component]
+fn handle(req: Request) -> anyhow::Result<impl IntoResponse> {
+    let mut router = Router::new();
+    router.get("/nested-spans", nested_spans);
+    router.get("/setting-attributes", setting_attributes);
+    router.get_async("/host-guest-host", host_guest_host);
+    router.get("/events", events);
+    router.get("/links", links);
+    router.get_async("/root-span", root_span);
+    router.get("/start-called-end-not-called", start_called_end_not_called);
+    router.get("/child-span-outlives-parent", child_span_outlives_parent);
+    Ok(router.handle(req))
+}
+
+fn setup_tracer(propagate_context: bool) -> (BoxedTracer, Option<ContextGuard>) {
+    // Set up a tracer using the WASI processor
+    let wasi_processor = opentelemetry_wasi::WasiSpanProcessor::new();
+    let tracer_provider = SdkTracerProvider::builder()
+        .with_span_processor(wasi_processor)
+        .build();
+    global::set_tracer_provider(tracer_provider);
+    let tracer = global::tracer("wasi-otel-tracing");
+
+    if propagate_context {
+        let wasi_propagator = opentelemetry_wasi::TraceContextPropagator::new();
+        (
+            tracer,
+            Some(wasi_propagator.extract(&Context::current()).attach()),
+        )
+    } else {
+        (tracer, None)
+    }
+}
+
+fn nested_spans(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(true);
+    tracer.in_span("outer_func", |_| {
+        tracer.in_span("inner_func", |_| {});
+    });
+    Response::new(200, "")
+}
+
+fn setting_attributes(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(true);
+    tracer.in_span("setting_attributes", |cx| {
+        let span = cx.span();
+        span.set_attribute(KeyValue::new("foo", "bar"));
+        span.set_attribute(KeyValue::new("foo", "baz"));
+        span.set_attribute(KeyValue::new(
+            "qux",
+            Value::Array(Array::String(vec!["qaz".into(), "thud".into()])),
+        ));
+    });
+
+    Response::new(200, "")
+}
+
+async fn host_guest_host(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(true);
+    let mut span = tracer.start("guest");
+    make_request().await;
+    span.end();
+
+    Response::new(200, "")
+}
+
+fn events(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(true);
+    tracer.in_span("events", |cx| {
+        let span = cx.span();
+        span.add_event("basic-event".to_string(), vec![]);
+        span.add_event(
+            "event-with-attributes".to_string(),
+            vec![KeyValue::new("foo", true)],
+        );
+        let time = time::SystemTime::now()
+            .duration_since(time::UNIX_EPOCH)
+            .unwrap();
+        let time = time.as_secs_f64();
+        let time = time::Duration::from_secs_f64(time + 1.0);
+        let time = time::SystemTime::UNIX_EPOCH + time;
+        span.add_event_with_timestamp("event-with-timestamp", time, vec![]);
+    });
+    Response::new(200, "")
+}
+
+fn links(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(true);
+    let mut first = tracer.start("first");
+    first.end();
+    let mut second = tracer.start("second");
+    second.add_link(
+        first.span_context().clone(),
+        vec![KeyValue::new("foo", "bar")],
+    );
+    second.end();
+    Response::new(200, "")
+}
+
+async fn root_span(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(false);
+    let mut span = tracer.start("root");
+    make_request().await;
+    span.end();
+    Response::new(200, "")
+}
+
+async fn make_request() {
+    let req = Request::builder()
+        .method(Method::Get)
+        .uri("/fake-route")
+        .build();
+    let _res: Response = spin_sdk::http::send(req).await.unwrap();
+}
+
+fn start_called_end_not_called(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(true);
+    let _span = tracer.start("start_called_end_not_called");
+    // span.end() is not called...
+    Response::new(200, "")
+}
+
+fn child_span_outlives_parent(_req: Request, _params: Params) -> Response {
+    let (tracer, _ctx) = setup_tracer(true);
+    let child = {
+        let parent = tracer.start("parent");
+        let parent_ctx = Context::current_with_span(parent);
+        let _guard = parent_ctx.clone().attach();
+        tracer.start("child")
+    };
+    drop(child);
+    Response::new(200, "")
+}

--- a/tests/testcases/wasi-otel-tracing/spin.toml
+++ b/tests/testcases/wasi-otel-tracing/spin.toml
@@ -1,0 +1,19 @@
+spin_manifest_version = 2
+
+[application]
+authors = ["Fermyon Engineering <engineering@fermyon.com>"]
+description = "An application to exercise wasi-otel tracing functionality."
+name = "wasi-otel-tracing"
+version = "1.0.0"
+
+[[trigger.http]]
+route = "/..."
+component = "wasi-otel-tracing"
+
+[component.wasi-otel-tracing]
+source = "%{source=wasi-otel-tracing}"
+key_value_stores = ["default"]
+allowed_outbound_hosts = ["http://self"]
+[component.wasi-otel-tracing.build]
+command = "cargo build --target wasm32-wasi --release"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/wit/deps/otel@0.2.0-rc.2/logs.wit
+++ b/wit/deps/otel@0.2.0-rc.2/logs.wit
@@ -1,0 +1,36 @@
+interface logs {
+    use types.{instrumentation-scope, %resource, value, key-value};
+    use tracing.{span-id, trace-id, trace-flags};
+    use wasi:clocks/wall-clock@0.2.0.{datetime};
+
+    /// Called when a log is emitted.
+    on-emit: func(data: log-record);
+
+    /// Represents the recording of an event.
+    record log-record {
+        /// Time when the event occurred.
+        timestamp: option<datetime>,
+        /// Time when the event was observed.
+        observed-timestamp: option<datetime>,
+        /// The severity text(also known as log level).
+        severity-text: option<string>,
+        /// The numerical value of the severity ranging from 1-24.
+        severity-number: option<u8>,
+        /// The body of the log record.
+        body: option<value>,
+        /// Additional information about the specific event occurrence.
+        attributes: option<list<key-value>>,
+        /// Name that identifies the class / type of event.
+        event-name: option<string>,
+        /// Describes the source of the log.
+        %resource: option<%resource>,
+        /// Describes the scope that emitted the log.
+        instrumentation-scope: option<instrumentation-scope>,
+        /// Request trace id.
+        trace-id: option<trace-id>,
+        /// Request span id.
+        span-id: option<span-id>,
+        /// W3C trace flag.
+        trace-flags: option<trace-flags>,
+    }
+}

--- a/wit/deps/otel@0.2.0-rc.2/metrics.wit
+++ b/wit/deps/otel@0.2.0-rc.2/metrics.wit
@@ -1,0 +1,256 @@
+interface metrics {
+    use wasi:clocks/wall-clock@0.2.0.{datetime};
+    use wasi:clocks/monotonic-clock@0.2.0.{duration};
+    use types.{key-value, instrumentation-scope, %resource};
+    use tracing.{span-id, trace-id};
+
+    /// Exports a resource's metric data.
+    %export: func(metrics: resource-metrics) -> result<_, error>;
+
+    /// An error resulting from `export` being called.
+    type error = string;
+
+    /// A collection of `scope-metrics` and the associated `resource` that created them.
+    record resource-metrics {
+        /// The entity that collected the metrics.
+        %resource: %resource,
+        /// The collection of metrics with unique `instrumentation-scope`s.
+        scope-metrics: list<scope-metrics>,
+    }
+
+    /// A collection of `metric`s produced by a meter.
+    record scope-metrics {
+        /// The instrumentation scope that the meter was created with.
+        scope: instrumentation-scope,
+        /// The list of aggregations created by the meter.
+        metrics: list<metric>,
+    }
+
+    /// A collection of one or more aggregated time series from a metric.
+    record metric {
+        /// The name of the metric that created this data.
+        name: string,
+        /// The description of the metric, which can be used in documentation.
+        description: string,
+        /// The unit in which the metric reports.
+        unit: string,
+        /// The aggregated data from a metric.
+        data: metric-data
+    }
+
+    /// Metric data for all types.
+    variant metric-data {
+        /// Metric data for an f64 gauge.
+        f64-gauge(gauge),
+        /// Metric data for an f64 sum.
+        f64-sum(sum),
+        /// Metric data for an f64 histogram.
+        f64-histogram(histogram),
+        /// Metric data for an f64 exponential-histogram.
+        f64-exponential-histogram(exponential-histogram),
+        /// Metric data for an u64 gauge.
+        u64-gauge(gauge),
+        /// Metric data for an u64 sum.
+        u64-sum(sum),
+        /// Metric data for an u64 histogram.
+        u64-histogram(histogram),
+        /// Metric data for an u64 exponential-histogram.
+        u64-exponential-histogram(exponential-histogram),
+        /// Metric data for an s64 gauge.
+        s64-gauge(gauge),
+        /// Metric data for an s64 sum.
+        s64-sum(sum),
+        /// Metric data for an s64 histogram.
+        s64-histogram(histogram),
+        /// Metric data for an s64 exponential-histogram.
+        s64-exponential-histogram(exponential-histogram),
+    }
+
+    /// A measurement of the current value of an instrument.
+    record gauge {
+        /// Represents individual aggregated measurements with unique attributes.
+        data-points: list<gauge-data-point>,
+        /// The time when the time series was started.
+        start-time: option<datetime>,
+        /// The time when the time series was recorded.
+        time: datetime,
+    }
+
+    /// A single data point in a time series to be associated with a `gauge`.
+    record gauge-data-point {
+        /// `attributes` is the set of key value pairs that uniquely identify the
+        /// time series.
+        attributes: list<key-value>,
+        /// The value of this data point.
+        value: metric-number,
+        /// The sampled `exemplar`s collected during the time series.
+        exemplars: list<exemplar>,
+    }
+
+    /// Represents the sum of all measurements of values from an instrument.
+    record sum {
+         /// Represents individual aggregated measurements with unique attributes.
+        data-points: list<sum-data-point>,
+        /// The time when the time series was started.
+        start-time: datetime,
+        /// The time when the time series was recorded.
+        time: datetime,
+        /// Describes if the aggregation is reported as the change from the last report
+        /// time, or the cumulative changes since a fixed start time.
+        temporality: temporality,
+        /// Whether this aggregation only increases or decreases.
+        is-monotonic: bool,
+    }
+
+    /// A single data point in a time series to be associated with a `sum`.
+    record sum-data-point {
+        /// `attributes` is the set of key value pairs that uniquely identify the
+        /// time series.
+        attributes: list<key-value>,
+        /// The value of this data point.
+        value: metric-number,
+        /// The sampled `exemplar`s collected during the time series.
+        exemplars: list<exemplar>,
+    }
+
+    /// Represents the histogram of all measurements of values from an instrument.
+    record histogram {
+        /// Individual aggregated measurements with unique attributes.
+        data-points: list<histogram-data-point>,
+        /// The time when the time series was started.
+        start-time: datetime,
+        /// The time when the time series was recorded.
+        time: datetime,
+        /// Describes if the aggregation is reported as the change from the last report
+        /// time, or the cumulative changes since a fixed start time.
+        temporality: temporality,
+    }
+
+    /// A single data point in a time series to be associated with a `histogram`.
+    record histogram-data-point {
+        /// The set of key value pairs that uniquely identify the time series.
+        attributes: list<key-value>,
+        /// The number of updates this histogram has been calculated with.
+        count: u64,
+        /// The upper bounds of the buckets of the histogram.
+        bounds: list<f64>,
+        /// The count of each of the buckets.
+        bucket-counts: list<u64>,
+        /// The minimum value recorded.
+        min: option<metric-number>,
+        /// The maximum value recorded.
+        max: option<metric-number>,
+        /// The sum of the values recorded
+        sum: metric-number,
+        /// The sampled `exemplar`s collected during the time series.
+        exemplars: list<exemplar>,
+    }
+
+    /// The histogram of all measurements of values from an instrument.
+    record exponential-histogram {
+        /// The individual aggregated measurements with unique attributes.
+        data-points: list<exponential-histogram-data-point>,
+        /// When the time series was started.
+        start-time: datetime,
+        /// The time when the time series was recorded.
+        time: datetime,
+        /// Describes if the aggregation is reported as the change from the last report
+        /// time, or the cumulative changes since a fixed start time.
+        temporality: temporality,
+    }
+
+    /// A single data point in a time series to be associated with an `exponential-histogram `.
+    record exponential-histogram-data-point {
+        /// The set of key value pairs that uniquely identify the time series.
+        attributes: list<key-value>,
+        /// The number of updates this histogram has been calculated with.
+        count: u64,
+        /// The minimum value recorded.
+        min: option<metric-number>,
+        /// The maximum value recorded.
+        max: option<metric-number>,
+        /// The maximum value recorded.
+        sum: metric-number,
+        /// Describes the resolution of the histogram.
+        ///
+        /// Boundaries are located at powers of the base, where:
+        ///
+        ///   base = 2 ^ (2 ^ -scale)
+        scale: s8,
+        /// The number of values whose absolute value is less than or equal to
+        /// `zero_threshold`.
+        ///
+        /// When `zero_threshold` is `0`, this is the number of values that cannot be
+        /// expressed using the standard exponential formula as well as values that have
+        /// been rounded to zero.
+        zero-count: u64,
+        /// The range of positive value bucket counts.
+        positive-bucket: exponential-bucket,
+        /// The range of negative value bucket counts.
+        negative-bucket: exponential-bucket,
+        /// The width of the zero region.
+        ///
+        /// Where the zero region is defined as the closed interval
+        /// [-zero_threshold, zero_threshold].
+        zero-threshold: f64,
+        /// The sampled exemplars collected during the time series.
+        exemplars: list<exemplar>,
+    }
+
+    /// A set of bucket counts, encoded in a contiguous array of counts.
+    record exponential-bucket {
+        /// The bucket index of the first entry in the `counts` list.
+        offset: s32,
+        /// A list where `counts[i]` carries the count of the bucket at index `offset + i`.
+        ///
+        /// `counts[i]` is the count of values greater than base^(offset+i) and less than
+        /// or equal to base^(offset+i+1).
+        counts: list<u64>,
+    }
+
+    /// A measurement sampled from a time series providing a typical example.
+    record exemplar {
+        /// The attributes recorded with the measurement but filtered out of the
+        /// time series' aggregated data.
+        filtered-attributes: list<key-value>,
+        /// The time when the measurement was recorded.
+        time: datetime,
+        /// The measured value.
+        value: metric-number,
+        /// The ID of the span that was active during the measurement.
+        ///
+        /// If no span was active or the span was not sampled this will be empty.
+        span-id: span-id,
+        /// The ID of the trace the active span belonged to during the measurement.
+        ///
+        /// If no span was active or the span was not sampled this will be empty.
+        trace-id: trace-id,
+    }
+
+    /// Defines the window that an aggregation was calculated over.
+    enum temporality {
+        /// A measurement interval that continues to expand forward in time from a
+        /// starting point.
+        ///
+        /// New measurements are added to all previous measurements since a start time.
+        ///
+        /// This is the default temporality.
+        cumulative,
+        /// A measurement interval that resets each cycle.
+        ///
+        /// Measurements from one cycle are recorded independently, measurements from
+        /// other cycles do not affect them.
+        delta,
+        /// Configures Synchronous Counter and Histogram instruments to use
+        /// Delta aggregation temporality, which allows them to shed memory
+        /// following a cardinality explosion, thus use less memory.
+        low-memory,
+    }
+
+    /// The number types available for any given instrument.
+    variant metric-number {
+        %f64(f64),
+        %s64(s64),
+        %u64(u64),
+    }
+}

--- a/wit/deps/otel@0.2.0-rc.2/tracing.wit
+++ b/wit/deps/otel@0.2.0-rc.2/tracing.wit
@@ -1,0 +1,122 @@
+interface tracing {
+    use wasi:clocks/wall-clock@0.2.0.{datetime};
+    use types.{key-value, instrumentation-scope};
+
+    /// Called when a span is started.
+    on-start: func(context: span-context);
+
+    /// Called when a span is ended.
+    on-end: func(span: span-data);
+
+    /// Returns the span context of the host.
+    outer-span-context: func() -> span-context;
+
+    /// The data associated with a span.
+    record span-data {
+        /// Span context.
+        span-context: span-context,
+        /// Span parent id.
+        parent-span-id: string,
+        /// Span kind.
+        span-kind: span-kind,
+        // Span name.
+        name: string,
+        /// Span start time.
+        start-time: datetime,
+        /// Span end time.
+        end-time: datetime,
+        /// Span attributes.
+        attributes: list<key-value>,
+        /// Span events.
+        events: list<event>,
+        /// Span Links.
+        links: list<link>,
+        /// Span status.
+        status: status,
+        /// Instrumentation scope that produced this span.
+        instrumentation-scope: instrumentation-scope,
+        /// Number of attributes dropped by the span due to limits being reached.
+        dropped-attributes: u32,
+        /// Number of events dropped by the span due to limits being reached.
+        dropped-events: u32,
+        /// Number of links dropped by the span due to limits being reached.
+        dropped-links: u32,
+    }
+
+    /// Identifying trace information about a span that can be serialized and propagated.
+    record span-context {
+        /// The `trace-id` for this `span-context`.
+        trace-id: trace-id,
+        /// The `span-id` for this `span-context`.
+        span-id: span-id,
+        /// The `trace-flags` for this `span-context`.
+        trace-flags: trace-flags,
+        /// Whether this `span-context` was propagated from a remote parent.
+        is-remote: bool,
+        /// The `trace-state` for this `span-context`.
+        trace-state: trace-state,
+    }
+
+    /// The trace that this `span-context` belongs to.
+    ///
+    /// 16 bytes encoded as a hexadecimal string.
+    type trace-id = string;
+
+    /// The id of this `span-context`.
+    ///
+    /// 8 bytes encoded as a hexadecimal string.
+    type span-id = string;
+
+    /// Flags that can be set on a `span-context`.
+    flags trace-flags {
+        /// Whether the `span` should be sampled or not.
+        sampled,
+    }
+
+    /// Carries system-specific configuration data, represented as a list of key-value pairs. `trace-state` allows multiple tracing systems to participate in the same trace.
+    ///
+    /// If any invalid keys or values are provided then the `trace-state` will be treated as an empty list.
+    type trace-state = list<tuple<string, string>>;
+
+    /// Describes the relationship between the Span, its parents, and its children in a trace.
+    enum span-kind {
+        /// Indicates that the span describes a request to some remote service. This span is usually the parent of a remote server span and does not end until the response is received.
+        client,
+        /// Indicates that the span covers server-side handling of a synchronous RPC or other remote request. This span is often the child of a remote client span that was expected to wait for a response.
+        server,
+        /// Indicates that the span describes the initiators of an asynchronous request. This parent span will often end before the corresponding child consumer span, possibly even before the child span starts. In messaging scenarios with batching, tracing individual messages requires a new producer span per message to be created.
+        producer,
+        /// Indicates that the span describes a child of an asynchronous consumer request.
+        consumer,
+        /// Default value. Indicates that the span represents an internal operation within an application, as opposed to an operations with remote parents or children.
+        internal
+    }
+
+    /// An event describing a specific moment in time on a span and associated attributes.
+    record event {
+        /// Event name.
+        name: string,
+        /// Event time.
+        time: datetime,
+        /// Event attributes.
+        attributes: list<key-value>,
+    }
+
+    /// Describes a relationship to another `span`.
+    record link {
+        /// Denotes which `span` to link to.
+        span-context: span-context,
+        /// Attributes describing the link.
+        attributes: list<key-value>,
+    }
+
+    /// The `status` of a `span`.
+    variant status {
+        /// The default status.
+        unset,
+        /// The operation has been validated by an Application developer or Operator to have completed successfully.
+        ok,
+        /// The operation contains an error with a description.
+        error(string),
+    }
+}

--- a/wit/deps/otel@0.2.0-rc.2/types.wit
+++ b/wit/deps/otel@0.2.0-rc.2/types.wit
@@ -1,0 +1,46 @@
+interface types {
+    /// A key-value pair describing an attribute.
+    record key-value {
+        /// The attribute name.
+        key: key,
+        /// The attribute value.
+        value: value,
+    }
+
+    /// The key part of attribute `key-value` pairs.
+    type key = string;
+
+    /// The value part of attribute `key-value` pairs.
+    ///
+    /// This corresponds with the `AnyValue` type defined in the [attribute spec](https://opentelemetry.io/docs/specs/otel/common/#anyvalue).
+    /// Because WIT doesn't support recursive types, the data needs to be serialized. JSON is used as the encoding format.
+    ///
+    /// Byte arrays require special encoding since JSON cannot distinguish them from number arrays.
+    /// They are base64-encoded with a prefix that follows the Data URI RFC 2397 convention: 
+    /// `data:application/octet-stream;base64,<BASE64_ENCODED_BYTES>`
+    type value = string;
+
+    /// An immutable representation of the entity producing telemetry as attributes.
+    record %resource {
+        /// Attributes that identify the resource.
+        attributes: list<key-value>,
+        /// The schema URL to be recorded in the emitted resource.
+        schema-url: option<string>,
+    }
+
+    /// Describes the instrumentation scope that produced telemetry.
+    record instrumentation-scope {
+        /// Name of the instrumentation scope.
+        name: string,
+
+        /// The library version.
+        version: option<string>,
+
+        /// Schema URL used by this library.
+        /// https://opentelemetry.io/docs/specs/otel/schemas/#schema-url
+        schema-url: option<string>,
+
+        /// Specifies the instrumentation scope attributes to associate with emitted telemetry.
+        attributes: list<key-value>,
+    }
+}

--- a/wit/deps/otel@0.2.0-rc.2/world.wit
+++ b/wit/deps/otel@0.2.0-rc.2/world.wit
@@ -1,0 +1,8 @@
+package wasi:otel@0.2.0-rc.2;
+
+world imports {
+    import types;
+    import tracing;
+    import metrics;
+    import logs;
+}

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -15,6 +15,8 @@ world platform {
   include wasi:cli/imports@0.3.0-rc-2026-01-06;
   @unstable(feature = wasip3-rc20260106)
   import wasi:http/handler@0.3.0-rc-2026-01-06;
+  @unstable(feature = wasi-otel)
+  include wasi:otel/imports@0.2.0-rc.2;
   include fermyon:spin/platform@2.0.0;
   include wasi:keyvalue/imports@0.2.0-draft2;
   import spin:postgres/postgres@3.0.0;


### PR DESCRIPTION
# Overview
This is an implementation of [WASI OTel](https://github.com/calebschoepp/wasi-otel) which gives guest applications the ability to export traces, metrics and logs with [OpenTelemetry SDKs](https://github.com/calebschoepp/opentelemetry-wasi).

We see two options for adding this to Spin:
- Require the user to compile Spin with configuration flags that will enable this feature.
- Have this feature available out-of-the-box and add an experimental-features flag that the user will pass to spin up.

To help ease adoption, we would prefer to pass a flag to spin up, but we know there was some previous work around this with wasip3 so we're happy to defer to that process.

Some additional notes:
- In the root `Cargo.toml`, you will notice that certain experimental features are being enabled for the `opentelemetry-sdk` dependency, and that we are using `reqwest-client` instead of `reqwest-blocking-client` in the `opentelemetry` dependency. These are all to prevent runtime errors that come from the default OpenTelemetry dependency configurations conflicting with Spin's async runtime.
- `wasi-otel` has been moved to Phase 1.

# Usage
To try the features added in this PR, do the following:

1. Build Spin from [this branch](https://github.com/asteurer/spin/tree/wasi-otel):
```bash
git clone --branch wasi-otel --depth 1 https://github.com/asteurer/spin
cd spin
cargo install --path .
spin plugin update
spin plugin install otel
```

2. Clone [OpenTelemetry WASI](https://github.com/calebschoepp/opentelemetry-wasi) and try the Rust example applications:
```bash
git clone https://github.com/calebschoepp/opentelemetry-wasi
spin otel setup

cd opentelemetry-wasi/rust/examples/spin-basic
spin otel up -- --build --experimental-wasi-otel

# In a different terminal window
spin otel open jaeger
spin otel open grafana
curl localhost:3000
```