### PR TITLE
Expose CPU and memory usage on per-component execution spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8309,6 +8309,7 @@ dependencies = [
  "spin-doctor",
  "spin-environments",
  "spin-factor-outbound-networking",
+ "spin-factors-executor",
  "spin-http",
  "spin-loader",
  "spin-locked-app",
@@ -8734,7 +8735,9 @@ dependencies = [
  "spin-factor-wasi",
  "spin-factors",
  "spin-factors-test",
+ "spin-telemetry",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ watchexec-filterer-globset = "8.0"
 spin-app = { path = "crates/app" }
 spin-build = { path = "crates/build" }
 spin-common = { path = "crates/common" }
+spin-factors-executor = { path = "crates/factors-executor" }
 spin-doctor = { path = "crates/doctor" }
 spin-environments = { path = "crates/environments" }
 spin-factor-outbound-networking = { path = "crates/factor-outbound-networking" }
@@ -106,12 +107,14 @@ vergen = { version = "^8.2.1", default-features = false, features = [
 ] }
 
 [features]
-default = ["llm"]
+default = ["llm", "cpu-time-metrics"]
 all-tests = ["extern-dependencies-tests"]
 extern-dependencies-tests = []
 llm = ["spin-runtime-factors/llm"]
 llm-metal = ["llm", "spin-runtime-factors/llm-metal"]
 llm-cublas = ["llm", "spin-runtime-factors/llm-cublas"]
+# This enables the collection and emission CPU time elapsed per component execution.
+cpu-time-metrics = ["spin-factors-executor/cpu-time-metrics"]
 
 [workspace]
 members = [

--- a/crates/factors-executor/Cargo.toml
+++ b/crates/factors-executor/Cargo.toml
@@ -13,6 +13,8 @@ anyhow = { workspace = true }
 spin-app = { path = "../app" }
 spin-core = { path = "../core" }
 spin-factors = { path = "../factors" }
+spin-telemetry = { path = "../telemetry" }
+tracing = { workspace = true }
 
 [dev-dependencies]
 spin-factor-wasi = { path = "../factor-wasi" }
@@ -21,3 +23,6 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true
+
+[features]
+cpu-time-metrics = ["spin-core/call-hook"]


### PR DESCRIPTION
# Overview
This is a feature that enables the collection and emission of CPU and memory usage for each component.
Closes #2933

## Notes about the collected metrics
This measures 3 things:
- Memory usage from component instantiation
- Memory usage from component execution
- The total CPU time elapsed actively running guest code in this instance.

Although [it was proposed](https://github.com/spinframework/spin/issues/2933#issuecomment-2498733789) to measure CPU cycles, I think that that measuring execution time is sufficient for now.

## Usage
### Prerequisites
- [Spin OTel plugin](https://github.com/fermyon/otel-plugin)
- A Spin application that generates CPU and memory usage - Feel free to use [this one](https://github.com/asteurer/spin-component-metrics-example)

### Generate usage metrics
```sh
cd spin-component-metrics-example
spin otel setup
spin otel open grafana
spin build
spin otel up

# In a different terminal
curl localhost:3000
```