### PR TITLE
Asyncify MySQL interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8877,6 +8877,7 @@ dependencies = [
  "spin-factors-test",
  "spin-resource-table",
  "spin-telemetry",
+ "spin-wasi-async",
  "spin-world",
  "tokio",
  "tracing",

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -22,6 +22,7 @@ spin-factors = { path = "../factors" }
 spin-resource-table = { path = "../table" }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
+spin-wasi-async = { path = "../wasi-async" }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing = { workspace = true }
 url = { workspace = true }

--- a/crates/factor-outbound-mysql/src/client.rs
+++ b/crates/factor-outbound-mysql/src/client.rs
@@ -1,15 +1,17 @@
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use futures::stream::TryStreamExt as _;
+use futures::{future::FutureExt as _, stream::TryStreamExt as _};
 use mysql_async::consts::ColumnType;
 use mysql_async::prelude::{FromValue, Queryable as _};
 use mysql_async::{Conn as MysqlClient, Opts, OptsBuilder, SslOpts, from_value_opt};
 use spin_core::async_trait;
+use spin_world::spin::mysql::mysql as v3;
 use spin_world::v2::mysql::{self as v2};
 use spin_world::v2::rdbms_types::{
     self as v2_types, Column, DbDataType, DbValue, ParameterValue, RowSet,
 };
+use tokio::sync::{Mutex, mpsc, oneshot};
 use url::Url;
 
 #[async_trait]
@@ -30,6 +32,20 @@ pub trait Client: Send + Sync + 'static {
         params: Vec<ParameterValue>,
         max_result_bytes: usize,
     ) -> Result<RowSet, v2::Error>;
+
+    async fn query_async(
+        client: Arc<Mutex<Self>>,
+        statement: String,
+        params: Vec<v3::ParameterValue>,
+        max_result_bytes: usize,
+    ) -> Result<
+        (
+            Vec<v3::Column>,
+            mpsc::Receiver<v3::Row>,
+            oneshot::Receiver<Result<(), v3::Error>>,
+        ),
+        v3::Error,
+    >;
 }
 
 #[async_trait]
@@ -100,6 +116,93 @@ impl Client for MysqlClient {
         }
 
         Ok(v2_types::RowSet { columns, rows })
+    }
+
+    async fn query_async(
+        client: Arc<Mutex<Self>>,
+        statement: String,
+        params: Vec<v3::ParameterValue>,
+        max_result_bytes: usize,
+    ) -> Result<
+        (
+            Vec<v3::Column>,
+            mpsc::Receiver<v3::Row>,
+            oneshot::Receiver<Result<(), v3::Error>>,
+        ),
+        v3::Error,
+    > {
+        let db_params = params
+            .into_iter()
+            .map(|v| to_sql_parameter(v2_types::ParameterValue::from(v)))
+            .collect::<Vec<_>>();
+        let parameters = mysql_async::Params::Positional(db_params);
+
+        let (rows_tx, rows_rx) = mpsc::channel(4);
+        let (err_tx, err_rx) = oneshot::channel();
+        let (columns_tx, columns_rx) = oneshot::channel();
+
+        let mut byte_count = std::mem::size_of::<(
+            Vec<v3::Column>,
+            mpsc::Receiver<v3::Row>,
+            oneshot::Receiver<Result<(), v3::Error>>,
+        )>();
+
+        tokio::spawn(
+            async move {
+                let mut client = client.lock().await;
+
+                let mut query_result = client
+                    .exec_iter(&statement, parameters)
+                    .await
+                    .map_err(|e| v3::Error::QueryFailed(format!("{e:?}")))?;
+
+                let columns = convert_columns(query_result.columns());
+
+                _ = columns_tx.send(
+                    columns
+                        .iter()
+                        .map(|v| v3::Column::from(v.clone()))
+                        .collect(),
+                );
+
+                let mut query_result = query_result
+                    .stream()
+                    .await
+                    .map_err(|e| v3::Error::Other(e.to_string()))?
+                    .ok_or_else(|| v3::Error::Other("unable to stream query result".into()))?;
+
+                while let Some(row) = query_result
+                    .try_next()
+                    .await
+                    .map_err(|e| v3::Error::Other(e.to_string()))?
+                {
+                    let row = convert_row(row, &columns).map_err(v3::Error::from)?;
+
+                    byte_count += row.iter().map(|v| v.memory_size()).sum::<usize>();
+                    if byte_count > max_result_bytes {
+                        return Err(v3::Error::Other(format!(
+                            "query result exceeds limit of {max_result_bytes} bytes"
+                        )));
+                    }
+
+                    rows_tx
+                        .send(row.into_iter().map(v3::DbValue::from).collect())
+                        .await
+                        .map_err(|e| v3::Error::Other(format!("async error: {e}")))?;
+                }
+
+                Ok(())
+            }
+            .map(move |result| {
+                _ = err_tx.send(result);
+            }),
+        );
+
+        let columns = columns_rx
+            .await
+            .map_err(|e| v3::Error::Other(format!("async error: {e}")))?;
+
+        Ok((columns, rows_rx, err_rx))
     }
 }
 

--- a/crates/factor-outbound-mysql/src/host.rs
+++ b/crates/factor-outbound-mysql/src/host.rs
@@ -1,62 +1,27 @@
 use anyhow::Result;
-use spin_core::wasmtime::component::Resource;
+use spin_core::wasmtime::component::{Accessor, FutureReader, Resource, StreamReader};
 use spin_telemetry::traces::{self, Blame};
 use spin_world::MAX_HOST_BUFFERED_BYTES;
+use spin_world::spin::mysql::mysql as v3;
 use spin_world::v1::mysql as v1;
-use spin_world::v2::mysql::{self as v2, Connection};
+use spin_world::v2::mysql as v2;
 use spin_world::v2::rdbms_types as v2_types;
-use spin_world::v2::rdbms_types::ParameterValue;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 use tracing::field::Empty;
 use tracing::{Level, instrument};
 
-use crate::InstanceState;
 use crate::client::Client;
+use crate::{InstanceState, InstanceStateInner, MysqlFactorData};
 
-impl<C: Client> InstanceState<C> {
-    async fn open_connection(&mut self, address: &str) -> Result<Resource<Connection>, v2::Error> {
-        let client = C::build_client(address).await.map_err(|e| {
-            // The guest supplies the address and credentials; connection
-            // failures (wrong password, TLS error, unreachable host, etc.)
-            // are the guest's problem.
-            let err = v2::Error::ConnectionFailed(format!("{e:?}"));
-            traces::mark_as_error(&err, Some(Blame::Guest));
-            err
-        })?;
-        self.connections
-            .push(client)
-            .map_err(|_| {
-                // The guest exceeded the host-imposed connection limit.
-                let err = v2::Error::ConnectionFailed("too many connections".into());
-                traces::mark_as_error(&err, Some(Blame::Guest));
-                err
-            })
-            .map(Resource::new_own)
-    }
+impl<C: Client> InstanceStateInner<C> {
+    async fn open_connection(
+        &mut self,
+        address: &str,
+    ) -> Result<Resource<v2::Connection>, v2::Error> {
+        spin_factor_outbound_networking::record_address_fields(address);
 
-    async fn get_client(&mut self, connection: Resource<Connection>) -> Result<&mut C, v2::Error> {
-        self.connections.get_mut(connection.rep()).ok_or_else(|| {
-            // The connection table is managed entirely by the host, so a
-            // missing handle indicates a host-side bug, not a guest mistake.
-            let err = v2::Error::ConnectionFailed("no connection found".into());
-            traces::mark_as_error(&err, Some(Blame::Host));
-            err
-        })
-    }
-
-    async fn is_address_allowed(&self, address: &str) -> Result<bool> {
-        self.allowed_hosts.check_url(address, "mysql").await
-    }
-}
-
-impl<C: Client> v2::Host for InstanceState<C> {}
-
-impl<C: Client> v2::HostConnection for InstanceState<C> {
-    #[instrument(name = "spin_outbound_mysql.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
-    async fn open(&mut self, address: String) -> Result<Resource<Connection>, v2::Error> {
-        self.otel.reparent_tracing_span();
-        spin_factor_outbound_networking::record_address_fields(&address);
-
-        if !self.is_address_allowed(&address).await.map_err(|e| {
+        if !self.is_address_allowed(address).await.map_err(|e| {
             // The allow-list check infrastructure itself failed; that's a
             // host problem, not anything the guest did wrong.
             let err = v2::Error::Other(e.to_string());
@@ -69,19 +34,161 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
             traces::mark_as_error(&err, Some(Blame::Guest));
             return Err(err);
         }
-        self.open_connection(&address).await
+        let client = C::build_client(address).await.map_err(|e| {
+            // The guest supplies the address and credentials; connection
+            // failures (wrong password, TLS error, unreachable host, etc.)
+            // are the guest's problem.
+            let err = v2::Error::ConnectionFailed(format!("{e:?}"));
+            traces::mark_as_error(&err, Some(Blame::Guest));
+            err
+        })?;
+        self.connections
+            .push(Arc::new(Mutex::new(client)))
+            .map_err(|_| {
+                // The guest exceeded the host-imposed connection limit.
+                let err = v2::Error::ConnectionFailed("too many connections".into());
+                traces::mark_as_error(&err, Some(Blame::Guest));
+                err
+            })
+            .map(Resource::new_own)
+    }
+
+    fn get_client(
+        &mut self,
+        connection: Resource<v2::Connection>,
+    ) -> Result<Arc<Mutex<C>>, v2::Error> {
+        self.connections
+            .get(connection.rep())
+            .cloned()
+            .ok_or_else(|| {
+                // The connection table is managed entirely by the host, so a
+                // missing handle indicates a host-side bug, not a guest mistake.
+                let err = v2::Error::ConnectionFailed("no connection found".into());
+                traces::mark_as_error(&err, Some(Blame::Host));
+                err
+            })
+    }
+
+    async fn is_address_allowed(&self, address: &str) -> Result<bool> {
+        self.allowed_hosts.check_url(address, "mysql").await
+    }
+}
+
+impl<C: Client> v3::Host for InstanceState<C> {
+    fn convert_error(&mut self, error: v3::Error) -> Result<v3::Error> {
+        Ok(error)
+    }
+}
+
+impl<C: Client> v3::HostConnection for InstanceState<C> {
+    async fn drop(&mut self, connection: Resource<v3::Connection>) -> Result<()> {
+        let mut state = self.0.lock().await;
+        state.connections.remove(connection.rep());
+        Ok(())
+    }
+}
+
+type QueryTuple = (
+    Vec<v3::Column>,
+    StreamReader<v3::Row>,
+    FutureReader<Result<(), v3::Error>>,
+);
+
+impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
+    #[instrument(name = "spin_outbound_mysql.open", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    async fn open<T>(
+        accessor: &Accessor<T, Self>,
+        address: String,
+    ) -> Result<Resource<v3::Connection>, v3::Error> {
+        let state = accessor.with(|mut access| access.get().0.clone());
+        let mut state = state.lock().await;
+        state.otel.reparent_tracing_span();
+        Ok(state.open_connection(&address).await?)
+    }
+
+    #[instrument(name = "spin_outbound_mysql.execute", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    async fn execute<T>(
+        accessor: &Accessor<T, Self>,
+        connection: Resource<v3::Connection>,
+        statement: String,
+        params: Vec<v3::ParameterValue>,
+    ) -> Result<(), v3::Error> {
+        let state = accessor.with(|mut access| access.get().0.clone());
+        let client = {
+            let mut state = state.lock().await;
+            state.otel.reparent_tracing_span();
+            state.get_client(connection)?
+        };
+        client
+            .lock()
+            .await
+            .execute(statement, params.into_iter().map(Into::into).collect())
+            .await
+            .map_err(track_db_error_on_span)?;
+        Ok(())
+    }
+
+    #[instrument(name = "spin_outbound_mysql.query", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    async fn query<T>(
+        accessor: &Accessor<T, Self>,
+        connection: Resource<v3::Connection>,
+        statement: String,
+        params: Vec<v3::ParameterValue>,
+    ) -> Result<QueryTuple, v3::Error> {
+        let state = accessor.with(|mut access| access.get().0.clone());
+        let client = {
+            let mut state = state.lock().await;
+            state.otel.reparent_tracing_span();
+            state.get_client(connection)?
+        };
+
+        let (columns, stream, future) =
+            C::query_async(client, statement, params, MAX_HOST_BUFFERED_BYTES)
+                .await
+                .map_err(|v| v3::Error::from(track_db_error_on_span(v2::Error::from(v))))?;
+
+        let (stream, future) = accessor
+            .with(|mut access| {
+                anyhow::Ok((
+                    StreamReader::new(&mut access, spin_wasi_async::stream::producer(stream))?,
+                    FutureReader::new(&mut access, future)?,
+                ))
+            })
+            .map_err(|e| {
+                // Setting up the async stream/future channels is a host
+                // implementation detail; if it fails, that's a host bug.
+                let err = v3::Error::Other(e.to_string());
+                traces::mark_as_error(&err, Some(Blame::Host));
+                err
+            })?;
+
+        Ok((columns, stream, future))
+    }
+}
+
+impl<C: Client> v2::Host for InstanceState<C> {}
+
+impl<C: Client> v2::HostConnection for InstanceState<C> {
+    #[instrument(name = "spin_outbound_mysql.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    async fn open(&mut self, address: String) -> Result<Resource<v2::Connection>, v2::Error> {
+        let mut state = self.0.lock().await;
+        state.otel.reparent_tracing_span();
+        state.open_connection(&address).await
     }
 
     #[instrument(name = "spin_outbound_mysql.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
     async fn execute(
         &mut self,
-        connection: Resource<Connection>,
+        connection: Resource<v2::Connection>,
         statement: String,
-        params: Vec<ParameterValue>,
+        params: Vec<v2_types::ParameterValue>,
     ) -> Result<(), v2::Error> {
-        self.otel.reparent_tracing_span();
-        self.get_client(connection)
-            .await?
+        let mut state = self.0.lock().await;
+        state.otel.reparent_tracing_span();
+        state
+            .get_client(connection)?
+            .lock()
+            .await
             .execute(statement, params)
             .await
             .map_err(track_db_error_on_span)
@@ -90,20 +197,24 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
     #[instrument(name = "spin_outbound_mysql.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
     async fn query(
         &mut self,
-        connection: Resource<Connection>,
+        connection: Resource<v2::Connection>,
         statement: String,
-        params: Vec<ParameterValue>,
+        params: Vec<v2_types::ParameterValue>,
     ) -> Result<v2_types::RowSet, v2::Error> {
-        self.otel.reparent_tracing_span();
-        self.get_client(connection)
-            .await?
+        let mut state = self.0.lock().await;
+        state.otel.reparent_tracing_span();
+        state
+            .get_client(connection)?
+            .lock()
+            .await
             .query(statement, params, MAX_HOST_BUFFERED_BYTES)
             .await
             .map_err(track_db_error_on_span)
     }
 
-    async fn drop(&mut self, connection: Resource<Connection>) -> Result<()> {
-        self.connections.remove(connection.rep());
+    async fn drop(&mut self, connection: Resource<v2::Connection>) -> Result<()> {
+        let mut state = self.0.lock().await;
+        state.connections.remove(connection.rep());
         Ok(())
     }
 }
@@ -117,16 +228,10 @@ impl<C: Send> v2_types::Host for InstanceState<C> {
 /// Delegate a function call to the v2::HostConnection implementation
 macro_rules! delegate {
     ($self:ident.$name:ident($address:expr, $($arg:expr),*)) => {{
-        if !$self.is_address_allowed(&$address).await.map_err(|e| {
-            let err = v2::Error::Other(e.to_string());
-            traces::mark_as_error(&err, Some(Blame::Host));
-            err
-        })? {
-            let err = v2::Error::ConnectionFailed(format!("address {} is not permitted", $address));
-            traces::mark_as_error(&err, Some(Blame::Guest));
-            return Err(err.into());
-        }
-        let connection = $self.open_connection(&$address).await?;
+        let connection = {
+            let mut state = $self.0.lock().await;
+            state.open_connection(&$address).await?
+        };
         <Self as v2::HostConnection>::$name($self, connection, $($arg),*)
             .await
             .map_err(Into::into)

--- a/crates/factor-outbound-mysql/src/host.rs
+++ b/crates/factor-outbound-mysql/src/host.rs
@@ -15,10 +15,7 @@ use crate::client::Client;
 use crate::{InstanceState, InstanceStateInner, MysqlFactorData};
 
 impl<C: Client> InstanceStateInner<C> {
-    async fn open_connection(
-        &mut self,
-        address: &str,
-    ) -> Result<Resource<v2::Connection>, v2::Error> {
+    async fn open_connection(&mut self, address: &str) -> Result<u32, v2::Error> {
         spin_factor_outbound_networking::record_address_fields(address);
 
         if !self.is_address_allowed(address).await.map_err(|e| {
@@ -50,23 +47,16 @@ impl<C: Client> InstanceStateInner<C> {
                 traces::mark_as_error(&err, Some(Blame::Guest));
                 err
             })
-            .map(Resource::new_own)
     }
 
-    fn get_client(
-        &mut self,
-        connection: Resource<v2::Connection>,
-    ) -> Result<Arc<Mutex<C>>, v2::Error> {
-        self.connections
-            .get(connection.rep())
-            .cloned()
-            .ok_or_else(|| {
-                // The connection table is managed entirely by the host, so a
-                // missing handle indicates a host-side bug, not a guest mistake.
-                let err = v2::Error::ConnectionFailed("no connection found".into());
-                traces::mark_as_error(&err, Some(Blame::Host));
-                err
-            })
+    fn get_client(&mut self, connection: u32) -> Result<Arc<Mutex<C>>, v2::Error> {
+        self.connections.get(connection).cloned().ok_or_else(|| {
+            // The connection table is managed entirely by the host, so a
+            // missing handle indicates a host-side bug, not a guest mistake.
+            let err = v2::Error::ConnectionFailed("no connection found".into());
+            traces::mark_as_error(&err, Some(Blame::Host));
+            err
+        })
     }
 
     async fn is_address_allowed(&self, address: &str) -> Result<bool> {
@@ -103,7 +93,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
         let state = accessor.with(|mut access| access.get().0.clone());
         let mut state = state.lock().await;
         state.otel.reparent_tracing_span();
-        Ok(state.open_connection(&address).await?)
+        Ok(Resource::new_own(state.open_connection(&address).await?))
     }
 
     #[instrument(name = "spin_outbound_mysql.execute", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
@@ -117,7 +107,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
         let client = {
             let mut state = state.lock().await;
             state.otel.reparent_tracing_span();
-            state.get_client(connection)?
+            state.get_client(connection.rep())?
         };
         client
             .lock()
@@ -139,7 +129,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
         let client = {
             let mut state = state.lock().await;
             state.otel.reparent_tracing_span();
-            state.get_client(connection)?
+            state.get_client(connection.rep())?
         };
 
         let (columns, stream, future) =
@@ -173,7 +163,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
     async fn open(&mut self, address: String) -> Result<Resource<v2::Connection>, v2::Error> {
         let mut state = self.0.lock().await;
         state.otel.reparent_tracing_span();
-        state.open_connection(&address).await
+        state.open_connection(&address).await.map(Resource::new_own)
     }
 
     #[instrument(name = "spin_outbound_mysql.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
@@ -186,7 +176,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
         let mut state = self.0.lock().await;
         state.otel.reparent_tracing_span();
         state
-            .get_client(connection)?
+            .get_client(connection.rep())?
             .lock()
             .await
             .execute(statement, params)
@@ -204,7 +194,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
         let mut state = self.0.lock().await;
         state.otel.reparent_tracing_span();
         state
-            .get_client(connection)?
+            .get_client(connection.rep())?
             .lock()
             .await
             .query(statement, params, MAX_HOST_BUFFERED_BYTES)
@@ -230,7 +220,7 @@ macro_rules! delegate {
     ($self:ident.$name:ident($address:expr, $($arg:expr),*)) => {{
         let connection = {
             let mut state = $self.0.lock().await;
-            state.open_connection(&$address).await?
+            Resource::new_own(state.open_connection(&$address).await?)
         };
         <Self as v2::HostConnection>::$name($self, connection, $($arg),*)
             .await

--- a/crates/factor-outbound-mysql/src/lib.rs
+++ b/crates/factor-outbound-mysql/src/lib.rs
@@ -8,8 +8,11 @@ use spin_factor_outbound_networking::{
     OutboundNetworkingFactor, config::allowed_hosts::OutboundAllowedHosts,
 };
 use spin_factors::{Factor, FactorData, InitContext, RuntimeFactors, SelfInstanceBuilder};
+use spin_world::spin::mysql::mysql as v3;
 use spin_world::v1::mysql as v1;
-use spin_world::v2::mysql::{self as v2};
+use spin_world::v2::mysql as v2;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 pub struct OutboundMysqlFactor<C = MysqlClient> {
     _phantom: std::marker::PhantomData<C>,
@@ -23,6 +26,7 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundMysqlFactor<C> {
     fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
         ctx.link_bindings(v1::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(v2::add_to_linker::<_, FactorData<Self>>)?;
+        ctx.link_bindings(v3::add_to_linker::<_, MysqlFactorData<C>>)?;
         Ok(())
     }
 
@@ -42,11 +46,11 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundMysqlFactor<C> {
             .allowed_hosts();
         let otel = OtelFactorState::from_prepare_context(&mut ctx)?;
 
-        Ok(InstanceState {
+        Ok(InstanceState(Arc::new(Mutex::new(InstanceStateInner {
             allowed_hosts,
             connections: Default::default(),
             otel,
-        })
+        }))))
     }
 }
 
@@ -64,10 +68,22 @@ impl<C> OutboundMysqlFactor<C> {
     }
 }
 
-pub struct InstanceState<C> {
+pub struct InstanceStateInner<C> {
     allowed_hosts: OutboundAllowedHosts,
-    connections: spin_resource_table::Table<C>,
+    connections: spin_resource_table::Table<Arc<Mutex<C>>>,
     otel: OtelFactorState,
 }
 
+pub struct InstanceState<C>(Arc<Mutex<InstanceStateInner<C>>>);
+
 impl<C: Send + 'static> SelfInstanceBuilder for InstanceState<C> {}
+
+pub struct MysqlFactorData<C: Client>(OutboundMysqlFactor<C>);
+
+impl<C: Client> spin_core::wasmtime::component::HasData for MysqlFactorData<C> {
+    type Data<'a> = &'a mut InstanceState<C>;
+}
+
+impl<C: Client> spin_core::wasmtime::component::HasData for InstanceState<C> {
+    type Data<'a> = &'a mut InstanceState<C>;
+}

--- a/crates/factor-outbound-mysql/tests/factor_test.rs
+++ b/crates/factor-outbound-mysql/tests/factor_test.rs
@@ -6,9 +6,12 @@ use spin_factor_variables::VariablesFactor;
 use spin_factors::{RuntimeFactors, anyhow};
 use spin_factors_test::{TestEnvironment, toml};
 use spin_world::async_trait;
+use spin_world::spin::mysql::mysql as v3;
 use spin_world::v2::mysql::HostConnection;
 use spin_world::v2::mysql::{self as v2};
 use spin_world::v2::rdbms_types::{ParameterValue, RowSet};
+use std::sync::Arc;
+use tokio::sync::{Mutex, mpsc, oneshot};
 
 #[derive(RuntimeFactors)]
 struct TestFactors {
@@ -132,5 +135,24 @@ impl Client for MockClient {
             columns: vec![],
             rows: vec![],
         })
+    }
+
+    async fn query_async(
+        _client: Arc<Mutex<Self>>,
+        _statement: String,
+        _params: Vec<v3::ParameterValue>,
+        _max_result_bytes: usize,
+    ) -> Result<
+        (
+            Vec<v3::Column>,
+            mpsc::Receiver<v3::Row>,
+            oneshot::Receiver<Result<(), v3::Error>>,
+        ),
+        v3::Error,
+    > {
+        let (_, rows_rx) = mpsc::channel(4);
+        let (err_tx, err_rx) = oneshot::channel();
+        _ = err_tx.send(Ok(()));
+        Ok((Vec::new(), rows_rx, err_rx))
     }
 }

--- a/crates/world/src/conversions.rs
+++ b/crates/world/src/conversions.rs
@@ -2,8 +2,10 @@ use super::*;
 
 mod rdbms_types {
     use super::*;
+    use spin::mysql::mysql as mysql3;
     use spin::postgres3_0_0::postgres as pg3;
     use spin::postgres4_2_0::postgres as pg4;
+    use v2::mysql as mysql2;
 
     impl From<v2::rdbms_types::Column> for v1::rdbms_types::Column {
         fn from(value: v2::rdbms_types::Column) -> Self {
@@ -407,6 +409,103 @@ mod rdbms_types {
                 pg4::Error::QueryFailed(e) => pg3::Error::QueryFailed(pg_error_text(e)),
                 pg4::Error::ValueConversionFailed(e) => pg3::Error::ValueConversionFailed(e),
                 pg4::Error::Other(e) => pg3::Error::Other(e),
+            }
+        }
+    }
+
+    impl From<v2::rdbms_types::Column> for mysql3::Column {
+        fn from(column: v2::rdbms_types::Column) -> Self {
+            Self {
+                name: column.name,
+                data_type: column.data_type.into(),
+            }
+        }
+    }
+
+    impl From<v2::rdbms_types::DbDataType> for mysql3::DbDataType {
+        fn from(ty: v2::rdbms_types::DbDataType) -> Self {
+            match ty {
+                v2::rdbms_types::DbDataType::Boolean => Self::Boolean,
+                v2::rdbms_types::DbDataType::Int8 => Self::Int8,
+                v2::rdbms_types::DbDataType::Int16 => Self::Int16,
+                v2::rdbms_types::DbDataType::Int32 => Self::Int32,
+                v2::rdbms_types::DbDataType::Int64 => Self::Int64,
+                v2::rdbms_types::DbDataType::Uint8 => Self::Uint8,
+                v2::rdbms_types::DbDataType::Uint16 => Self::Uint16,
+                v2::rdbms_types::DbDataType::Uint32 => Self::Uint32,
+                v2::rdbms_types::DbDataType::Uint64 => Self::Uint64,
+                v2::rdbms_types::DbDataType::Floating32 => Self::Floating32,
+                v2::rdbms_types::DbDataType::Floating64 => Self::Floating64,
+                v2::rdbms_types::DbDataType::Str => Self::Str,
+                v2::rdbms_types::DbDataType::Binary => Self::Binary,
+                v2::rdbms_types::DbDataType::Other => Self::Other,
+            }
+        }
+    }
+
+    impl From<v2::rdbms_types::DbValue> for mysql3::DbValue {
+        fn from(ty: v2::rdbms_types::DbValue) -> Self {
+            match ty {
+                v2::rdbms_types::DbValue::Boolean(v) => Self::Boolean(v),
+                v2::rdbms_types::DbValue::Int8(v) => Self::Int8(v),
+                v2::rdbms_types::DbValue::Int16(v) => Self::Int16(v),
+                v2::rdbms_types::DbValue::Int32(v) => Self::Int32(v),
+                v2::rdbms_types::DbValue::Int64(v) => Self::Int64(v),
+                v2::rdbms_types::DbValue::Uint8(v) => Self::Uint8(v),
+                v2::rdbms_types::DbValue::Uint16(v) => Self::Uint16(v),
+                v2::rdbms_types::DbValue::Uint32(v) => Self::Uint32(v),
+                v2::rdbms_types::DbValue::Uint64(v) => Self::Uint64(v),
+                v2::rdbms_types::DbValue::Floating32(v) => Self::Floating32(v),
+                v2::rdbms_types::DbValue::Floating64(v) => Self::Floating64(v),
+                v2::rdbms_types::DbValue::Str(v) => Self::Str(v),
+                v2::rdbms_types::DbValue::Binary(v) => Self::Binary(v),
+                v2::rdbms_types::DbValue::DbNull => Self::DbNull,
+                v2::rdbms_types::DbValue::Unsupported => Self::Unsupported,
+            }
+        }
+    }
+
+    impl From<mysql2::Error> for mysql3::Error {
+        fn from(error: mysql2::Error) -> Self {
+            match error {
+                mysql2::Error::ConnectionFailed(v) => Self::ConnectionFailed(v),
+                mysql2::Error::BadParameter(v) => Self::BadParameter(v),
+                mysql2::Error::QueryFailed(v) => Self::QueryFailed(v),
+                mysql2::Error::ValueConversionFailed(v) => Self::ValueConversionFailed(v),
+                mysql2::Error::Other(v) => Self::Other(v),
+            }
+        }
+    }
+
+    impl From<mysql3::Error> for mysql2::Error {
+        fn from(error: mysql3::Error) -> Self {
+            match error {
+                mysql3::Error::ConnectionFailed(v) => Self::ConnectionFailed(v),
+                mysql3::Error::BadParameter(v) => Self::BadParameter(v),
+                mysql3::Error::QueryFailed(v) => Self::QueryFailed(v),
+                mysql3::Error::ValueConversionFailed(v) => Self::ValueConversionFailed(v),
+                mysql3::Error::Other(v) => Self::Other(v),
+            }
+        }
+    }
+
+    impl From<mysql3::ParameterValue> for mysql2::ParameterValue {
+        fn from(value: mysql3::ParameterValue) -> Self {
+            match value {
+                mysql3::ParameterValue::Boolean(v) => Self::Boolean(v),
+                mysql3::ParameterValue::Int8(v) => Self::Int8(v),
+                mysql3::ParameterValue::Int16(v) => Self::Int16(v),
+                mysql3::ParameterValue::Int32(v) => Self::Int32(v),
+                mysql3::ParameterValue::Int64(v) => Self::Int64(v),
+                mysql3::ParameterValue::Uint8(v) => Self::Uint8(v),
+                mysql3::ParameterValue::Uint16(v) => Self::Uint16(v),
+                mysql3::ParameterValue::Uint32(v) => Self::Uint32(v),
+                mysql3::ParameterValue::Uint64(v) => Self::Uint64(v),
+                mysql3::ParameterValue::Floating32(v) => Self::Floating32(v),
+                mysql3::ParameterValue::Floating64(v) => Self::Floating64(v),
+                mysql3::ParameterValue::Str(v) => Self::Str(v),
+                mysql3::ParameterValue::Binary(v) => Self::Binary(v),
+                mysql3::ParameterValue::DbNull => Self::DbNull,
             }
         }
     }

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -37,6 +37,7 @@ wasmtime::component::bindgen!({
         "fermyon:spin/variables@2.0.0.error" => v2::variables::Error,
         "spin:key-value/key-value@3.0.0.error" => spin::key_value::key_value::Error,
         "spin:mqtt/mqtt@3.0.0.error" => spin::mqtt::mqtt::Error,
+        "spin:mysql/mysql@3.0.0.error" => spin::mysql::mysql::Error,
         "spin:postgres/postgres@3.0.0.error" => spin::postgres3_0_0::postgres::Error,
         "spin:postgres/postgres@4.2.0.error" => spin::postgres4_2_0::postgres::Error,
         "spin:redis/redis@3.0.0.error" => spin::redis::redis::Error,
@@ -45,6 +46,9 @@ wasmtime::component::bindgen!({
         "wasi:config/store@0.2.0-draft-2024-09-27.error" => wasi::config::store::Error,
         "wasi:keyvalue/store.error" => wasi::keyvalue::store::Error,
         "wasi:keyvalue/atomics.cas-error" => wasi::keyvalue::atomics::CasError,
+    },
+    with: {
+        "spin:mysql/mysql@3.0.0.connection": v2::mysql::Connection,
     },
     anyhow: true,
 });

--- a/crates/world/src/lib.rs
+++ b/crates/world/src/lib.rs
@@ -47,9 +47,6 @@ wasmtime::component::bindgen!({
         "wasi:keyvalue/store.error" => wasi::keyvalue::store::Error,
         "wasi:keyvalue/atomics.cas-error" => wasi::keyvalue::atomics::CasError,
     },
-    with: {
-        "spin:mysql/mysql@3.0.0.connection": v2::mysql::Connection,
-    },
     anyhow: true,
 });
 

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -5129,6 +5129,7 @@ dependencies = [
  "spin-factors",
  "spin-resource-table",
  "spin-telemetry",
+ "spin-wasi-async",
  "spin-world",
  "tokio",
  "tracing",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1556,6 +1556,39 @@ route = "/..."
         Ok(())
     }
 
+    #[cfg(feature = "extern-dependencies-tests")]
+    #[test]
+    fn test_mysql_v3() -> anyhow::Result<()> {
+        run_test(
+            "mysql-v3",
+            SpinConfig {
+                binary_path: spin_binary(),
+                spin_up_args: Vec::new(),
+                app_type: SpinAppType::Http,
+            },
+            ServicesConfig::new(["mysql"])?,
+            move |env| {
+                let spin = env.runtime_mut();
+                let request = Request::full(Method::Get, "/", &[], None::<Vec<u8>>);
+                assert_spin_request(
+                    spin,
+                    request,
+                    Response::full(
+                        200,
+                        [("content-type".to_owned(), "text/plain".to_owned())]
+                            .into_iter()
+                            .collect(),
+                        vec![b"success".to_vec()],
+                    ),
+                )?;
+
+                Ok(())
+            },
+        )?;
+
+        Ok(())
+    }
+
     #[test]
     fn test_spin_inbound_http() -> anyhow::Result<()> {
         run_test(

--- a/tests/test-components/components/Cargo.lock
+++ b/tests/test-components/components/Cargo.lock
@@ -783,6 +783,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mysql-v3"
+version = "0.1.0"
+dependencies = [
+ "helper",
+ "wit-bindgen 0.54.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/tests/test-components/components/mysql-v3/Cargo.toml
+++ b/tests/test-components/components/mysql-v3/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "mysql-v3"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+helper = { path = "../../helper" }
+wit-bindgen = { workspace = true, features = ['async-spawn'] }

--- a/tests/test-components/components/mysql-v3/src/lib.rs
+++ b/tests/test-components/components/mysql-v3/src/lib.rs
@@ -1,0 +1,200 @@
+#![deny(warnings)]
+
+wit_bindgen::generate!({
+    path: "../../../../wit",
+    world: "spin:up/http-trigger@4.0.0",
+    generate_all,
+});
+
+use {
+    crate::{
+        exports::wasi::http0_3_0_rc_2026_03_15::handler::Guest,
+        spin::mysql::mysql,
+        wasi::http0_3_0_rc_2026_03_15::types::{ErrorCode, Fields, Request, Response},
+    },
+    helper::{bail, ensure, ensure_matches, ensure_ok},
+    std::env,
+    wit_bindgen::rt::async_support,
+};
+
+struct Component;
+
+export!(Component);
+
+impl Guest for Component {
+    async fn handle(_request: Request) -> Result<Response, ErrorCode> {
+        Ok(match test().await {
+            Ok(()) => respond(200, "success".into()),
+            Err(message) => respond(500, message),
+        })
+    }
+}
+
+fn respond(status: u16, message: String) -> Response {
+    let (mut tx, rx) = wit_stream::new();
+    async_support::spawn(async move {
+        tx.write_all(message.into_bytes()).await;
+    });
+    let response = Response::new(
+        Fields::from_list(&[("content-type".into(), "text/plain".as_bytes().into())]).unwrap(),
+        Some(rx),
+        wit_future::new(|| Ok(None)).1,
+    )
+    .0;
+    response.set_status_code(status).unwrap();
+    response
+}
+
+async fn test() -> Result<(), String> {
+    ensure_matches!(
+        mysql::Connection::open("hello".into()).await,
+        Err(mysql::Error::ConnectionFailed(_))
+    );
+    ensure_matches!(
+        mysql::Connection::open("localhost:10000".into()).await,
+        Err(mysql::Error::ConnectionFailed(_))
+    );
+
+    let address = ensure_ok!(env::var("DB_URL"));
+    let conn = ensure_ok!(mysql::Connection::open(address).await);
+    let rows = ensure_ok!(test_numeric_types(&conn).await);
+    ensure!(rows.iter().all(|r| r.len() == 14));
+    ensure!(matches!(rows[0][13], mysql::DbValue::Int8(1)));
+
+    let rows = ensure_ok!(test_character_types(&conn).await);
+    ensure!(rows.iter().all(|r| r.len() == 6));
+    ensure!(matches!(rows[0][0], mysql::DbValue::Str(ref s) if s == "rvarchar"));
+
+    ensure_ok!(
+        conn.execute(
+            "CREATE TEMPORARY TABLE big_text (rkey int, rvalue mediumtext);".into(),
+            Vec::new()
+        )
+        .await
+    );
+
+    // Insert 256 copies of a 1MB string, which exceeds the 128MB query
+    // result limit we impose in `factor-outbound-mysql`:
+    let big_text = "y".repeat(1 << 20);
+    for i in 0..256 {
+        ensure_ok!(
+            conn.execute(
+                "INSERT INTO big_text(rkey, rvalue) VALUES(?, ?);".into(),
+                vec![
+                    mysql::ParameterValue::Int32(i),
+                    mysql::ParameterValue::Str(big_text.clone())
+                ]
+            )
+            .await
+        );
+    }
+
+    // This should exceed the 128MB query result limit:
+    let big = async {
+        let (_, stream, future) = conn
+            .query("SELECT * FROM big_text".into(), Vec::new())
+            .await?;
+        let rows = stream.collect().await;
+        future.await?;
+        Ok(rows)
+    };
+
+    match big.await {
+        Ok(_) => bail!("large select should not have succeeded",),
+        Err(mysql::Error::Other(s)) if s.contains("query result exceeds limit") => {}
+        Err(e) => bail!("unexpected error: {e}",),
+    }
+
+    Ok(())
+}
+
+async fn test_numeric_types(conn: &mysql::Connection) -> Result<Vec<mysql::Row>, mysql::Error> {
+    let create_table_sql = r#"
+        CREATE TEMPORARY TABLE test_numeric_types (
+            rtiny TINYINT NOT NULL,
+            rsmall SMALLINT NOT NULL,
+            rmedium MEDIUMINT NOT NULL,
+            rint INT NOT NULL,
+            rbig BIGINT NOT NULL,
+            rfloat FLOAT NOT NULL,
+            rdouble DOUBLE NOT NULL,
+            rutiny TINYINT UNSIGNED NOT NULL,
+            rusmall SMALLINT UNSIGNED NOT NULL,
+            rumedium MEDIUMINT UNSIGNED NOT NULL,
+            ruint INT UNSIGNED NOT NULL,
+            rubig BIGINT UNSIGNED NOT NULL,
+            rtinyint1 TINYINT(1) NOT NULL,
+            rbool BOOLEAN NOT NULL
+         );
+    "#;
+
+    conn.execute(create_table_sql.into(), Vec::new()).await?;
+
+    let insert_sql = r#"
+        INSERT INTO test_numeric_types
+            (rtiny, rsmall, rmedium, rint, rbig, rfloat, rdouble, rutiny, rusmall, rumedium, ruint, rubig, rtinyint1, rbool)
+        VALUES
+            (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1);
+    "#;
+
+    conn.execute(insert_sql.into(), Vec::new()).await?;
+
+    let sql = r#"
+        SELECT
+            rtiny,
+            rsmall,
+            rmedium,
+            rint,
+            rbig,
+            rfloat,
+            rdouble,
+            rutiny,
+            rusmall,
+            rumedium,
+            ruint,
+            rubig,
+            rtinyint1,
+            rbool
+        FROM test_numeric_types;
+    "#;
+
+    let (_, stream, future) = conn.query(sql.into(), Vec::new()).await?;
+    let rows = stream.collect().await;
+    future.await?;
+    Ok(rows)
+}
+
+async fn test_character_types(conn: &mysql::Connection) -> Result<Vec<mysql::Row>, mysql::Error> {
+    let create_table_sql = r#"
+        CREATE TEMPORARY TABLE test_character_types (
+            rvarchar varchar(40) NOT NULL,
+            rtext text NOT NULL,
+            rchar char(10) NOT NULL,
+            rbinary binary(10) NOT NULL,
+            rvarbinary varbinary(10) NOT NULL,
+            rblob BLOB NOT NULL
+         );
+    "#;
+
+    conn.execute(create_table_sql.into(), Vec::new()).await?;
+
+    let insert_sql = r#"
+        INSERT INTO test_character_types
+            (rvarchar, rtext, rchar, rbinary, rvarbinary, rblob)
+        VALUES
+            ('rvarchar', 'rtext', 'rchar', 'a', 'a', 'a');
+    "#;
+
+    conn.execute(insert_sql.into(), Vec::new()).await?;
+
+    let sql = r#"
+        SELECT
+            rvarchar, rtext, rchar, rbinary, rvarbinary, rblob
+        FROM test_character_types;
+    "#;
+
+    let (_, stream, future) = conn.query(sql.into(), Vec::new()).await?;
+    let rows = stream.collect().await;
+    future.await?;
+    Ok(rows)
+}

--- a/tests/test-components/components/outbound-mysql/src/lib.rs
+++ b/tests/test-components/components/outbound-mysql/src/lib.rs
@@ -31,7 +31,7 @@ impl Component {
         ));
 
         // Insert 256 copies of a 1MB string, which exceeds the 128MB query
-        // result limit we impose in `factor-outbound-pg`:
+        // result limit we impose in `factor-outbound-mysql`:
         let big_text = "y".repeat(1 << 20);
         for i in 0..256 {
             ensure_ok!(conn.execute(

--- a/tests/testcases/mysql-v3/spin.toml
+++ b/tests/testcases/mysql-v3/spin.toml
@@ -1,0 +1,19 @@
+spin_manifest_version = 2
+
+[application]
+authors = ["Spin Framework Contributors"]
+description = "An application that tests outbound MySQL support."
+name = "spin-mysql-v3"
+version = "1.0.0"
+
+[[trigger.http]]
+route = "/..."
+component = "mysql"
+
+[component.mysql]
+source = "%{source=mysql-v3}"
+allowed_outbound_hosts = ["mysql://localhost:%{port=3306}"]
+environment = { DB_URL = "mysql://spin:spin@localhost:%{port=3306}/spin_dev" }
+[component.mysql.build]
+command = "cargo build --target wasm32-wasip1 --release"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/wit/deps/spin-mysql@3.0.0.wit
+++ b/wit/deps/spin-mysql@3.0.0.wit
@@ -1,0 +1,88 @@
+package spin:mysql@3.0.0;
+
+interface mysql {
+  /// Errors related to interacting with a database.
+  variant error {
+      connection-failed(string),
+      bad-parameter(string),
+      query-failed(string),
+      value-conversion-failed(string),
+      other(string)
+  }
+
+  /// Data types for a database column
+  enum db-data-type {
+      boolean,
+      int8,
+      int16,
+      int32,
+      int64,
+      uint8,
+      uint16,
+      uint32,
+      uint64,
+      floating32,
+      floating64,
+      str,
+      binary,
+      other,
+  }
+
+  /// Database values
+  variant db-value {
+      boolean(bool),
+      int8(s8),
+      int16(s16),
+      int32(s32),
+      int64(s64),
+      uint8(u8),
+      uint16(u16),
+      uint32(u32),
+      uint64(u64),
+      floating32(f32),
+      floating64(f64),
+      str(string),
+      binary(list<u8>),
+      db-null,
+      unsupported,
+  }
+
+  /// Values used in parameterized queries
+  variant parameter-value {
+      boolean(bool),
+      int8(s8),
+      int16(s16),
+      int32(s32),
+      int64(s64),
+      uint8(u8),
+      uint16(u16),
+      uint32(u32),
+      uint64(u64),
+      floating32(f32),
+      floating64(f64),
+      str(string),
+      binary(list<u8>),
+      db-null,
+  }
+
+  /// A database column
+  record column {
+      name: string,
+      data-type: db-data-type,
+  }
+
+  /// A database row
+  type row = list<db-value>;
+
+  /// A connection to a MySQL database.
+  resource connection {
+    /// Open a connection to the MySQL instance at `address`.
+    open: static async func(address: string) -> result<connection, error>;
+
+    /// query the database: select
+    query: async func(statement: string, params: list<parameter-value>) -> result<tuple<list<column>, stream<row>, future<result<_, error>>>, error>;
+
+    /// execute command to the database: insert, update, delete
+    execute: async func(statement: string, params: list<parameter-value>) -> result<_, error>;
+  }
+}

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -24,6 +24,7 @@ world platform {
   include wasi:keyvalue/imports@0.2.0-draft2;
   import spin:key-value/key-value@3.0.0;
   import spin:mqtt/mqtt@3.0.0;
+  import spin:mysql/mysql@3.0.0;
   import spin:postgres/postgres@3.0.0;
   import spin:postgres/postgres@4.2.0;
   import spin:redis/redis@3.0.0;


### PR DESCRIPTION
This adds a new `spin:mysql/mysql@3.0.0` interface with async functions for opening, executing, and querying.

The implementation uses `Arc<Mutex<_>>` to control access to the host state and individual connections, meaning at most one `open` operation may proceed at a time, and each connection will accept at most one `execute` or `query` operation at a time, with any other operations queuing up behind that one.  In no case will the guest be blocked (assuming `mysql-async` is well-behaved), so it can do other things concurrently while it's waiting for DB I/O.