### PR TITLE
Add content-length header attributes to outbound HTTP spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8732,6 +8732,7 @@ dependencies = [
  "tokio-rustls 0.26.0",
  "tower-service",
  "tracing",
+ "tracing-opentelemetry",
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true, features = ["macros", "rt", "net"] }
 tokio-rustls = { workspace = true }
 tower-service = { workspace = true }
 tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
 wasmtime = { workspace = true }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-http = { workspace = true }

--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -12,7 +12,11 @@ use std::{
 
 use bytes::Bytes;
 use futures::channel::oneshot;
-use http::{header::HOST, uri::Scheme, Uri};
+use http::{
+    header::{CONTENT_LENGTH, HOST},
+    uri::Scheme,
+    HeaderMap, Uri,
+};
 use http_body::{Body, Frame, SizeHint};
 use http_body_util::{combinators::UnsyncBoxBody, BodyExt};
 use hyper_util::{
@@ -35,7 +39,7 @@ use tokio::{
 };
 use tokio_rustls::client::TlsStream;
 use tower_service::Service;
-use tracing::{field::Empty, instrument, Instrument};
+use tracing::{field::Empty, instrument, Instrument, Span};
 use wasmtime::component::HasData;
 use wasmtime_wasi::TrappableError;
 use wasmtime_wasi_http::{
@@ -53,6 +57,8 @@ use crate::{
     intercept::{InterceptOutcome, OutboundHttpInterceptor},
     wasi_2023_10_18, wasi_2023_11_10, InstanceHttpHooks, OutboundHttpFactor, SelfRequestOrigin,
 };
+
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
 
@@ -453,6 +459,12 @@ impl RequestSender {
             }
         }
 
+        record_content_length_header(
+            &span,
+            request.headers(),
+            "http.request.header.content-length",
+        );
+
         Ok(self
             .send_request(request, config, override_connect_addr)
             .await?)
@@ -583,7 +595,10 @@ impl RequestSender {
             .map_err(hyper_legacy_request_error)?
             .map(|body| body.map_err(hyper_request_error).boxed_unsync());
 
-        tracing::Span::current().record("http.response.status_code", resp.status().as_u16());
+        let span = tracing::Span::current();
+        span.record("http.response.status_code", resp.status().as_u16());
+
+        record_content_length_header(&span, resp.headers(), "http.response.header.content-length");
 
         Ok(IncomingResponse {
             resp,
@@ -1121,5 +1136,13 @@ pub fn p3_to_p2_error_code(code: p3_types::ErrorCode) -> p2_types::ErrorCode {
         p3_types::ErrorCode::LoopDetected => p2_types::ErrorCode::LoopDetected,
         p3_types::ErrorCode::ConfigurationError => p2_types::ErrorCode::ConfigurationError,
         p3_types::ErrorCode::InternalError(payload) => p2_types::ErrorCode::InternalError(payload),
+    }
+}
+
+fn record_content_length_header(span: &Span, headers: &HeaderMap, attr_name: &'static str) {
+    if let Some(content_length) = headers.get(CONTENT_LENGTH) {
+        if let Ok(size_str) = content_length.to_str() {
+            span.set_attribute(attr_name, size_str.to_string());
+        }
     }
 }


### PR DESCRIPTION
## Description

Records `http.request.header.content-length` and `http.response.header.content-length` on outbound HTTP spans when the header is present.

Uses `set_attribute()` from `tracing_opentelemetry::OpenTelemetrySpanExt` because the OTel attribute names contain hyphens, which `tracing`'s `#[instrument]` field system cannot represent.

I didn't implement a test because I thought it's not worth to add another expensive integration test case just for a new field sent to OTel collector.

I used a small HTTP component and [otel-desktop-viewer](https://github.com/CtrlSpice/otel-desktop-viewer) to verify this works as expected:

```rust
#[http_component]
async fn handle_test_spin_rust(req: Request) -> anyhow::Result<impl IntoResponse> {
    println!("Handling request to {:?}", req.header("spin-full-url"));

    let outbound_request = Request::get("https://httpbin.org/get")
        .header("accept", "application/json")
        .build();
    let outbound_response: Response = spin_sdk::http::send(outbound_request)
        .await
        .context("failed to call https://httpbin.org/get")?;
    let outbound_status = outbound_response.status();
    let outbound_body_len = outbound_response.body().len();
    
    Ok(Response::builder()
        .status(200)
        .header("content-type", "text/plain")
        .body(format!(
            "Hello World!\nhttpbin.org/get status: {outbound_status}\nhttpbin.org/get body bytes: {outbound_body_len}"
        ))
        .build())
}
```

Addresses part of https://github.com/spinframework/spin/issues/3188 (Option 1).

### Changes

- `crates/factor-outbound-http/Cargo.toml` — added `tracing-opentelemetry` dependency
- `crates/factor-outbound-http/src/wasi.rs` — added `record_content_length_header` helper and call sites for request (after interceptor) and response
