### PR TITLE
fix(templates): Add `spin add` snippet for `http-rust-wasip3-unstable` template

### DIFF
--- a/templates/http-rust-wasip3-unstable/metadata/snippets/component.txt
+++ b/templates/http-rust-wasip3-unstable/metadata/snippets/component.txt
@@ -1,0 +1,12 @@
+[[trigger.http]]
+route = "{{http-path}}"
+component = "{{project-name | kebab_case}}"
+executor = { type = "wasip3-unstable" }
+
+[component.{{project-name | kebab_case}}]
+source = "{{ output-path }}/target/wasm32-wasip2/release/{{project-name | snake_case}}.wasm"
+allowed_outbound_hosts = []
+[component.{{project-name | kebab_case}}.build]
+command = "cargo build --target wasm32-wasip2 --release"
+workdir = "{{ output-path }}"
+watch = ["src/**/*.rs", "Cargo.toml"]


### PR DESCRIPTION
Without this, `spin add` doesn't work for this template.