### PR TITLE
Make the right features line up

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9407,6 +9407,7 @@ dependencies = [
  "itertools 0.14.0",
  "oci-distribution 0.11.0 (git+https://github.com/fermyon/oci-distribution?rev=7b291a39f74d1a3c9499d934a56cae6580fc8e37)",
  "reqwest 0.12.9",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "spin-common",

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -12,6 +12,11 @@ chrono = { workspace = true }
 dirs = { workspace = true }
 docker_credential = "1"
 docker-registry = { version = "0.9", default-features = false }
+# Force a TLS feature on docker-registry's reqwest 0.13. Building `-p spin-oci` in
+# isolation doesn't pull in `oci-client` (which is what activates `reqwest/native-tls`
+# on 0.13 during a workspace build), so without this docker-registry fails to compile
+# because items it uses are gated behind reqwest's `__tls` cfg.
+reqwest_0_13 = { package = "reqwest", version = "0.13", default-features = false, features = ["native-tls"] }
 flate2 = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }


### PR DESCRIPTION
Currently `spin-oci` does not compile on its own but does compile when compiling the entire workspace. This is due to the cargo feature resolver being funky. We essentially need to force the version of `reqwest` that `docker-registry` uses to use the right feature.