### PR TITLE
`spin new -E` should not fail just because template update fails

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -309,24 +309,44 @@ async fn env_templates_and_plugins(
                     .await?;
             let env_name = loaded_env.name;
             let env_def = loaded_env.env_def;
-            //   - create a TM for it
+
+            // Create a TemplateManager for this environment's templates
             let template_manager = TemplateManager::for_environment(&env_name)?;
-            //   - install the templates to that TM
+
+            // If the env has templates, install the templates to that TemplateManager.
+            // If this fails, fall back to already installed templates for that env,
+            // or bail if we don't have env templates already installed.
             let env_templates = env_def.templates();
             if let Some(env_templates) = env_templates {
                 let source = spin_templates::TemplateSource::try_from_git(
                     env_templates.url(),
                     env_templates.tag(),
                     crate::build_info::SPIN_VERSION,
-                )?;
-                template_manager
+                )
+                .with_context(|| format!("Invalid templates URL in environment '{env_ref}'"))?;
+                if let Err(e) = template_manager
                     .install(
                         &source,
                         &spin_templates::InstallOptions::default().update(true),
                         &DiscardingReporter,
                     )
-                    .await?;
+                    .await
+                {
+                    // Couldn't fetch templates, and we don't already have them from a previous use.
+                    if is_empty(&template_manager).await {
+                        return Err(e).with_context(|| {
+                            format!("Cannot install templates for '{env_ref}' environment")
+                        });
+                    }
+                    // Couldn't fetch templates, but we do have some existing ones
+                    terminal::warn!(
+                        "Cannot check for updated templates for '{env_ref}' environment"
+                    );
+                    eprintln!("Using your existing templates");
+                    eprintln!();
+                }
             }
+
             if is_empty(&template_manager).await {
                 match variant {
                     TemplateVariantInfo::NewApplication => {


### PR DESCRIPTION
`spin new -E` always tries to install the latest templates from the remote.  If this fails, `spin new` bails.

But this is suboptimal for people doing `spin new -E` on a plane or whatever.  If they've already got templates for their environment, they should be allowed to use those: okay, they _might_ not be the latest, but 1. they probably are and 2. even if they're not, they're still better than nothing.

This fixes that.  As long as they have templates for the env, they'll be able to create apps even while away from the network.

(Obviously, if they have _never_ had the templates _at all_ before getting on the plane, they're still out of luck.  Fixing this is outside the scope of Spin.)

Tested by `new -E`-ing from a local env file, then modifying the env file to point to an invalid tag and `new -E`-ing again.  Got the "can't check" warning but it still let me use the templates.

Reviewer notes:

* I am not sure what to do about the code structure here.  The function is now nearly 100 lines, with multiple conditionals and significant nesting, and arms pushed more than a screen apart so you see a case and go "wait what does this go with".  I tried extracting functions to do the env template install and manage the if-then logic (e.g. return an outcome code and drive messaging off that( but nothing came out very nicely.  Advice welcome!

* I wondered if I should put a timeout on it so the user of a ropey network doesn't get blocked waiting for a network connection that will never come.  It's a nice backstop but man even moar complexity? Yikes. Thoughts?
