### PR TITLE
Skip allowed outbound host entries that are empty due to empty variable resolution

### DIFF
--- a/crates/expressions/src/lib.rs
+++ b/crates/expressions/src/lib.rs
@@ -132,6 +132,22 @@ pub struct Resolver {
     component_configs: HashMap<String, HashMap<String, Template>>,
 }
 
+impl SyncResolver for Resolver {
+    fn resolve_variable(&self, key: &str) -> Result<String> {
+        let var = self
+            .variables
+            .get(key)
+            // This should have been caught by validate_template
+            .ok_or_else(|| Error::InvalidName(key.to_string()))?;
+
+        var.default.clone().ok_or_else(|| {
+            Error::Provider(anyhow::anyhow!(
+                "no provider resolved required variable {key:?}"
+            ))
+        })
+    }
+}
+
 impl Resolver {
     /// Creates a Resolver for the given Tree.
     pub fn new(variables: impl IntoIterator<Item = (String, Variable)>) -> Result<Self> {
@@ -196,20 +212,6 @@ impl Resolver {
         Ok(template)
     }
 
-    fn resolve_variable(&self, key: &str) -> Result<String> {
-        let var = self
-            .variables
-            .get(key)
-            // This should have been caught by validate_template
-            .ok_or_else(|| Error::InvalidName(key.to_string()))?;
-
-        var.default.clone().ok_or_else(|| {
-            Error::Provider(anyhow::anyhow!(
-                "no provider resolved required variable {key:?}"
-            ))
-        })
-    }
-
     fn validate_template(&self, template: String) -> Result<Template> {
         let template = Template::new(template)?;
         // Validate template variables are valid
@@ -229,15 +231,16 @@ impl Resolver {
     }
 }
 
-/// A resolver who has resolved all variables.
-#[derive(Default)]
-pub struct PreparedResolver {
-    variables: HashMap<String, String>,
-}
-
-impl PreparedResolver {
-    /// Resolves a the given template.
-    pub fn resolve_template(&self, template: &Template) -> Result<String> {
+/// Resolves a template to a string.
+///
+/// Because this trait is synchronous, implementations should not
+/// perform I/O. Mostly this is an abstraction over PreparedResolver
+/// to allow tests to inject fakes.
+pub trait SyncResolver {
+    /// Resolves the given template.
+    ///
+    /// Do not override this implementation.
+    fn resolve_template(&self, template: &Template) -> Result<String> {
         let mut resolved_parts: Vec<Cow<str>> = Vec::with_capacity(template.parts().len());
         for part in template.parts() {
             resolved_parts.push(match part {
@@ -248,6 +251,20 @@ impl PreparedResolver {
         Ok(resolved_parts.concat())
     }
 
+    /// Resolves a variable to a string.
+    ///
+    /// This must be implemented, but consumers should not usually
+    /// call it directly: call `resolve_template` instead.
+    fn resolve_variable(&self, key: &str) -> Result<String>;
+}
+
+/// A resolver who has resolved all variables.
+#[derive(Default)]
+pub struct PreparedResolver {
+    variables: HashMap<String, String>,
+}
+
+impl SyncResolver for PreparedResolver {
     fn resolve_variable(&self, key: &str) -> Result<String> {
         self.variables
             .get(key)

--- a/crates/outbound-networking-config/src/allowed_hosts.rs
+++ b/crates/outbound-networking-config/src/allowed_hosts.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, bail, ensure};
 use futures_util::future::{BoxFuture, Shared};
-use spin_expressions::Resolver;
+use spin_expressions::SyncResolver;
 use url::Host;
 
 /// The domain used for service chaining.
@@ -429,30 +429,47 @@ enum PartialAllowedHostConfig {
 
 impl PartialAllowedHostConfig {
     /// Returns this config, resolving any template with the given resolver.
-    fn resolve(
-        self,
-        resolver: &spin_expressions::PreparedResolver,
-    ) -> anyhow::Result<AllowedHostConfig> {
+    fn resolve(self, resolver: &impl SyncResolver) -> anyhow::Result<Option<AllowedHostConfig>> {
         match self {
-            Self::Exact(h) => Ok(h),
-            Self::Unresolved(t) => AllowedHostConfig::parse(resolver.resolve_template(&t)?),
+            Self::Exact(h) => Ok(Some(h)),
+            Self::Unresolved(t) => {
+                let resolved = resolver.resolve_template(&t)?;
+                Self::parse_or_skip(&resolved)
+            }
         }
     }
 
     /// Validates this config. Only templates that can be resolved with default
     /// values from the given resolver will be fully validated.
-    fn validate(&self, resolver: &Resolver) -> anyhow::Result<()> {
+    fn validate(&self, resolver: &impl SyncResolver) -> anyhow::Result<()> {
         if let Self::Unresolved(template) = self {
             let Ok(resolved) = resolver.resolve_template(template) else {
                 // We're missing a default value so we can't validate further
                 return Ok(());
             };
-            AllowedHostConfig::parse(&resolved).with_context(|| {
+
+            Self::parse_or_skip(&resolved).with_context(|| {
                 let template_str = template.to_string();
                 format!("using default variable value(s) with template {template_str:?} results in invalid config {resolved:?}")
             })?;
         }
         Ok(())
+    }
+
+    /// This should be used ONLY for resolutions involved variable
+    /// substitution (which is why it is here rather than on AllowedHostConfig).
+    /// An empty literal remains an error: this allows us to be forgiving if
+    /// an empty variable results in an empty resolution.
+    fn parse_or_skip(resolved: &str) -> anyhow::Result<Option<AllowedHostConfig>> {
+        // An empty variable could result in an empty host. We
+        // ignore these, so as to support an "optional endpoint"
+        // scenario.
+        // TODO: consider if we want other schemes too?
+        if resolved.is_empty() || resolved == "http://" || resolved == "https://" {
+            Ok(None)
+        } else {
+            AllowedHostConfig::parse(resolved).map(Some)
+        }
     }
 }
 
@@ -468,20 +485,23 @@ impl AllowedHostsConfig {
     /// with the given resolver.
     pub fn parse<S: AsRef<str>>(
         hosts: &[S],
-        resolver: &spin_expressions::PreparedResolver,
+        resolver: &impl SyncResolver,
         component_ids: &[String],
     ) -> anyhow::Result<AllowedHostsConfig> {
         let partial = Self::parse_partial(hosts)?;
         let allowed = partial
             .into_iter()
-            .map(|p| p.resolve(resolver))
+            .flat_map(|p| p.resolve(resolver).transpose())
             .collect::<anyhow::Result<Vec<_>>>()?;
         let allowed = Self::expand_wildcard_service_chaining(allowed, component_ids);
         Ok(Self::SpecificHosts(allowed))
     }
 
     /// Validates the given allowed_outbound_hosts values with the given resolver.
-    pub fn validate<S: AsRef<str>>(hosts: &[S], resolver: &Resolver) -> anyhow::Result<()> {
+    pub fn validate<S: AsRef<str>>(
+        hosts: &[S],
+        resolver: &impl SyncResolver,
+    ) -> anyhow::Result<()> {
         for partial in Self::parse_partial(hosts)? {
             partial.validate(resolver)?;
         }
@@ -697,8 +717,35 @@ mod test {
         }
     }
 
-    fn dummy_resolver() -> spin_expressions::PreparedResolver {
-        spin_expressions::PreparedResolver::default()
+    #[derive(Default)]
+    struct DummyResolver {
+        variables: std::collections::HashMap<String, String>,
+    }
+
+    impl SyncResolver for DummyResolver {
+        fn resolve_variable(&self, key: &str) -> spin_expressions::Result<String> {
+            self.variables
+                .get(key)
+                .cloned()
+                .ok_or(spin_expressions::Error::InvalidName(key.to_string()))
+        }
+    }
+
+    fn dummy_resolver() -> impl SyncResolver {
+        DummyResolver::default()
+    }
+
+    fn populated_resolver(values: &[(&str, &str)]) -> impl SyncResolver {
+        let variables = values
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        DummyResolver { variables }
+    }
+
+    fn empty_values_resolver() -> impl SyncResolver {
+        populated_resolver(&[("one", ""), ("two", "")])
     }
 
     use ip_network::{IpNetwork, Ipv4Network, Ipv6Network};
@@ -1101,5 +1148,66 @@ mod test {
         assert_eq!("second.spin.internal", exact_host(&allowed[2]));
         assert_eq!("third.spin.internal", exact_host(&allowed[3]));
         assert_eq!("spinframework.dev", exact_host(&allowed[4]));
+    }
+
+    #[test]
+    fn allowed_hosts_ignores_empty_due_to_empty_variables() {
+        let resolver = empty_values_resolver();
+        let hosts = &["https://{{ one }}", "{{ two }}", "https://three"];
+
+        let AllowedHostsConfig::SpecificHosts(allowed) =
+            AllowedHostsConfig::parse(hosts, &resolver, &[]).expect("parse should have succeeded")
+        else {
+            panic!("expanded AllowedHostsConfig should be specific hosts");
+        };
+
+        assert_eq!(1, allowed.len());
+        assert_eq!("three", exact_host(&allowed[0]));
+    }
+
+    #[test]
+    fn valid_hosts_are_valid() {
+        let resolver = dummy_resolver();
+        let hosts = &["http://x.y", "*://my.db:*"];
+        AllowedHostsConfig::validate(hosts, &resolver).expect("valid hosts should be valid");
+    }
+
+    #[test]
+    fn invalid_hosts_are_invalid() {
+        let resolver = dummy_resolver();
+        let hosts = &["http://x.y", "zootle! wurdl!", "}{ !!**"];
+        AllowedHostsConfig::validate(hosts, &resolver)
+            .expect_err("invalid hosts should be invalid");
+    }
+
+    #[test]
+    fn variables_make_hosts_valid() {
+        let resolver = populated_resolver(&[("dbhost", "example.com"), ("dbport", "1234")]);
+        let hosts = &["http://{{ dbhost }}", "http://{{ dbhost }}:{{ dbport }}"];
+        AllowedHostsConfig::validate(hosts, &resolver).expect("happy variables make hosts valid");
+    }
+
+    #[test]
+    fn bad_variables_make_hosts_invalid() {
+        let resolver = populated_resolver(&[("dbhost", "zoinks, Scooby!")]);
+        let hosts = &["http://{{ dbhost }}"];
+        AllowedHostsConfig::validate(hosts, &resolver)
+            .expect_err("bad variables make hosts invalid");
+    }
+
+    #[test]
+    fn missing_variables_ignored_when_checking_validity() {
+        let resolver = dummy_resolver();
+        let hosts = &["http://{{ dbhost }}"];
+        AllowedHostsConfig::validate(hosts, &resolver)
+            .expect("missing variables errors should be deferred");
+    }
+
+    #[test]
+    fn empty_resolutions_ignored_when_checking_validity() {
+        let resolver = empty_values_resolver();
+        let hosts = &["https://{{ one }}", "{{ two }}", "https://three"];
+        AllowedHostsConfig::validate(hosts, &resolver)
+            .expect("empty resolutions should ignored as valid");
     }
 }


### PR DESCRIPTION
Fixes #3549.

I had to introduce a resolver trait instead of using PreparedResolver for the annoying reason that I couldn't initialise a PreparedResolver with empty strings for testing.  I tried a `#[cfg(test)]` method on PreparedResolver to initialise it with fixed values, but it didn't work across the crate boundary.
