### PR TITLE
open issues in js and python sdk repos to tag templates on new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,51 @@ jobs:
           event-type: spin-release
           client-payload: '{"version": "${{ github.ref_name }}"}'
 
+  notify-template-repos:
+    name: Open issues in template repos for new release
+    needs: create-gh-release
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'spinframework' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Check if this is at least a minor release
+        id: check-minor
+        shell: bash
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(.*)$ ]]; then
+            PATCH="${BASH_REMATCH[3]}"
+            PRE="${BASH_REMATCH[4]}"
+            # Only notify for minor+ releases (patch == 0 and no pre-release suffix)
+            if [[ "$PATCH" == "0" && -z "$PRE" ]]; then
+              echo "is_minor=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "is_minor=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "is_minor=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open issues in template repos
+        if: steps.check-minor.outputs.is_minor == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DEST_REPO_ACCESS_TOKEN }}
+          script: |
+            const repos = [
+              'spinframework/spin-js-sdk',
+              'spinframework/spin-python-sdk',
+            ];
+            const version = '${{ github.ref_name }}';
+            for (const fullRepo of repos) {
+              const [owner, repo] = fullRepo.split('/');
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title: `Tag templates for Spin ${version} release`,
+                body: `Spin [${version}](https://github.com/spinframework/spin/releases/tag/${version}) has been released.\n\nPlease tag compatible templates for this release.`,
+              });
+            }
+
   docker:
     runs-on: "ubuntu-22.04"
     needs: [build-and-sign, build-spin-static]


### PR DESCRIPTION
This PR adds a job to release CI that opens issues in the Python and JS SDK repos to remind us to tag templates whenever there is a release of Spin. We have run into some issues with the 2 repos where the templates have not been tagged for the latest release and which leads to the templating subsystem pulling from `main` which may be in a non working state.

This is an attempt to at least connect the release flow to the SDK repos but I am definitely open to better alternative ideas.