### PR TITLE
Update rust examples to use new sdk

### DIFF
--- a/.github/workflows/rust-sdk-release.yml
+++ b/.github/workflows/rust-sdk-release.yml
@@ -19,6 +19,11 @@ jobs:
         shell: bash
         run: ./scripts/bump-rust-template-sdk.sh ${{ github.event.client_payload.version }}
 
+      # Run script to update the examples
+      - name: Bump Rust Examples SDK Dependency
+        shell: bash
+        run: ./scripts/bump-rust-examples-sdk.sh ${{ github.event.client_payload.version }}
+
       # Import GPG key for signing commits
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v6
@@ -32,10 +37,10 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "chore(rust-templates): bump Spin Rust SDK to ${{ github.event.client_payload.version }}"
-          title: "chore(rust-templates): bump Spin Rust SDK to ${{ github.event.client_payload.version }}"
+          commit-message: "chore(rust-sdk-release): bump Spin Rust SDK to ${{ github.event.client_payload.version }}"
+          title: "chore(rust-sdk-release): bump Spin Rust SDK to ${{ github.event.client_payload.version }}"
           body: |
-            Update the Spin Rust Templates SDK dependency to ${{ github.event.client_payload.version }}.
+            Update the Spin Rust Templates & Examples SDK dependency to ${{ github.event.client_payload.version }}.
           branch: bump-spin-rust-sdk-${{ github.event.client_payload.version }}
           base: main
           delete-branch: true

--- a/examples/http-rust/Cargo.toml
+++ b/examples/http-rust/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1"
 http = "1.3.1"
-spin-sdk = "5.0.0"
+spin-sdk = "5.2.0"
 
 [workspace]

--- a/examples/open-ai-rust/Cargo.toml
+++ b/examples/open-ai-rust/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-spin-sdk = "3.1.0"
+spin-sdk = "5.2.0"
 
 [workspace]

--- a/examples/spin-wagi-http/http-rust/Cargo.toml
+++ b/examples/spin-wagi-http/http-rust/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1"
 # General-purpose crate with common HTTP types.
 http = "1.3.1"
 # The Spin SDK.
-spin-sdk = "5.0.0"
+spin-sdk = "5.2.0"
 
 
 [workspace]

--- a/scripts/bump-rust-examples-sdk.sh
+++ b/scripts/bump-rust-examples-sdk.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# This script updates the `spin-sdk` dependency in Rust examples
+# `Cargo.toml` files under the `examples` directory.
+set -euo pipefail
+
+VERSION=$1
+
+# -i syntax differs between GNU and Mac sed; this usage is supported by both
+SED_INPLACE='sed -i.bak'
+
+# cleanup
+trap 'find examples -name "*.bak" -delete' EXIT
+
+usage() {
+  echo "Usage: $0 <VERSION>"
+  echo "Updates the Rust examples SDK dependency to the specified version"
+  echo "Example: $0 v6.0.0"
+}
+
+if [[ $# -ne 1 ]]
+then
+  usage
+  exit 1
+fi
+
+# Ensure version is an 'official' release
+if [[ ! "${VERSION}" =~ ^v[0-9]+.[0-9]+.[0-9]+$ ]]
+then
+  echo "VERSION doesn't match v[0-9]+.[0-9]+.[0-9]+ and may be a prerelease; skipping."
+  exit 1
+fi
+
+# Strip the leading v for Cargo.toml
+STRIPPED_VERSION="${VERSION#v}"
+
+# Update the version in the Cargo.toml files for each Rust example
+find examples -type f -path "examples/*-rust/Cargo.toml" -exec $SED_INPLACE "/^\[dependencies\]/,/^\[/ s/^spin-sdk = \".*\"/spin-sdk = \"${STRIPPED_VERSION}\"/" {} +


### PR DESCRIPTION
Updates the examples to use the newly released [spin-rust-sdk](https://crates.io/crates/spin-sdk)

+ adds some automation to do this for the next release