### PR TITLE
Improve target error message

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -589,7 +589,9 @@ mod tests {
 
         assert!(err.contains("can't run in environment wasi-minimal"));
         assert!(err.contains("world wasi:cli/command@0.2.0"));
-        assert!(err.contains("requires imports named"));
+        assert!(
+            err.contains("requires the following imports, which the environment does not provide")
+        );
         assert!(err.contains("wasi:cli/stdout"));
     }
 

--- a/crates/environments/src/environment.rs
+++ b/crates/environments/src/environment.rs
@@ -474,7 +474,7 @@ mod test {
             "unexpected error {err}"
         );
         assert!(
-            err.contains("requires imports named"),
+            err.contains("requires the following imports, which the environment does not provide"),
             "unexpected error {err}"
         );
         assert!(
@@ -583,7 +583,7 @@ mod test {
             "unexpected error {err}"
         );
         assert!(
-            err.contains("requires imports named"),
+            err.contains("requires the following imports, which the environment does not provide"),
             "unexpected error {err}"
         );
         assert!(

--- a/crates/environments/src/lib.rs
+++ b/crates/environments/src/lib.rs
@@ -288,13 +288,14 @@ fn format_target_result_error(
     report: &wac_types::TargetValidationReport,
 ) -> anyhow::Error {
     let mut error_string = format!(
-        "Component {} ({}) can't run in environment {} because world {} ...\n",
-        component_id, source_description, env_name, target_world_name
+        "Component {component_id} ({source_description}) can't run in environment {env_name} (world {target_world_name}).\n",
     );
 
     for (idx, import) in report.imports_not_in_target().enumerate() {
         if idx == 0 {
-            error_string.push_str("... requires imports named\n  - ");
+            error_string.push_str(
+                "The component requires the following imports, which the environment does not provide:\n  - ",
+            );
         } else {
             error_string.push_str("  - ");
         }
@@ -304,7 +305,9 @@ fn format_target_result_error(
 
     for (idx, (export, export_kind)) in report.missing_exports().enumerate() {
         if idx == 0 {
-            error_string.push_str("... requires exports named\n  - ");
+            error_string.push_str(
+                "The environment requires the following exports, which the component does not provide:\n  - ",
+            );
         } else {
             error_string.push_str("  - ");
         }
@@ -315,7 +318,7 @@ fn format_target_result_error(
     }
 
     for (name, extern_kind, error) in report.mismatched_types() {
-        error_string.push_str("... found a type mismatch for ");
+        error_string.push_str("Found a type mismatch for ");
         error_string.push_str(&format!("{extern_kind} {name}: {error}"));
     }
 


### PR DESCRIPTION
The original message conflated the component's requirements with the world's, making it sound like the target world requires the imports. The new output now correctly attributes them.

Original:
```
Error: Component target-env-test (file "target/wasm32-wasip2/release/target_env_test.wasm") can't run in environment wasi-http-0.2 because world spin:wasi-http/http-trigger@0.2.0 ...
... requires imports named
  - fermyon:spin/key-value@2.0.0
  - fermyon:spin/sqlite@2.0.0
  - wasi:cli/environment@0.2.3
  - wasi:cli/exit@0.2.3
  - wasi:filesystem/preopens@0.2.3
  - wasi:filesystem/types@0.2.3
```

Improved:
```
Component target-env-test (file "...") can't run in environment wasi-http-0.2 (world spin:wasi-http/http-trigger@0.2.0).
The component requires the following imports, which the environment does not provide:
  - fermyon:spin/key-value@2.0.0
  - fermyon:spin/sqlite@2.0.0
  - wasi:cli/environment@0.2.3
  ...
```