### PR TITLE
Shell completions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1610,6 +1610,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
+ "clap_lex 1.1.0",
+ "is_executable",
+ "shlex",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,6 +4664,15 @@ dependencies = [
  "hermit-abi 0.4.0",
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "is_executable"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabb8b4867b26294d818bf3f651a454b6901431711abb96e296245888d6e8c4"
+dependencies = [
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8472,6 +8493,7 @@ dependencies = [
  "cargo-target-dep",
  "clap",
  "clap-markdown",
+ "clap_complete",
  "clap_lex 0.7.7",
  "clearscreen",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ spin-trigger-http = { path = "crates/trigger-http" }
 spin-trigger-redis = { path = "crates/trigger-redis" }
 terminal = { path = "crates/terminal" }
 rand.workspace = true
+clap_complete = { version = "4.6.2", features = ["unstable-dynamic"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # This needs to be an explicit dependency to enable

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -28,10 +28,12 @@ pub struct BuildCommand {
     /// The build profile to build. The default is the anonymous profile (usually
     /// the release build).
     #[clap(long)]
+    #[arg(add = clap_complete::ArgValueCandidates::new(crate::completions::profiles))]
     pub profile: Option<String>,
 
     /// Component ID to build. This can be specified multiple times. The default is all components.
     #[clap(short = 'c', long)]
+    #[arg(add = clap_complete::ArgValueCandidates::new(crate::completions::components))]
     pub component_id: Vec<String>,
 
     /// By default, if the application manifest specifies one or more deployment targets, Spin

--- a/src/commands/maintenance.rs
+++ b/src/commands/maintenance.rs
@@ -9,6 +9,8 @@ pub enum MaintenanceCommands {
     GenerateReference(GenerateReference),
     /// Generate JSON schema for application manifest.
     GenerateManifestSchema(GenerateSchema),
+    /// Generate shell completions. Requires the COMPLETE environment variable to be set.
+    GenerateCompletions,
 }
 
 impl MaintenanceCommands {
@@ -16,6 +18,7 @@ impl MaintenanceCommands {
         match self {
             MaintenanceCommands::GenerateReference(cmd) => cmd.run().await,
             MaintenanceCommands::GenerateManifestSchema(cmd) => cmd.run().await,
+            MaintenanceCommands::GenerateCompletions => GenerateCompletions::run().await,
         }
     }
 }
@@ -146,4 +149,42 @@ fn write(output: &Option<PathBuf>, text: &str) -> anyhow::Result<()> {
         None => println!("{text}"),
     }
     Ok(())
+}
+
+#[derive(Parser, Debug)]
+pub struct GenerateCompletions;
+
+impl GenerateCompletions {
+    async fn run() -> anyhow::Result<()> {
+        // This intentionally does not use `crate::is_completions_request`.
+        // The reason is that `is_completions_request` may grow stronger, because it must
+        // avoid inferring a completion scenario when there isn't one (because the
+        // consequence of getting it wrong would be 'you can't run Spin commands').
+        // Whereas this check has to be as weak as possible, because it must avoid inferring a
+        // *non*-completion scenario when there *is* one (because the consequence
+        // of doing so would be 'you can't generate completions', whereas the consequence of
+        // failing to spot a non-completion scenario is merely 'you don't get a good error').
+        if std::env::var_os("COMPLETE").is_none() {
+            anyhow::bail!(
+                "Set the COMPLETE environment variable to the name of your shell while generating completions."
+            );
+        }
+
+        // `SpinApp::Up` is associated with `UpCommand`, which does its work by clever
+        // parsing tricks. `clap_complete` is frustratingly oblivious to these clever
+        // parsing tricks, so if you run it over `SpinApp`, it doesn't generate completions
+        // for `spin up`. So we sub in the `inner()` which carries the actual 'real' clap parsing.
+        let factory = || {
+            let cmd = crate::SpinApp::command();
+            let up_inner = crate::commands::up::UpCommand::inner()
+                .name("up")
+                .alias("u");
+            cmd.mut_subcommand("up", |_| up_inner)
+        };
+
+        let env = clap_complete::env::CompleteEnv::with_factory(factory);
+        env.complete();
+
+        Ok(())
+    }
 }

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -30,15 +30,17 @@ pub struct TemplateNewCommandCore {
 
     /// The template from which to create the new application or component. Run `spin templates list` to see available options.
     #[clap(short = 't', long = "template")]
+    #[arg(add = clap_complete::ArgValueCandidates::new(completions::template_ids))]
     pub template_id: Option<String>,
 
     /// Filter templates to select by tags.
     #[clap(long = "tag", conflicts_with = "template_id")]
+    #[arg(add = clap_complete::ArgValueCandidates::new(completions::template_tags))]
     pub tags: Vec<String>,
 
     /// The directory in which to create the new application or component.
     /// The default is the name argument.
-    #[clap(short = 'o', long = "output", group = "location")]
+    #[clap(short = 'o', long = "output", group = "location", value_hint = clap::ValueHint::DirPath)]
     pub output_path: Option<PathBuf>,
 
     /// Create the new application or component in the current directory.
@@ -390,6 +392,47 @@ fn validate_name(name: &str) -> Result<String, String> {
         "Each segment of the name must start with a letter. {invalid_text} {verb} not start with a letter"
     );
     Err(msg)
+}
+
+mod completions {
+    use super::*;
+
+    pub fn template_ids() -> Vec<clap_complete::CompletionCandidate> {
+        let fut = async move {
+            let Ok(template_manager) = TemplateManager::try_default() else {
+                return vec![];
+            };
+            let Ok(list) = template_manager.list().await else {
+                return vec![];
+            };
+            list.templates
+                .iter()
+                .map(|t| clap_complete::CompletionCandidate::new(t.id()))
+                .collect::<Vec<_>>()
+        };
+
+        let h = tokio::runtime::Handle::current();
+        tokio::task::block_in_place(move || h.block_on(fut))
+    }
+
+    pub fn template_tags() -> Vec<clap_complete::CompletionCandidate> {
+        let fut = async move {
+            let Ok(template_manager) = TemplateManager::try_default() else {
+                return vec![];
+            };
+            let Ok(list) = template_manager.list().await else {
+                return vec![];
+            };
+            list.templates
+                .iter()
+                .flat_map(|t| t.tags())
+                .map(clap_complete::CompletionCandidate::new)
+                .collect::<Vec<_>>()
+        };
+
+        let h = tokio::runtime::Handle::current();
+        tokio::task::block_in_place(move || h.block_on(fut))
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/plugins.rs
+++ b/src/commands/plugins.rs
@@ -69,6 +69,7 @@ pub struct Install {
         conflicts_with = PLUGIN_LOCAL_PLUGIN_MANIFEST_OPT,
         required_unless_present_any = [PLUGIN_REMOTE_PLUGIN_MANIFEST_OPT, PLUGIN_LOCAL_PLUGIN_MANIFEST_OPT],
     )]
+    #[arg(add = clap_complete::ArgValueCandidates::new(completions::installable_plugins))]
     pub name: Option<String>,
 
     /// Path to local plugin manifest.
@@ -163,6 +164,7 @@ impl Install {
 #[derive(Parser, Debug)]
 pub struct Uninstall {
     /// Name of Spin plugin.
+    #[arg(add = clap_complete::ArgValueCandidates::new(completions::installed_plugins))]
     pub name: String,
 }
 
@@ -189,6 +191,7 @@ pub struct Upgrade {
         name = PLUGIN_NAME_OPT,
         conflicts_with = PLUGIN_ALL_OPT,
     )]
+    #[arg(add = clap_complete::ArgValueCandidates::new(completions::installed_plugins))]
     pub name: Option<String>,
 
     /// Upgrade all plugins.
@@ -463,6 +466,7 @@ impl Upgrade {
 #[derive(Parser, Debug)]
 pub struct Show {
     /// Name of Spin plugin.
+    #[arg(add = clap_complete::ArgValueCandidates::new(completions::all_plugins))]
     pub name: String,
 }
 
@@ -922,6 +926,71 @@ async fn try_install(
         Ok(true)
     } else {
         Ok(false)
+    }
+}
+
+mod completions {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    pub fn installable_plugins() -> Vec<clap_complete::CompletionCandidate> {
+        let Ok(plugin_manager) = PluginManager::try_default() else {
+            return vec![];
+        };
+
+        let Ok(catalogue_plugins) = plugin_manager.store().catalogue_manifests() else {
+            return vec![];
+        };
+        let catalogue_names: HashSet<_> = catalogue_plugins.iter().map(|m| m.name()).collect();
+
+        let Ok(installed_plugins) = plugin_manager.store().installed_manifests() else {
+            return vec![];
+        };
+        let installed_names: HashSet<_> = installed_plugins.iter().map(|m| m.name()).collect();
+
+        let installable_names = catalogue_names.difference(&installed_names);
+
+        installable_names
+            .map(clap_complete::CompletionCandidate::new)
+            .collect()
+    }
+
+    pub fn installed_plugins() -> Vec<clap_complete::CompletionCandidate> {
+        let Ok(plugin_manager) = PluginManager::try_default() else {
+            return vec![];
+        };
+
+        let Ok(installed_plugins) = plugin_manager.store().installed_manifests() else {
+            return vec![];
+        };
+
+        installed_plugins
+            .iter()
+            .map(|m| clap_complete::CompletionCandidate::new(m.name()))
+            .collect()
+    }
+
+    pub fn all_plugins() -> Vec<clap_complete::CompletionCandidate> {
+        let Ok(plugin_manager) = PluginManager::try_default() else {
+            return vec![];
+        };
+
+        let Ok(catalogue_plugins) = plugin_manager.store().catalogue_manifests() else {
+            return vec![];
+        };
+        let catalogue_names: HashSet<_> = catalogue_plugins.iter().map(|m| m.name()).collect();
+
+        let Ok(installed_plugins) = plugin_manager.store().installed_manifests() else {
+            return vec![];
+        };
+        let installed_names: HashSet<_> = installed_plugins.iter().map(|m| m.name()).collect();
+
+        let all_names = catalogue_names.union(&installed_names);
+
+        all_names
+            .map(clap_complete::CompletionCandidate::new)
+            .collect()
     }
 }
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -43,6 +43,7 @@ pub struct Push {
     /// The build profile to push. The default is the anonymous profile (usually
     /// the release build).
     #[clap(long)]
+    #[arg(add = clap_complete::ArgValueCandidates::new(crate::completions::profiles))]
     pub profile: Option<String>,
 
     /// Ignore server certificate errors
@@ -72,7 +73,7 @@ pub struct Push {
     pub reference: String,
 
     /// Cache directory for downloaded registry data.
-    #[clap(long)]
+    #[clap(long, value_hint = clap::ValueHint::DirPath)]
     pub cache_dir: Option<PathBuf>,
 
     /// Specifies the OCI image manifest annotations (in key=value format).

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -84,7 +84,7 @@ impl UpCommand {
 /// Argument parser for UpCommand.
 #[derive(Parser, Debug, Default)]
 #[clap(about = "Start the Spin application", disable_help_flag = true)]
-struct UpCommandInner {
+pub(crate) struct UpCommandInner {
     #[clap(short = 'h', long = "help")]
     pub help: bool,
 
@@ -123,6 +123,7 @@ struct UpCommandInner {
     /// The build profile to run. The default is the anonymous profile (usually
     /// the release build).
     #[clap(long)]
+    #[arg(add = clap_complete::ArgValueCandidates::new(crate::completions::profiles))]
     pub profile: Option<String>,
 
     /// Ignore server certificate errors from a registry
@@ -138,11 +139,11 @@ struct UpCommandInner {
     pub env: Vec<(String, String)>,
 
     /// Temporary directory for the static assets of the components.
-    #[clap(long = "temp", alias = "tmp")]
+    #[clap(long = "temp", alias = "tmp", value_hint = clap::ValueHint::DirPath)]
     pub tmp: Option<PathBuf>,
 
     /// Cache directory for downloaded components and assets.
-    #[clap(long)]
+    #[clap(long, value_hint = clap::ValueHint::DirPath)]
     pub cache_dir: Option<PathBuf>,
 
     /// For local apps with directory mounts and no excluded files, mount them directly instead of using a temporary
@@ -161,6 +162,7 @@ struct UpCommandInner {
 
     /// [Experimental] Component ID to run. This can be specified multiple times. The default is all components.
     #[clap(short = 'c', long = "component-id")]
+    #[arg(add = clap_complete::ArgValueCandidates::new(crate::completions::components))]
     pub components: Vec<String>,
 
     /// All other args, to be passed through to the trigger

--- a/src/commands/watch.rs
+++ b/src/commands/watch.rs
@@ -47,6 +47,7 @@ pub struct WatchCommand {
     /// The build profile to build and run. The default is the anonymous profile (usually
     /// the release build).
     #[clap(long)]
+    #[arg(add = clap_complete::ArgValueCandidates::new(crate::completions::profiles))]
     pub profile: Option<String>,
 
     /// Clear the screen before each run.

--- a/src/completions.rs
+++ b/src/completions.rs
@@ -1,0 +1,63 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use clap_complete::CompletionCandidate;
+
+pub fn profiles() -> Vec<CompletionCandidate> {
+    let Some(toml) = load_manifest_toml() else {
+        return vec![];
+    };
+
+    let Some(components) = toml.get("component").and_then(|t| t.as_table()) else {
+        return vec![];
+    };
+
+    let mut all_profiles = HashSet::new();
+
+    for component in components.values() {
+        if let Some(profiles) = component
+            .get("profile")
+            .and_then(|t| t.as_table())
+            .map(|t| t.keys())
+        {
+            all_profiles.extend(profiles);
+        }
+    }
+
+    all_profiles.iter().map(CompletionCandidate::new).collect()
+}
+
+pub fn components() -> Vec<CompletionCandidate> {
+    let Some(toml) = load_manifest_toml() else {
+        return vec![];
+    };
+
+    let Some(components) = toml.get("component").and_then(|t| t.as_table()) else {
+        return vec![];
+    };
+
+    components.keys().map(CompletionCandidate::new).collect()
+}
+
+fn load_manifest_toml() -> Option<toml::Table> {
+    let mut args = std::env::args();
+
+    let default_path = PathBuf::from("spin.toml");
+
+    let manifest_path = if args.len() <= 2 {
+        default_path
+    } else {
+        match args.position(|a| a == "-f" || a == "--from" || a == "--file" || a == "--from-file") {
+            None => default_path,
+            Some(_) => match args.next() {
+                None => default_path,
+                Some(arg) => {
+                    spin_common::paths::resolve_manifest_file_path(arg).unwrap_or(default_path)
+                }
+            },
+        }
+    };
+
+    std::fs::read_to_string(manifest_path)
+        .ok()
+        .and_then(|text| toml::from_str::<toml::Table>(&text).ok())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod build_info;
 pub mod commands;
+pub(crate) mod completions;
 mod directory_rels;
 pub(crate) mod opts;
 pub mod subprocess;
@@ -29,6 +30,10 @@ use spin_trigger_redis::RedisTrigger;
 pub use opts::HELP_ARGS_ONLY_TRIGGER_TYPE;
 
 pub async fn run() -> anyhow::Result<()> {
+    if is_completion_request() {
+        return (MaintenanceCommands::GenerateCompletions).run().await;
+    }
+
     let version = build_info();
     spin_telemetry::init(version.clone()).context("Failed to initialize telemetry")?;
 
@@ -65,6 +70,10 @@ pub async fn run() -> anyhow::Result<()> {
         .run()
         .await
         .inspect_err(|err| tracing::debug!(?err))
+}
+
+fn is_completion_request() -> bool {
+    std::env::var_os("COMPLETE").is_some_and(|v| !v.is_empty())
 }
 
 /// The Spin CLI


### PR DESCRIPTION
FIFTH TIME'S THE CHARM PLEASE LET FIFTH TIME BE THE CHARM

Okay this is still kinda WIP.  I need to do a pass for other things that would benefit from completions other than "uh filename", and I need to figure out how to get any completions working at all with the new `spin up` because oof.  It also needs testing on zsh at minimum.  But in the meantime, tyre kicking fans:

HOW IT WORKS IF IT DOES WORK WHICH IS YET TO BE CONFIRMED

The idea is that `spin maintenance generate-completions` generates a bash script, and that generated bash script calls back into Spin to get the completions.  That's why Spin now needs to check "am I being called for completions" and divert processing before doing normal command parsing.  I am not entirely easy about this but it is what it is.  Open to better thoughts.

HOW TO USE IT

**IMPORTANT: the `spin` binary must be on your PATH** (as far as I can tell)

1. Run `spin maintenance generate-completions` _with the `COMPLETE` environment variable set_ to your shell.  This will produce a completion script.  E.g. `COMPLETE=bash spin maintenance generate-completions >completions.sh`
2. `source` the completion script e.g. `source ./completions.sh`

If this works reliably, then we can do [what `clap-complete` describes](https://docs.rs/clap_complete/latest/clap_complete/env/index.html) - at startup, pipe the output script directly to `source`.  In this model, to install the completions is:

```
echo "source <(COMPLETE=bash spin maintenance generate-completions)" >> ~/.bashrc
```

(But obviously, "this works reliably" is vanishingly unlikely, so I'll probably see y'all back here in a year's time.)
