### PR TITLE
outbound-mqtt: add runtime config for mqtt max payload size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8850,6 +8850,7 @@ version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
  "rumqttc",
+ "serde",
  "spin-core",
  "spin-factor-otel",
  "spin-factor-outbound-networking",

--- a/crates/factor-outbound-mqtt/Cargo.toml
+++ b/crates/factor-outbound-mqtt/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+serde = { workspace = true }
 # Upstream hasn't been updating dependencies: https://github.com/bytebeamio/rumqtt/issues/1046
 rumqttc = { git = "https://github.com/spinframework/rumqtt", rev = "65b7b39a70b12d1781acb61cc07f1f1b680e7643", default-features = false, features = ["use-rustls-no-provider", "url"] }
 spin-core = { path = "../core" }

--- a/crates/factor-outbound-mqtt/src/host.rs
+++ b/crates/factor-outbound-mqtt/src/host.rs
@@ -18,7 +18,7 @@ pub struct InstanceState {
     connections: spin_resource_table::Table<Arc<dyn MqttClient>>,
     create_client: Arc<dyn ClientCreator>,
     otel: OtelFactorState,
-    max_payload_size_bytes: usize,
+    max_payload_size_bytes: Option<usize>,
 }
 
 impl InstanceState {
@@ -26,7 +26,7 @@ impl InstanceState {
         allowed_hosts: OutboundAllowedHosts,
         create_client: Arc<dyn ClientCreator>,
         otel: OtelFactorState,
-        max_payload_size_bytes: usize,
+        max_payload_size_bytes: Option<usize>,
     ) -> Self {
         Self {
             allowed_hosts: AllowedHostChecker::new(allowed_hosts),
@@ -161,11 +161,13 @@ impl v3::HostConnectionWithStore for crate::MqttFactorData {
                 .map(|c| (c, host.max_payload_size_bytes))
         })?;
 
-        if payload.len() > max_payload_size_bytes {
+        if let Some(limit) = max_payload_size_bytes
+            && payload.len() > limit
+        {
             return Err(v3::Error::Other(format!(
                 "payload size {} exceeds the maximum allowed size of {} bytes",
                 payload.len(),
-                max_payload_size_bytes
+                limit
             )));
         }
 
@@ -227,11 +229,13 @@ impl v2::HostConnection for InstanceState {
     ) -> Result<(), v2::Error> {
         self.otel.reparent_tracing_span();
 
-        if payload.len() > self.max_payload_size_bytes {
+        if let Some(limit) = self.max_payload_size_bytes
+            && payload.len() > limit
+        {
             return Err(v2::Error::Other(format!(
                 "payload size {} exceeds the maximum allowed size of {} bytes",
                 payload.len(),
-                self.max_payload_size_bytes
+                limit
             )));
         }
 

--- a/crates/factor-outbound-mqtt/src/host.rs
+++ b/crates/factor-outbound-mqtt/src/host.rs
@@ -18,6 +18,7 @@ pub struct InstanceState {
     connections: spin_resource_table::Table<Arc<dyn MqttClient>>,
     create_client: Arc<dyn ClientCreator>,
     otel: OtelFactorState,
+    max_payload_size_bytes: usize,
 }
 
 impl InstanceState {
@@ -25,12 +26,14 @@ impl InstanceState {
         allowed_hosts: OutboundAllowedHosts,
         create_client: Arc<dyn ClientCreator>,
         otel: OtelFactorState,
+        max_payload_size_bytes: usize,
     ) -> Self {
         Self {
             allowed_hosts: AllowedHostChecker::new(allowed_hosts),
             create_client,
             connections: spin_resource_table::Table::new(1024),
             otel,
+            max_payload_size_bytes,
         }
     }
 }
@@ -151,11 +154,20 @@ impl v3::HostConnectionWithStore for crate::MqttFactorData {
         payload: v3::Payload,
         qos: v3::Qos,
     ) -> Result<(), v3::Error> {
-        let conn = accessor.with(|mut access| {
+        let (conn, max_payload_size_bytes) = accessor.with(|mut access| {
             let host = access.get();
             host.otel.reparent_tracing_span();
             host.get_conn_v3(connection)
+                .map(|c| (c, host.max_payload_size_bytes))
         })?;
+
+        if payload.len() > max_payload_size_bytes {
+            return Err(v3::Error::Other(format!(
+                "payload size {} exceeds the maximum allowed size of {} bytes",
+                payload.len(),
+                max_payload_size_bytes
+            )));
+        }
 
         conn.publish_bytes(topic, qos, payload).await?;
 
@@ -214,6 +226,14 @@ impl v2::HostConnection for InstanceState {
         qos: v2::Qos,
     ) -> Result<(), v2::Error> {
         self.otel.reparent_tracing_span();
+
+        if payload.len() > self.max_payload_size_bytes {
+            return Err(v2::Error::Other(format!(
+                "payload size {} exceeds the maximum allowed size of {} bytes",
+                payload.len(),
+                self.max_payload_size_bytes
+            )));
+        }
 
         let conn = self.get_conn(connection)?;
 

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -32,7 +32,7 @@ impl OutboundMqttFactor {
 }
 
 pub struct AppState {
-    max_payload_size_bytes: usize,
+    max_payload_size_bytes: Option<usize>,
 }
 
 impl Factor for OutboundMqttFactor {

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -1,5 +1,6 @@
 mod allowed_hosts;
 mod host;
+pub mod runtime_config;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -30,9 +31,13 @@ impl OutboundMqttFactor {
     }
 }
 
+pub struct AppState {
+    max_payload_size_bytes: usize,
+}
+
 impl Factor for OutboundMqttFactor {
-    type RuntimeConfig = ();
-    type AppState = ();
+    type RuntimeConfig = runtime_config::RuntimeConfig;
+    type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
     fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
@@ -43,9 +48,12 @@ impl Factor for OutboundMqttFactor {
 
     fn configure_app<T: RuntimeFactors>(
         &self,
-        _ctx: ConfigureAppContext<T, Self>,
+        mut ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
-        Ok(())
+        let config = ctx.take_runtime_config().unwrap_or_default();
+        Ok(AppState {
+            max_payload_size_bytes: config.max_payload_size_bytes,
+        })
     }
 
     fn prepare<T: RuntimeFactors>(
@@ -61,6 +69,7 @@ impl Factor for OutboundMqttFactor {
             allowed_hosts,
             self.create_client.clone(),
             otel,
+            ctx.app_state().max_payload_size_bytes,
         ))
     }
 }

--- a/crates/factor-outbound-mqtt/src/runtime_config.rs
+++ b/crates/factor-outbound-mqtt/src/runtime_config.rs
@@ -1,0 +1,21 @@
+pub mod spin;
+
+/// Default maximum MQTT payload size: 1 MiB.
+///
+/// MQTT allows up to 256 MiB
+pub const DEFAULT_MAX_PAYLOAD_SIZE_BYTES: usize = 1024 * 1024;
+
+/// Runtime configuration for outbound MQTT.
+#[derive(Debug)]
+pub struct RuntimeConfig {
+    /// Maximum allowed payload size in bytes for outbound MQTT publishes.
+    pub max_payload_size_bytes: usize,
+}
+
+impl Default for RuntimeConfig {
+    fn default() -> Self {
+        Self {
+            max_payload_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE_BYTES,
+        }
+    }
+}

--- a/crates/factor-outbound-mqtt/src/runtime_config.rs
+++ b/crates/factor-outbound-mqtt/src/runtime_config.rs
@@ -1,21 +1,12 @@
 pub mod spin;
 
-/// Default maximum MQTT payload size: 1 MiB.
-///
-/// MQTT allows up to 256 MiB
-pub const DEFAULT_MAX_PAYLOAD_SIZE_BYTES: usize = 1024 * 1024;
-
 /// Runtime configuration for outbound MQTT.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct RuntimeConfig {
     /// Maximum allowed payload size in bytes for outbound MQTT publishes.
-    pub max_payload_size_bytes: usize,
-}
-
-impl Default for RuntimeConfig {
-    fn default() -> Self {
-        Self {
-            max_payload_size_bytes: DEFAULT_MAX_PAYLOAD_SIZE_BYTES,
-        }
-    }
+    ///
+    /// When `None` (the default), no limit is enforced. Operators in multi-tenant deployments
+    /// should set this to prevent tenants from sending excessively large payloads.
+    /// Configure via `[outbound_mqtt] max_payload_size_bytes` in the runtime config TOML.
+    pub max_payload_size_bytes: Option<usize>,
 }

--- a/crates/factor-outbound-mqtt/src/runtime_config/spin.rs
+++ b/crates/factor-outbound-mqtt/src/runtime_config/spin.rs
@@ -1,0 +1,35 @@
+use anyhow::Context;
+use serde::Deserialize;
+use spin_factors::runtime_config::toml::GetTomlValue;
+
+/// Get the runtime configuration for outbound MQTT from a TOML table.
+///
+/// Expects the table to be in the format:
+/// ```toml
+/// [outbound_mqtt]
+/// max_payload_size_bytes = 65536  # optional, defaults to 1 MiB
+/// ```
+pub fn config_from_table(
+    table: &impl GetTomlValue,
+) -> anyhow::Result<Option<super::RuntimeConfig>> {
+    if let Some(outbound_mqtt) = table.get("outbound_mqtt") {
+        let toml = outbound_mqtt
+            .clone()
+            .try_into::<OutboundMqttToml>()
+            .context("failed to parse [outbound_mqtt] table")?;
+        Ok(Some(super::RuntimeConfig {
+            max_payload_size_bytes: toml
+                .max_payload_size_bytes
+                .unwrap_or(super::DEFAULT_MAX_PAYLOAD_SIZE_BYTES),
+        }))
+    } else {
+        Ok(None)
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OutboundMqttToml {
+    #[serde(default)]
+    max_payload_size_bytes: Option<usize>,
+}

--- a/crates/factor-outbound-mqtt/src/runtime_config/spin.rs
+++ b/crates/factor-outbound-mqtt/src/runtime_config/spin.rs
@@ -7,7 +7,7 @@ use spin_factors::runtime_config::toml::GetTomlValue;
 /// Expects the table to be in the format:
 /// ```toml
 /// [outbound_mqtt]
-/// max_payload_size_bytes = 65536  # optional, defaults to 1 MiB
+/// max_payload_size_bytes = 65536  # optional, no limit by default
 /// ```
 pub fn config_from_table(
     table: &impl GetTomlValue,
@@ -18,9 +18,7 @@ pub fn config_from_table(
             .try_into::<OutboundMqttToml>()
             .context("failed to parse [outbound_mqtt] table")?;
         Ok(Some(super::RuntimeConfig {
-            max_payload_size_bytes: toml
-                .max_payload_size_bytes
-                .unwrap_or(super::DEFAULT_MAX_PAYLOAD_SIZE_BYTES),
+            max_payload_size_bytes: toml.max_payload_size_bytes,
         }))
     } else {
         Ok(None)

--- a/crates/factor-outbound-mqtt/tests/factor_test.rs
+++ b/crates/factor-outbound-mqtt/tests/factor_test.rs
@@ -9,6 +9,7 @@ use spin_factor_variables::VariablesFactor;
 use spin_factors::{RuntimeFactors, anyhow};
 use spin_factors_test::{TestEnvironment, toml};
 use spin_world::spin::mqtt::mqtt::{Error, Qos};
+use spin_world::v2::mqtt as v2;
 
 pub struct MockMqttClient {}
 
@@ -61,7 +62,6 @@ fn test_env() -> TestEnvironment<TestFactors> {
 
 #[tokio::test]
 async fn disallowed_host_fails() -> anyhow::Result<()> {
-    use spin_world::v2::mqtt as v2;
     use v2::HostConnection;
 
     let env = TestEnvironment::new(factors()).extend_manifest(toml! {
@@ -89,7 +89,6 @@ async fn disallowed_host_fails() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn allowed_host_succeeds() -> anyhow::Result<()> {
-    use spin_world::v2::mqtt as v2;
     use v2::HostConnection;
 
     let mut state = test_env().build_instance_state().await?;
@@ -112,7 +111,6 @@ async fn allowed_host_succeeds() -> anyhow::Result<()> {
 
 #[tokio::test]
 async fn exercise_publish() -> anyhow::Result<()> {
-    use spin_world::v2::mqtt as v2;
     use v2::HostConnection;
 
     let mut state = test_env().build_instance_state().await?;
@@ -136,6 +134,113 @@ async fn exercise_publish() -> anyhow::Result<()> {
             v2::Qos::ExactlyOnce,
         )
         .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn oversized_payload_rejected() -> anyhow::Result<()> {
+    use v2::HostConnection;
+
+    const LIMIT: usize = 10;
+
+    let env = test_env().runtime_config(TestFactorsRuntimeConfig {
+        mqtt: Some(spin_factor_outbound_mqtt::runtime_config::RuntimeConfig {
+            max_payload_size_bytes: LIMIT,
+        }),
+        ..Default::default()
+    })?;
+
+    let mut state = env.build_instance_state().await?;
+
+    let conn = state
+        .mqtt
+        .open(
+            "mqtt://mqtt.test:1883".to_string(),
+            "username".to_string(),
+            "password".to_string(),
+            1,
+        )
+        .await?;
+
+    let oversized = vec![0u8; LIMIT + 1];
+    let err = state
+        .mqtt
+        .publish(conn, "topic".to_string(), oversized, v2::Qos::AtMostOnce)
+        .await;
+    assert!(
+        matches!(err, Err(v2::Error::Other(_))),
+        "expected Other error for oversized payload, got {err:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn payload_at_limit_succeeds() -> anyhow::Result<()> {
+    use v2::HostConnection;
+
+    const LIMIT: usize = 10;
+
+    let env = test_env().runtime_config(TestFactorsRuntimeConfig {
+        mqtt: Some(spin_factor_outbound_mqtt::runtime_config::RuntimeConfig {
+            max_payload_size_bytes: LIMIT,
+        }),
+        ..Default::default()
+    })?;
+
+    let mut state = env.build_instance_state().await?;
+
+    let conn = state
+        .mqtt
+        .open(
+            "mqtt://mqtt.test:1883".to_string(),
+            "username".to_string(),
+            "password".to_string(),
+            1,
+        )
+        .await?;
+
+    let exactly_limit = vec![0u8; LIMIT];
+    state
+        .mqtt
+        .publish(
+            conn,
+            "topic".to_string(),
+            exactly_limit,
+            v2::Qos::AtMostOnce,
+        )
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn payload_over_default_limit_fails() -> anyhow::Result<()> {
+    use v2::HostConnection;
+
+    let mut state = test_env().build_instance_state().await?;
+
+    let conn = state
+        .mqtt
+        .open(
+            "mqtt://mqtt.test:1883".to_string(),
+            "username".to_string(),
+            "password".to_string(),
+            1,
+        )
+        .await?;
+
+    let oversized =
+        vec![0u8; spin_factor_outbound_mqtt::runtime_config::DEFAULT_MAX_PAYLOAD_SIZE_BYTES + 1];
+    let err = state
+        .mqtt
+        .publish(conn, "topic".to_string(), oversized, v2::Qos::AtMostOnce)
+        .await;
+    assert!(
+        matches!(err, Err(v2::Error::Other(_))),
+        "expected Other error for oversized payload, got {err:?}"
+    );
 
     Ok(())
 }

--- a/crates/factor-outbound-mqtt/tests/factor_test.rs
+++ b/crates/factor-outbound-mqtt/tests/factor_test.rs
@@ -146,7 +146,7 @@ async fn oversized_payload_rejected() -> anyhow::Result<()> {
 
     let env = test_env().runtime_config(TestFactorsRuntimeConfig {
         mqtt: Some(spin_factor_outbound_mqtt::runtime_config::RuntimeConfig {
-            max_payload_size_bytes: LIMIT,
+            max_payload_size_bytes: Some(LIMIT),
         }),
         ..Default::default()
     })?;
@@ -184,7 +184,7 @@ async fn payload_at_limit_succeeds() -> anyhow::Result<()> {
 
     let env = test_env().runtime_config(TestFactorsRuntimeConfig {
         mqtt: Some(spin_factor_outbound_mqtt::runtime_config::RuntimeConfig {
-            max_payload_size_bytes: LIMIT,
+            max_payload_size_bytes: Some(LIMIT),
         }),
         ..Default::default()
     })?;
@@ -211,36 +211,6 @@ async fn payload_at_limit_succeeds() -> anyhow::Result<()> {
             v2::Qos::AtMostOnce,
         )
         .await?;
-
-    Ok(())
-}
-
-#[tokio::test]
-async fn payload_over_default_limit_fails() -> anyhow::Result<()> {
-    use v2::HostConnection;
-
-    let mut state = test_env().build_instance_state().await?;
-
-    let conn = state
-        .mqtt
-        .open(
-            "mqtt://mqtt.test:1883".to_string(),
-            "username".to_string(),
-            "password".to_string(),
-            1,
-        )
-        .await?;
-
-    let oversized =
-        vec![0u8; spin_factor_outbound_mqtt::runtime_config::DEFAULT_MAX_PAYLOAD_SIZE_BYTES + 1];
-    let err = state
-        .mqtt
-        .publish(conn, "topic".to_string(), oversized, v2::Qos::AtMostOnce)
-        .await;
-    assert!(
-        matches!(err, Err(v2::Error::Other(_))),
-        "expected Other error for oversized payload, got {err:?}"
-    );
 
     Ok(())
 }

--- a/crates/runtime-config/src/lib.rs
+++ b/crates/runtime-config/src/lib.rs
@@ -388,8 +388,10 @@ impl FactorRuntimeConfigSource<OutboundHttpFactor> for TomlRuntimeConfigSource<'
 }
 
 impl FactorRuntimeConfigSource<OutboundMqttFactor> for TomlRuntimeConfigSource<'_, '_> {
-    fn get_runtime_config(&mut self) -> anyhow::Result<Option<()>> {
-        Ok(None)
+    fn get_runtime_config(
+        &mut self,
+    ) -> anyhow::Result<Option<<OutboundMqttFactor as spin_factors::Factor>::RuntimeConfig>> {
+        spin_factor_outbound_mqtt::runtime_config::spin::config_from_table(&self.toml.table)
     }
 }
 


### PR DESCRIPTION
Sets a default max MQTT payload side for publish calls to 1MiB with the option to configure a max via runtime configuration.