### PR TITLE
Deprecate max_concurrent_requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8991,6 +8991,7 @@ dependencies = [
  "spin-factors-test",
  "spin-telemetry",
  "spin-world",
+ "terminal",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -22,6 +22,7 @@ spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
+terminal = { path = "../terminal" }
 tokio = { workspace = true, features = ["macros", "rt", "net"] }
 tokio-rustls = { workspace = true }
 tower-service = { workspace = true }

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -61,9 +61,7 @@ impl Factor for OutboundHttpFactor {
             connection_pooling_enabled: config.connection_pooling_enabled,
             concurrent_outbound_connections_semaphore: config
                 .max_concurrent_connections
-                // Permit count is the max concurrent connections + 1.
-                // i.e., 0 concurrent connections means 1 total connection.
-                .map(|n| Arc::new(Semaphore::new(n + 1))),
+                .map(|n| Arc::new(Semaphore::new(n))),
         })
     }
 

--- a/crates/factor-outbound-http/src/runtime_config/spin.rs
+++ b/crates/factor-outbound-http/src/runtime_config/spin.rs
@@ -7,16 +7,36 @@ use spin_factors::runtime_config::toml::GetTomlValue;
 /// ```toml
 /// [outbound_http]
 /// connection_pooling = true # optional, defaults to true
-/// max_concurrent_requests = 10 # optional, defaults to unlimited
+/// max_connections = 10      # optional, defaults to unlimited; 0 = no connections allowed
+/// # max_concurrent_requests is deprecated, use max_connections instead
 /// ```
 pub fn config_from_table(
     table: &impl GetTomlValue,
 ) -> anyhow::Result<Option<super::RuntimeConfig>> {
     if let Some(outbound_http) = table.get("outbound_http") {
-        let outbound_http_toml = outbound_http.clone().try_into::<OutboundHttpToml>()?;
+        let toml = outbound_http.clone().try_into::<OutboundHttpToml>()?;
+
+        let max_connections = match (toml.max_connections, toml.max_concurrent_requests) {
+            (Some(_), Some(_)) => anyhow::bail!(
+                "cannot set both `max_connections` and `max_concurrent_requests` in \
+                 `[outbound_http]`; use `max_connections` only"
+            ),
+            (Some(n), None) => Some(n),
+            (None, Some(n)) => {
+                terminal::warn!(
+                    "`max_concurrent_requests` in `[outbound_http]` is deprecated; \
+                     use `max_connections` instead (note: `max_connections = 0` blocks all \
+                     connections, whereas `max_concurrent_requests = 0` allowed 1 connection)"
+                );
+                // Preserve old semaphore semantics: n+1 permits so that 0 allowed 1 connection
+                Some(n + 1)
+            }
+            (None, None) => None,
+        };
+
         Ok(Some(super::RuntimeConfig {
-            connection_pooling_enabled: outbound_http_toml.connection_pooling,
-            max_concurrent_connections: outbound_http_toml.max_concurrent_requests,
+            connection_pooling_enabled: toml.connection_pooling,
+            max_concurrent_connections: max_connections,
         }))
     } else {
         Ok(None)
@@ -28,6 +48,9 @@ pub fn config_from_table(
 struct OutboundHttpToml {
     #[serde(default)]
     connection_pooling: bool,
+    #[serde(default)]
+    max_connections: Option<usize>,
+    /// Deprecated. Use `max_connections` instead.
     #[serde(default)]
     max_concurrent_requests: Option<usize>,
 }


### PR DESCRIPTION
*Setting to draft so we can let #3545, #3546, and #3537 settle first since this brings outbound http into line with the changes to the other factors made in those PRs.*

This deprecates the `max_concurrent_requests` runtime config setting to bring it more into line with the naming conventions for other factors introduced in #3545, #3546, and #3537. It also gets rid of the weird "0 means 1" semantics in the newly introduced option that I am responsible for despite @lann telling me it was a bad idea (I SHOULD HAVE LISTENED). 

This is a backwards compatible change, and we can consider removing the option completely in some future release.