### PR TITLE
Allow configurable max buffer size for HTTP connections

### DIFF
--- a/tests/testing-framework/src/runtimes/in_process_spin.rs
+++ b/tests/testing-framework/src/runtimes/in_process_spin.rs
@@ -104,7 +104,7 @@ async fn initialize_trigger(
     .await?;
 
     let app = spin_app::App::new("my-app", locked_app);
-    let trigger = HttpTrigger::new(&app, "127.0.0.1:80".parse().unwrap(), None, false)?;
+    let trigger = HttpTrigger::new(&app, "127.0.0.1:80".parse().unwrap(), None, false, None)?;
     let mut builder = TriggerAppBuilder::<_, FactorsBuilder>::new(trigger);
     let trigger_app = builder
         .build(


### PR DESCRIPTION
This introduces `SPIN_HTTP1_MAX_BUF_SIZE` to allow configuring the underlying maximum read buffer size for HTTP1 connections.