### PR TITLE
Fix misleading error on bad PostgreSQL connection string

### DIFF
--- a/tests/runtime-tests/tests/outbound-postgres-no-permission/error.txt
+++ b/tests/runtime-tests/tests/outbound-postgres-no-permission/error.txt
@@ -1,1 +1,1 @@
-Error::ConnectionFailed("address postgres://spin:spin@localhost:5432/spin_dev is not permitted")
+Error::ConnectionFailed("address postgres://localhost:5432 is not permitted")


### PR DESCRIPTION
Fixes #3379.

Bad connection string: `Error::ConnectionFailed("invalid connection string: unknown option 'honk'")`

Denied host: `Error::ConnectionFailed("address pantoufles.com is not permitted")`
