### PR TITLE
Update `schemars`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7191,6 +7191,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "regalloc2"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7840,12 +7860,13 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "indexmap 2.14.0",
+ "ref-cast",
  "schemars_derive",
  "semver",
  "serde",
@@ -7854,9 +7875,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pretty_assertions = "1.3"
 regex = { workspace = true }
 reqwest = { workspace = true }
 rpassword = "7"
-schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
+schemars = { workspace = true }
 semver = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = { workspace = true }
@@ -174,6 +174,7 @@ rusqlite = "0.34"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "logging", "tls12"] }
 rustls-pki-types = "1.12"
 rustls-platform-verifier = "0.6"
+schemars = { version = "1.2", features = ["indexmap2", "semver1"] }
 semver = "1"
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1.0"

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
-schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
+schemars = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 spin-serde = { path = "../serde" }

--- a/crates/manifest/src/schema/json_schema.rs
+++ b/crates/manifest/src/schema/json_schema.rs
@@ -1,4 +1,4 @@
-use crate::schema::v2::{ComponentSpec, Map, OneOrManyComponentSpecs};
+use crate::schema::v2::{Component, ComponentSpec, Map, OneOrManyComponentSpecs};
 use schemars::JsonSchema;
 
 // The structs here allow dead code because they exist only
@@ -163,35 +163,34 @@ pub enum WatchCommand {
     Command(String),
 }
 
-pub fn toml_table(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
-        instance_type: Some(schemars::schema::SingleOrVec::Single(Box::new(
-            schemars::schema::InstanceType::Object,
-        ))),
-        ..Default::default()
+pub fn toml_table(_gen: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "object"
     })
 }
 
-pub fn map_of_toml_tables(_gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
-        instance_type: Some(schemars::schema::SingleOrVec::Single(Box::new(
-            schemars::schema::InstanceType::Object,
-        ))),
-        ..Default::default()
+pub fn map_of_toml_tables(_gen: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "object"
     })
 }
 
 pub fn one_or_many<T: schemars::JsonSchema>(
-    gen: &mut schemars::gen::SchemaGenerator,
-) -> schemars::schema::Schema {
-    schemars::schema::Schema::Object(schemars::schema::SchemaObject {
-        subschemas: Some(Box::new(schemars::schema::SubschemaValidation {
-            one_of: Some(vec![
-                gen.subschema_for::<T>(),
-                gen.subschema_for::<Vec<T>>(),
-            ]),
-            ..Default::default()
-        })),
-        ..Default::default()
+    generator: &mut schemars::generate::SchemaGenerator,
+) -> schemars::Schema {
+    schemars::json_schema!({
+        "oneOf": [
+            generator.subschema_for::<T>(),
+            generator.subschema_for::<Vec<T>>(),
+        ]
+    })
+}
+
+pub fn id_or_component(generator: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "oneOf": [
+            generator.subschema_for::<spin_serde::KebabId>(),
+            generator.subschema_for::<Component>(),
+        ]
     })
 }

--- a/crates/manifest/src/schema/v2.rs
+++ b/crates/manifest/src/schema/v2.rs
@@ -15,7 +15,7 @@ pub(crate) type Map<K, V> = indexmap::IndexMap<K, V>;
 #[serde(deny_unknown_fields)]
 pub struct AppManifest {
     /// `spin_manifest_version = 2`
-    #[schemars(with = "usize", range = (min = 2, max = 2))]
+    #[schemars(with = "usize", range(min = 2, max = 2))]
     pub spin_manifest_version: FixedVersion<2>,
     /// `[application]`
     pub application: AppDetails,
@@ -173,6 +173,7 @@ pub struct OneOrManyComponentSpecs(
 /// Component reference or inline definition
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, untagged, try_from = "toml::Value")]
+#[schemars(schema_with = "json_schema::id_or_component")]
 pub enum ComponentSpec {
     /// `"component-id"`
     Reference(KebabId),

--- a/crates/serde/Cargo.toml
+++ b/crates/serde/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true }
-schemars = { version = "0.8.21", features = ["indexmap2", "semver"] }
+schemars = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 wasm-pkg-common = { workspace = true }

--- a/crates/serde/src/dependencies.rs
+++ b/crates/serde/src/dependencies.rs
@@ -2,6 +2,7 @@
 
 use crate::KebabId;
 use anyhow::anyhow;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use wasm_pkg_common::package::PackageRef;
@@ -80,8 +81,11 @@ impl FromStr for DependencyPackageName {
 /// Name of an import dependency.
 ///
 /// For example: `foo:bar/baz@0.1.0`, `foo:bar/baz`, `foo:bar@0.1.0`, `foo:bar`, `foo-bar`.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(
+    Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd, Hash, JsonSchema,
+)]
 #[serde(into = "String", try_from = "String")]
+#[schemars(with = "String")]
 pub enum DependencyName {
     /// Plain name
     Plain(KebabId),

--- a/crates/serde/src/version.rs
+++ b/crates/serde/src/version.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 /// FixedVersion represents a version integer field with a const value.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(into = "usize", try_from = "usize")]
-#[schemars(with = "usize", range = (min = V, max = V))]
+#[schemars(with = "usize")]
 pub struct FixedVersion<const V: usize>;
 
 impl<const V: usize> From<FixedVersion<V>> for usize {
@@ -28,7 +28,7 @@ impl<const V: usize> TryFrom<usize> for FixedVersion<V> {
 /// but accepts lower versions during deserialisation.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
 #[serde(into = "usize", try_from = "usize")]
-#[schemars(with = "usize", range = (min = 1, max = V))]
+#[schemars(with = "usize")]
 pub struct FixedVersionBackwardCompatible<const V: usize>;
 
 impl<const V: usize> From<FixedVersionBackwardCompatible<V>> for usize {


### PR DESCRIPTION
This emerged from looking into #3456.  Rust 2024 reserves the `gen` keyword, which was a module in `schemars` 0.8.  So to avoid reserved word woe in 2024, we need to bump schemars.  Is it just a few renames?  Reader, it is not.

I have diffed the JSON Schema documents produced by Spin main and Spin with this change, and there are some structural differences that make it hard to verify that the behaviour is the same.  But they look plausible.

To be clear, there is _no_ motivation to do this unless we are planning a move to Rust 2024.  This is just clearing some ground to make that less painful.
