### PR TITLE
Add new maintainer Caleb Schoepp

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@ _Listed in alphabetical order by first name_
 | Name | GitHub Username |
 | --- | --- |
 | Brian Hardock | fibonacci1729 |
+| Caleb Schoepp | calebschoepp |
 | Ivan Towlson | itowlson |
 | Joel Dice | dicej |
 | Kate Goldenring | kate-goldenring |


### PR DESCRIPTION
Caleb has been an active Spin contributor for the last 2+ years contributing features such as `spin watch` and driving alot of the otel/telemetry work. Caleb was nominated on 11/12 and a vote in the private CNCF spin-maintainers channel was passed unanimously.