### PR TITLE
Allow enabling experimental wasm features

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,13 @@ jobs:
         with:
           openssl-windows: "${{ matrix.os == 'windows-latest' }}"
 
+      - name: build release (canary)
+        if: github.ref == 'refs/heads/main'
+        shell: bash
+        run: cargo build --features experimental-wasm-features --release ${{ matrix.config.extraArgs }}
+
       - name: build release
+        if: github.ref != 'refs/heads/main'
         shell: bash
         run: cargo build --release ${{ matrix.config.extraArgs }}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ llm-metal = ["llm", "spin-runtime-factors/llm-metal"]
 llm-cublas = ["llm", "spin-runtime-factors/llm-cublas"]
 # This enables the collection and emission CPU time elapsed per component execution.
 cpu-time-metrics = ["spin-factors-executor/cpu-time-metrics"]
+experimental-wasm-features = ["spin-trigger/experimental-wasm-features"]
 
 [workspace]
 members = [

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -13,6 +13,8 @@ rust-version.workspace = true
 # `ComponentLoader::enable_loading_aot_compiled_components`
 # documentation for more information about the safety risks.
 unsafe-aot-compilation = []
+# Enables configuring unstable Wasm features.
+experimental-wasm-features = []
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Example: 
``` 
spin up \
   --experimental-wasm-feature gc \
   --experimental-wasm-feature exceptions \
   --experimental-wasm-feature function-references \
   --experimental-wasm-feature reference-types \
...
```

* Feature gated via `experimental-wasm-features`.
* Enabled for canary builds

