### PR TITLE
Enable running `wkg oci` packages as bare Wasm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,6 +217,8 @@ jobs:
           chmod +x grain-linux-x64
           mv grain-linux-x64 grain
           echo "$PWD" >> $GITHUB_PATH
+      - name: Install wkg
+        run: cargo install wkg
 
       - name: Run Full Integration Tests
         run: make test-integration-full

--- a/crates/oci/src/lib.rs
+++ b/crates/oci/src/lib.rs
@@ -8,7 +8,7 @@ pub mod utils;
 mod validate;
 
 pub use client::{Client, ComposeMode};
-pub use loader::OciLoader;
+pub use loader::{ExecutableArtifact, OciLoader};
 
 /// URL scheme used for the locked app "origin" metadata field for OCI-sourced apps.
 pub const ORIGIN_URL_SCHEME: &str = "vnd.fermyon.origin-oci";


### PR DESCRIPTION
Fixes #3360.

I tested this against `wkg oci push`:

```
$ wkg oci push ghcr.io/itowlson/v3vanilla40:1 ./target/wasm32-wasip2/release/v3vanilla40.wasm
$ spin up -f ghcr.io/itowlson/v3vanilla40:1
```

Note that I've only tested to the "hello world" level: if we believe we need to try this on a wider range of binaries then let's chat about desirable test coverage.  I'm also not sure if there's a good way to automate testing - open to advice!

It would be nice to also do it for proper packages (`wkg publish`) but that's probably going to need a bit more investigation and thinky-designy-sort-of-work.
