### PR TITLE
Upgrading templates should remove ones that no longer exist

### DIFF
--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -68,6 +68,8 @@ pub enum SkippedReason {
     AlreadyExists,
     /// The template was skipped because its manifest was missing or invalid.
     InvalidManifest(String),
+    /// The template was removed from the source but could not be removed locally.
+    CouldNotRemove,
 }
 
 /// The results of installing a set of templates.
@@ -76,6 +78,8 @@ pub struct InstallationResults {
     pub installed: Vec<Template>,
     /// The templates that were skipped during the install operation.
     pub skipped: Vec<(String, SkippedReason)>,
+    /// The templates that were removed during the install operation.
+    pub removed: Vec<String>,
 }
 
 /// The result of listing templates.
@@ -139,6 +143,21 @@ impl TemplateManager {
         let mut installed = vec![];
         let mut skipped = vec![];
 
+        let mut local_but_not_source = if let Some(upgrading_repo) = source.as_git_url() {
+            let local = self
+                .list()
+                .await
+                .map(|list| list.templates)
+                .unwrap_or_default();
+            local
+                .into_iter()
+                .filter(|t| t.is_from_source_repo(upgrading_repo))
+                .map(|t| t.id().to_string())
+                .collect()
+        } else {
+            std::collections::HashSet::new()
+        };
+
         for template_dir in template_dirs {
             let install_result = self
                 .install_one(&template_dir, options, source, reporter)
@@ -147,15 +166,39 @@ impl TemplateManager {
                     format!("Failed to install template from {}", template_dir.display())
                 })?;
             match install_result {
-                InstallationResult::Installed(template) => installed.push(template),
-                InstallationResult::Skipped(id, reason) => skipped.push((id, reason)),
+                InstallationResult::Installed(template) => {
+                    local_but_not_source.remove(template.id());
+                    installed.push(template);
+                }
+                InstallationResult::Skipped(id, reason) => {
+                    local_but_not_source.remove(id.as_str());
+                    skipped.push((id, reason));
+                }
+            }
+        }
+
+        let mut to_remove = match &options.exists_behaviour {
+            ExistsBehaviour::Skip => vec![],
+            ExistsBehaviour::Update => local_but_not_source.into_iter().collect::<Vec<_>>(),
+        };
+        let mut removed = Vec::with_capacity(to_remove.len());
+
+        for id in &to_remove {
+            match self.uninstall(id).await {
+                Ok(_) => removed.push(id.clone()),
+                Err(_) => skipped.push((id.to_string(), SkippedReason::CouldNotRemove)),
             }
         }
 
         installed.sort_by_key(|t| t.id().to_owned());
         skipped.sort_by_key(|(id, _)| id.clone());
+        to_remove.sort();
 
-        Ok(InstallationResults { installed, skipped })
+        Ok(InstallationResults {
+            installed,
+            skipped,
+            removed,
+        })
     }
 
     async fn install_one(

--- a/crates/templates/src/source.rs
+++ b/crates/templates/src/source.rs
@@ -93,6 +93,13 @@ impl TemplateSource {
             _ => None,
         }
     }
+
+    pub(crate) fn as_git_url(&self) -> Option<&Url> {
+        match self {
+            TemplateSource::Git(git) => Some(&git.url),
+            _ => None,
+        }
+    }
 }
 
 pub(crate) struct LocalTemplateSource {

--- a/crates/templates/src/template.rs
+++ b/crates/templates/src/template.rs
@@ -257,6 +257,11 @@ impl Template {
         }
     }
 
+    pub(crate) fn is_from_source_repo(&self, source_repo: &url::Url) -> bool {
+        self.source_repo()
+            .is_some_and(|r| r == source_repo.as_str())
+    }
+
     /// A human-readable description of where the template was installed
     /// from.
     pub fn installed_from_or_empty(&self) -> &str {

--- a/src/commands/templates.rs
+++ b/src/commands/templates.rs
@@ -163,6 +163,7 @@ impl Install {
     fn print_installed_templates(&self, installation_results: &InstallationResults) {
         let templates = &installation_results.installed;
         let skipped = &installation_results.skipped;
+        let removed = &installation_results.removed;
 
         if templates.is_empty() && skipped.is_empty() {
             println!("The specified source contained no templates");
@@ -190,6 +191,24 @@ impl Install {
 
                 for (id, reason) in skipped {
                     table.add_row(vec![id.clone(), skipped_reason_text(reason)]);
+                }
+
+                println!();
+                println!("{table}");
+            }
+            if !removed.is_empty() {
+                println!();
+                println!(
+                    "Removed {} templates no longer in repository",
+                    removed.len()
+                );
+
+                let mut table = Table::new();
+                table.set_header(vec!["Name"]);
+                table.load_preset(comfy_table::presets::ASCII_BORDERS_ONLY_CONDENSED);
+
+                for id in removed {
+                    table.add_row(vec![id.clone()]);
                 }
 
                 println!();
@@ -356,6 +375,7 @@ impl Upgrade {
 
     fn print_upgrade_summary(&self, summary: &UpgradeSummary) {
         let templates = &summary.upgraded;
+        let removed = &summary.removed;
         let errors = &summary.errored_repos;
 
         if templates.is_empty() {
@@ -376,6 +396,25 @@ impl Upgrade {
         }
 
         println!();
+
+        if !removed.is_empty() {
+            println!(
+                "Removed {} template(s) no longer in repository/ies",
+                removed.len()
+            );
+
+            let mut table = Table::new();
+            table.set_header(vec!["Name"]);
+            table.load_preset(comfy_table::presets::ASCII_BORDERS_ONLY_CONDENSED);
+
+            for id in removed {
+                table.add_row(vec![id.clone()]);
+            }
+
+            println!();
+            println!("{table}");
+            println!();
+        }
 
         if !errors.is_empty() {
             // Thanks English
@@ -440,6 +479,7 @@ fn elements_at<T>(source: Vec<T>, indexes: Vec<usize>) -> Vec<T> {
 
 struct UpgradeSummary {
     upgraded: Vec<Template>,
+    removed: Vec<String>,
     errored_repos: Vec<(String, String)>,
 }
 
@@ -447,6 +487,7 @@ impl UpgradeSummary {
     fn new() -> Self {
         Self {
             upgraded: vec![],
+            removed: vec![],
             errored_repos: vec![],
         }
     }
@@ -457,7 +498,10 @@ impl UpgradeSummary {
         installation_results: anyhow::Result<InstallationResults>,
     ) {
         match installation_results {
-            Ok(list) => self.upgraded.extend(list.installed),
+            Ok(list) => {
+                self.upgraded.extend(list.installed);
+                self.removed.extend(list.removed);
+            }
             Err(e) => self.errored_repos.push((url.to_owned(), e.to_string())),
         }
     }
@@ -611,6 +655,9 @@ fn skipped_reason_text(reason: &SkippedReason) -> String {
     match reason {
         SkippedReason::AlreadyExists => "Already exists".to_owned(),
         SkippedReason::InvalidManifest(msg) => format!("Template load error: {msg}"),
+        SkippedReason::CouldNotRemove => {
+            "No longer exists in source, but could not uninstall".to_owned()
+        }
     }
 }
 


### PR DESCRIPTION
~We haven't run into this situation yet as far as I know.  But...~ Uh, Ivan. We totally run into it with the old `http-rust-wasip3-unstable` template!

~(WIP.)~

I tested this by installing the 3.6 templates, then installing the main templates, and verifying that `http-rust-wasip3-unstable` was reported as removed (and no longer appeared in `spin templates list`). Then went back to 3.6 and `http-rust-p2` was correctly removed (and p3-unstable correctly reinstated).  Then did `spin templates upgrade` and verified again.

However, this is all "works on my machine."  Now, the feature applies only to remote (git) template stores (we don't really have origin tracking / upgrading for local directories), And we don't want to have the templates unit tests reaching out to GitHub.  So unit testing is likely ruled out.  I am not sure whether it is worth writing it as an integration test?
