### PR TITLE
outbound-networking: Turn `use_webpki_roots` back on by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8867,7 +8867,7 @@ dependencies = [
  "tracing",
  "url",
  "wasmtime-wasi",
- "webpki-roots",
+ "webpki-root-certs",
 ]
 
 [[package]]
@@ -11996,9 +11996,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -22,7 +22,7 @@ spin-outbound-networking-config = { path = "../outbound-networking-config" }
 spin-serde = { path = "../serde" }
 tracing = { workspace = true }
 url = { workspace = true }
-webpki-roots = "0.26"
+webpki-root-certs = "1.0.7"
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }

--- a/crates/factor-outbound-networking/src/runtime_config.rs
+++ b/crates/factor-outbound-networking/src/runtime_config.rs
@@ -19,17 +19,31 @@ pub struct RuntimeConfig {
 pub struct ClientTlsRuntimeConfig {
     /// The component(s) this configuration applies to.
     pub components: Vec<String>,
+
     /// The host(s) this configuration applies to.
     pub hosts: Vec<String>,
-    /// A set of CA certs that should be considered valid roots.
-    pub root_certificates: Vec<CertificateDer<'static>>,
-    /// If true, the operating system's certificate store will be used for
-    /// root certificate verification via `rustls-platform-verifier`.
+
+    /// If `true`, the operating system's certificate store will be used for
+    /// root certificate verification
+    /// [`rustls-platform-verifier`](rustls_platform_verifier).
+    ///
+    /// By default this is `true`.
     pub use_platform_roots: bool,
-    /// If true, the "standard" CA certs defined by `webpki-roots` crate will be
-    /// considered valid roots in addition to `root_certificates`.
-    /// Only used when `use_platform_roots` is false.
+
+    /// If `true`, the "standard" CA certs in the
+    /// [`webpki-root-certs`](webpki_root_certs) crate will be considered valid
+    /// roots.
+    ///
+    /// By default this is `true`.
     pub use_webpki_roots: bool,
+
+    /// A set of CA certs that should be considered valid roots.
+    ///
+    /// These will be used _in addition_ to roots enabled by
+    /// [`use_platform_roots`](Self::use_platform_roots) and
+    /// [`use_webpki_roots`](Self::use_webpki_roots).
+    pub root_certificates: Vec<CertificateDer<'static>>,
+
     /// A certificate and private key to be used as the client certificate for
     /// "mutual TLS" (mTLS).
     pub client_cert: Option<ClientCertRuntimeConfig>,
@@ -41,9 +55,8 @@ impl Default for ClientTlsRuntimeConfig {
             components: vec![],
             hosts: vec![],
             root_certificates: vec![],
-            // Use platform roots by default
             use_platform_roots: true,
-            use_webpki_roots: false,
+            use_webpki_roots: true,
             client_cert: None,
         }
     }

--- a/crates/factor-outbound-networking/src/tls.rs
+++ b/crates/factor-outbound-networking/src/tls.rs
@@ -1,7 +1,6 @@
 use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 use anyhow::{Context, ensure};
-use rustls::client::danger::ServerCertVerifier;
 
 use crate::runtime_config::{ClientCertRuntimeConfig, ClientTlsRuntimeConfig};
 
@@ -38,9 +37,9 @@ impl TlsClientConfigs {
                 "client TLS 'hosts' list may not be empty"
             );
             let tls_client_config = TlsClientConfig::new(
-                root_certificates,
-                use_webpki_roots,
                 use_platform_roots,
+                use_webpki_roots,
+                root_certificates,
                 client_cert,
             )
             .context("error building TLS client config")?;
@@ -104,46 +103,37 @@ pub struct TlsClientConfig(Arc<rustls::ClientConfig>);
 
 impl TlsClientConfig {
     fn new(
-        root_certificates: Vec<rustls_pki_types::CertificateDer<'static>>,
-        use_webpki_roots: bool,
         use_platform_roots: bool,
+        use_webpki_roots: bool,
+        root_certificates: Vec<rustls_pki_types::CertificateDer<'static>>,
         client_cert: Option<ClientCertRuntimeConfig>,
     ) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            use_platform_roots || use_webpki_roots || !root_certificates.is_empty(),
+            "at least one of 'use_platform_roots', 'use_webpki_roots', or 'root_certificates' must be set"
+        );
+
+        let mut extra_roots: Box<dyn Iterator<Item = _>> = Box::new(root_certificates.into_iter());
+        if use_webpki_roots {
+            extra_roots = Box::new(
+                extra_roots.chain(webpki_root_certs::TLS_SERVER_ROOT_CERTS.iter().cloned()),
+            );
+        }
+
+        let builder = rustls::ClientConfig::builder();
         let builder = if use_platform_roots {
-            let crypto_provider = rustls::crypto::CryptoProvider::get_default()
-                .cloned()
-                .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
-
-            let verifier: Arc<dyn ServerCertVerifier> = if root_certificates.is_empty() {
-                Arc::new(
-                    rustls_platform_verifier::Verifier::new(crypto_provider.clone())
-                        .context("failed to initialize platform certificate verifier")?,
-                )
-            } else {
-                Arc::new(
-                    rustls_platform_verifier::Verifier::new_with_extra_roots(
-                        root_certificates,
-                        crypto_provider.clone(),
-                    )
-                    .context(
-                        "failed to initialize platform certificate verifier with extra roots",
-                    )?,
-                )
-            };
-
-            rustls::ClientConfig::builder_with_provider(crypto_provider)
-                .with_safe_default_protocol_versions()?
+            let verifier = rustls_platform_verifier::Verifier::new_with_extra_roots(
+                extra_roots,
+                builder.crypto_provider().clone(),
+            )
+            .context("failed to initialize platform certificate verifier")?;
+            builder
                 .dangerous()
-                .with_custom_certificate_verifier(verifier)
+                .with_custom_certificate_verifier(Arc::new(verifier))
         } else {
             let mut root_store = rustls::RootCertStore::empty();
-            if use_webpki_roots {
-                root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-            }
-            for cert in root_certificates {
-                root_store.add(cert)?;
-            }
-            rustls::ClientConfig::builder().with_root_certificates(root_store)
+            extra_roots.try_for_each(|cert| root_store.add(cert))?;
+            builder.with_root_certificates(root_store)
         };
 
         let client_config = if let Some(ClientCertRuntimeConfig {
@@ -174,7 +164,7 @@ impl Deref for TlsClientConfig {
 
 impl Default for TlsClientConfig {
     fn default() -> Self {
-        Self::new(vec![], false, true, None).expect("default client config should be valid")
+        Self::new(true, false, vec![], None).expect("default client config should be valid")
     }
 }
 
@@ -214,7 +204,7 @@ mod tests {
             hosts: vec!["test-host".into()],
             root_certificates: vec![],
             use_platform_roots: false,
-            use_webpki_roots: false,
+            use_webpki_roots: true,
             client_cert: None,
         }])?;
         let config = configs.get_tls_client_config("test-component", "test-host");


### PR DESCRIPTION
https://github.com/spinframework/spin/pull/3426 added support for `rustls-platform-verifier` as `use_platform_roots` and enabled it by default, but it also disabled `use_webpki_roots` by default causing a regression in `containerd-shim-spin` (and potentially other consumers).

- Changes the default to enable both `use_platform_roots` _and_ `use_webpki_roots`.
- Switch from `webpki-roots` to `webpki-root-certs`, necessary to make enabling both options work correctly.
- Simplify some logic - enabled by the crate change above.
- Improve `ClientTlsRuntimeConfig` doc comments.