### PR TITLE
Remove obsolete licensing notice

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,3 +1,0 @@
-This project includes source code from third parties.
-
-- [clap-markdown](https://github.com/ConnorGray/clap-markdown). [View licences](/src/clap_markdown/LICENSE-APACHE).


### PR DESCRIPTION
The Clap 4 update removed the forked clap-markdown code: this notice is therefore no longer necessary or correct.
