### PR TITLE
fix: support falling back to webpki roots in default TLS config

### DIFF
--- a/crates/factor-outbound-networking/src/tls.rs
+++ b/crates/factor-outbound-networking/src/tls.rs
@@ -164,7 +164,7 @@ impl Deref for TlsClientConfig {
 
 impl Default for TlsClientConfig {
     fn default() -> Self {
-        Self::new(true, false, vec![], None).expect("default client config should be valid")
+        Self::new(true, true, vec![], None).expect("default client config should be valid")
     }
 }
 


### PR DESCRIPTION
This PR https://github.com/spinframework/spin/pull/3491 was missing an update to the Default configuration for the `TlsClientConfig` to support falling back to webpki roots. Shim e2e tests (based on the commit from #3491) are still failing with:
```sh
$ k logs wasm-spin-5898cc8646-6t4kp

thread 'main' (1) panicked at /home/kagold/.cargo/git/checkouts/spin-6133b75e3590288b/d46b136/crates/factor-outbound-networking/src/tls.rs:167:46:
default client config should be valid: failed to initialize platform certificate verifier

Caused by:
    unexpected error: No CA certificates were loaded from the system
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```