### PR TITLE
Fix test for `spin up` JSON output

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -108,7 +108,7 @@ mod integration_tests {
             },
             ServicesConfig::none(),
             move |env| {
-                let stdout = env.runtime_mut().stdout().to_owned();
+                let stdout = env.runtime_mut().wait_for_non_empty_stdout()?.to_owned();
 
                 let check_json = || -> anyhow::Result<()> {
                     let parsed: serde_json::Value =

--- a/tests/testing-framework/src/runtimes/spin_cli.rs
+++ b/tests/testing-framework/src/runtimes/spin_cli.rs
@@ -203,6 +203,27 @@ impl SpinCli {
         self.stdout.output_as_str().unwrap_or("<non-utf8>")
     }
 
+    pub fn wait_for_non_empty_stdout(&mut self) -> anyhow::Result<&str> {
+        const WAIT_FOR_STDOUT_MILLIS: u64 = 5000;
+        const POLL_STDOUT_INTERVAL_MILLIS: u64 = 50;
+        const NUM_WAITS: u64 = WAIT_FOR_STDOUT_MILLIS / POLL_STDOUT_INTERVAL_MILLIS;
+
+        for _ in 0..NUM_WAITS {
+            if !self.stdout().is_empty() {
+                // We don't mind if additional stuff has arrived on stdout since
+                // the empty check. As long as stdout can't go backwards we're okay.
+                // (And snapshotting makes the borrow checker mad, so...)
+                return Ok(self.stdout());
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(
+                POLL_STDOUT_INTERVAL_MILLIS,
+            ));
+        }
+
+        anyhow::bail!("waited for text to appear on stdout but it didn't");
+    }
+
     pub fn stderr(&mut self) -> &str {
         self.stderr.output_as_str().unwrap_or("<non-utf8>")
     }


### PR DESCRIPTION
Fixes #3437... I hope.

This fix is still a bit heuristic.  The test tries to read stdout once the Spin listener port opens.  This, I think, causes a race, because the output is also printed to stdout once the Spin listener port opens.  When the read wins, stdout is empty.  My fix is to wait until stdout is non-empty (by polling it until it is non-empty).  This potentially still has a race if output is partially written when a poll occurs, but the window is hopefully a bit smaller.

I was never able to reproduce the issue locally, so there's no proof this will make things better - maybe I've misunderstood the nature of the flake, or the "partially written" race is just as cruel as the "empty" race.  But this seemed like a minimal-investment first try!
