### PR TITLE
Don't log full PostgreSQL connection string

### DIFF
--- a/crates/factor-outbound-pg/src/client.rs
+++ b/crates/factor-outbound-pg/src/client.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
@@ -104,7 +106,9 @@ fn create_connection_pool(
         .parse::<tokio_postgres::Config>()
         .context("parsing Postgres connection string")?;
 
-    tracing::debug!("Build new connection: {}", address);
+    // The debug form isn't as easy to read as logging the address,
+    // but it redacts the password!
+    tracing::debug!("Build new connection: {config:?}");
 
     let mgr_config = deadpool_postgres::ManagerConfig {
         recycling_method: deadpool_postgres::RecyclingMethod::Clean,

--- a/crates/factor-outbound-pg/src/host.rs
+++ b/crates/factor-outbound-pg/src/host.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::result_large_err)]
+
 use anyhow::Result;
 use spin_core::wasmtime::component::{Accessor, FutureReader, Resource, StreamReader};
 use spin_world::spin::postgres3_0_0::postgres::{self as v3};


### PR DESCRIPTION
Fixes #3380.

Well, I think #3380 might have been fixed by other work on connection errors, because I can't make it happen, but I do see a location where we debug-log the address, so this fixes that.  But if anyone can still reproduce us including the unredacted connection string in an error message, please let me know how you did it, and I will fix it!

(Also fixed a couple of clippy tanties in new Rust.)
