### PR TITLE
Fix Markdown reference missing `spin up` bits

### DIFF
--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -42,7 +42,24 @@ impl GenerateReference {
 /// Rebuild a `clap::Command` with subcommands and options sorted alphabetically.
 /// This preserves the sorted output from the previously vendored clap-markdown fork.
 fn sorted_command(cmd: &clap::Command) -> clap::Command {
+    if cmd.get_name() == "up" {
+        let inner = crate::commands::up::UpCommand::inner()
+            // We have to munge the name to stop it recursing.
+            .name("up-inner");
+        return sorted_command(&inner);
+    }
+
     let mut new_cmd = clap::Command::new(cmd.get_name().to_owned());
+
+    // Because of the `up` shenanigans, we have to remove the help and
+    // version flags or Clap asserts on a duplicate flag in `watch`.
+    // (But this is no loss because clap-markdown skips them anyway.)
+    new_cmd = new_cmd.disable_help_flag(true).disable_version_flag(true);
+
+    // Unmunge the name munging
+    if cmd.get_name() == "up-inner" {
+        new_cmd = new_cmd.name("up");
+    }
 
     if let Some(v) = cmd.get_display_name() {
         new_cmd = new_cmd.display_name(v);

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -62,7 +62,7 @@ pub struct Push {
     #[clap(long, default_value_t = true)]
     pub compose: bool,
 
-    /// Specifies to perform `spin build` before pushing the application.
+    /// Specifies to perform `spin build` (with the default options) before pushing the application.
     #[clap(long, env = ALWAYS_BUILD_ENV)]
     pub build: bool,
 

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -41,6 +41,7 @@ const MULTI_TRIGGER_LET_ALL_START: tokio::time::Duration = tokio::time::Duration
 // NOTE: Most of the messy clap parsing details are in the child parsing module.
 pub struct UpCommand(UpCommandInner);
 
+/// Start the Spin application
 impl UpCommand {
     pub async fn run(self) -> Result<()> {
         // For displaying help, first print `spin up`'s own usage text, then
@@ -73,6 +74,10 @@ impl UpCommand {
         let mut cmd = UpCommand::parse_from(args);
         cmd.0.file_source = Some(manifest_file);
         cmd.0.run().await
+    }
+
+    pub(crate) fn inner() -> clap::Command {
+        UpCommandInner::command()
     }
 }
 

--- a/src/commands/up/parsing.rs
+++ b/src/commands/up/parsing.rs
@@ -172,9 +172,11 @@ fn classify_short_flags(
 
 impl Args for UpCommand {
     fn augment_args(cmd: clap::Command) -> clap::Command {
+        let inner = UpCommandInner::command();
+
         // The FromArgMatches impl below depends on some restrictions on
         // UpCommandInner, which we assert here to prevent bugs
-        for arg in UpCommandInner::command().get_arguments() {
+        for arg in inner.get_arguments() {
             assert!(
                 !arg.is_positional(),
                 "UpCommandInner cannot use positional arg {arg}"
@@ -188,11 +190,20 @@ impl Args for UpCommand {
         }
 
         // Grab all arguments for later parsing
-        cmd.disable_help_flag(true).arg(
+        let mut cmd = cmd.disable_help_flag(true).arg(
             clap::Arg::new("args")
                 .action(clap::ArgAction::Append)
                 .allow_hyphen_values(true),
-        )
+        );
+
+        if let Some(about) = inner.get_about() {
+            cmd = cmd.about(about.clone());
+        }
+        if let Some(long_about) = inner.get_long_about() {
+            cmd = cmd.long_about(long_about.clone());
+        }
+
+        cmd
     }
 
     fn augment_args_for_update(_: clap::Command) -> clap::Command {


### PR DESCRIPTION
This fixes an issue in the CLI reference generator, where `spin up` was missing its description and arguments.

~There remains an issue in `spin --help` where `up` is missing its description.  I had a go at fixing that and well, it worked but it made everything else worse so yeah nah.  I'll keep noodling...~ _Edit:_ I think I got it. I am a bit suspicious because the first time I tried this, the docs came out unsorted and with gaps, but when I added some tracing, it was fixed, and when I removed the tracing, it was still fixed. Right now I am putting that first failure down to bungling a rebuild or something, but... well, better build the habit of reading the Markdown before publishing it!

This also reverts a possibly inadvertent change to one piece of CLI docs - this makes it consistent with how the same option is presented elsewhere.  At least I think it does, maybe I am missing something and that was the reason for the change.
