### PR TITLE
Update OpenTelemetry dependencies and use experimental semantic convention constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,21 +290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite 2.5.0",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,33 +380,6 @@ dependencies = [
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "async-process",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.5.0",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -2855,9 +2813,9 @@ dependencies = [
 
 [[package]]
 name = "fake-opentelemetry-collector"
-version = "0.26.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce713bed1dfc379216421ebf0c4ee2268b5cb4d7894bed8a96d267834590916"
+checksum = "78fa9a15fc21ea5d1b00a9ead3f6991b3cccf73bf5364a3167465ca17b5884e1"
 dependencies = [
  "futures",
  "hex",
@@ -3845,18 +3803,6 @@ dependencies = [
  "log",
  "regex-automata",
  "regex-syntax",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4972,15 +4918,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5256,9 +5193,6 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "logos"
@@ -6186,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6200,9 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c513c7af3bec30113f3d4620134ff923295f1e9c580fda2b8abe0831f925ddc0"
+checksum = "e716f864eb23007bdd9dc4aec381e188a1cee28eecf22066772b5fd822b9727d"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -6212,9 +6146,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6226,11 +6160,10 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
- "async-trait",
  "futures-core",
  "http 1.3.1",
  "opentelemetry",
@@ -6246,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -6258,25 +6191,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
+checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
- "async-std",
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.9.4",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
@@ -8997,6 +8928,7 @@ dependencies = [
  "anyhow",
  "futures",
  "mysql_async",
+ "opentelemetry-semantic-conventions",
  "serde",
  "spin-core",
  "spin-factor-otel",
@@ -9059,6 +8991,7 @@ dependencies = [
  "futures",
  "moka",
  "native-tls",
+ "opentelemetry-semantic-conventions",
  "postgres-native-tls",
  "postgres_range",
  "rust_decimal",
@@ -9089,6 +9022,7 @@ name = "spin-factor-outbound-redis"
 version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
+ "opentelemetry-semantic-conventions",
  "redis",
  "serde",
  "spin-core",
@@ -9108,6 +9042,7 @@ name = "spin-factor-sqlite"
 version = "4.1.0-pre0"
 dependencies = [
  "async-trait",
+ "opentelemetry-semantic-conventions",
  "spin-core",
  "spin-factor-otel",
  "spin-factors",
@@ -9597,6 +9532,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "reqwest 0.12.9",
  "terminal",
@@ -10715,9 +10651,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -11014,12 +10950,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "value-bag"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vaultrs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ openssl = { version = "0.10" }
 anyhow = { workspace = true, features = ["backtrace"] }
 conformance = { path = "tests/conformance-tests" }
 conformance-tests = { workspace = true }
-fake-opentelemetry-collector = "0.26"
+fake-opentelemetry-collector = "0.28"
 hex = "0.4"
 http-body-util = { workspace = true }
 hyper = { workspace = true }
@@ -153,16 +153,16 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 indexmap = "2"
 itertools = "0.14"
 lazy_static = "1.5"
-opentelemetry = "0.28"
+opentelemetry = "0.29"
 # The default `reqwest-blocking-client` causes a runtime panic
-opentelemetry-otlp = { version = "0.28", default-features = false, features = ["http-proto", "reqwest-client", "logs"]}
-opentelemetry_sdk = {version = "0.28", features = [
+opentelemetry-otlp = { version = "0.29", default-features = false, features = ["http-proto", "reqwest-client", "logs"]}
+opentelemetry_sdk = {version = "0.29", features = [
   "experimental_metrics_periodicreader_with_async_runtime",
   "experimental_trace_batch_span_processor_with_async_runtime",
   "experimental_logs_batch_log_processor_with_async_runtime",
   "experimental_async_runtime"
 ]}
-opentelemetry-semantic-conventions = "0.28"
+opentelemetry-semantic-conventions = { version = "0.29", features = ["semconv_experimental"] }
 path-absolutize = "3"
 pin-project-lite = "0.2.16"
 quote = "1"
@@ -193,7 +193,7 @@ toml_edit = "0.22"
 tower-service = "0.3.3"
 tracing = { version = "0.1.44", features = ["log"] }
 url = "2.5.7"
-tracing-opentelemetry = { version = "0.29", default-features = false, features = ["metrics"] }
+tracing-opentelemetry = { version = "0.30", default-features = false, features = ["metrics"] }
 walkdir = "2"
 wac-graph = "0.10.0"
 wasm-encoder = "0.247.0"

--- a/crates/factor-otel/src/lib.rs
+++ b/crates/factor-otel/src/lib.rs
@@ -159,7 +159,7 @@ impl OtelFactor {
                 OtlpProtocol::HttpJson => bail!("http/json OTLP protocol is not supported"),
             };
 
-            let log_processor = BatchLogProcessor::builder(log_exporter, Tokio).build();
+            let mut log_processor = BatchLogProcessor::builder(log_exporter, Tokio).build();
             log_processor.set_resource(&resource);
             Some(Arc::new(log_processor))
         } else {

--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -140,8 +140,7 @@ impl p3::WasiHttpHooks for InstanceHttpHooks {
             {otel_attribute::URL_FULL} = Empty,
             {otel_attribute::HTTP_REQUEST_METHOD} = %request.method(),
             otel.name = %request.method(),
-            // Incubating convention; not yet a stable `opentelemetry_semantic_conventions` constant.
-            http.response.body.size = Empty,
+            {otel_attribute::HTTP_RESPONSE_BODY_SIZE} = Empty,
             {otel_attribute::HTTP_RESPONSE_STATUS_CODE} = Empty,
             {otel_attribute::SERVER_ADDRESS} = Empty,
             {otel_attribute::SERVER_PORT} = Empty,
@@ -276,10 +275,7 @@ impl<B: Body<Error = p2_types::ErrorCode> + Unpin> Body for BetweenBytesTimeoutB
 
         let mut record_body_size_once = |body_size: u64| {
             if let Some(span) = me.span.take() {
-                // `http.response.body.size` is incubating (behind semconv_experimental)
-                // in opentelemetry-semantic-conventions 0.28. Leave as literal to avoid
-                // enabling the experimental feature.
-                span.record("http.response.body.size", body_size);
+                span.record(otel_attribute::HTTP_RESPONSE_BODY_SIZE, body_size);
             }
         };
         match poll_result {

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -16,6 +16,7 @@ mysql_async = { version = "0.35", default-features = false, features = [
   "minimal-rust",
   "native-tls-tls",
 ] }
+opentelemetry-semantic-conventions = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }

--- a/crates/factor-outbound-mysql/src/host.rs
+++ b/crates/factor-outbound-mysql/src/host.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
+use opentelemetry_semantic_conventions::attribute as otel_attribute;
 use spin_core::wasmtime::component::{Accessor, FutureReader, Resource, StreamReader};
 use spin_factor_outbound_networking::ConnectionPermit;
 use spin_telemetry::traces::{self, Blame};
@@ -94,7 +95,7 @@ type QueryTuple = (
 );
 
 impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
-    #[instrument(name = "spin_outbound_mysql.open", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_mysql.open", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open<T>(
         accessor: &Accessor<T, Self>,
         address: String,
@@ -114,7 +115,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
         ))
     }
 
-    #[instrument(name = "spin_outbound_mysql.execute", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_mysql.execute", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", otel.name = statement))]
     async fn execute<T>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -136,7 +137,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
         Ok(())
     }
 
-    #[instrument(name = "spin_outbound_mysql.query", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_mysql.query", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", otel.name = statement))]
     async fn query<T>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -177,7 +178,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
 impl<C: Client> v2::Host for InstanceState<C> {}
 
 impl<C: Client> v2::HostConnection for InstanceState<C> {
-    #[instrument(name = "spin_outbound_mysql.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_mysql.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<v2::Connection>, v2::Error> {
         let permit = self
             .semaphore
@@ -192,7 +193,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
             .map(Resource::new_own)
     }
 
-    #[instrument(name = "spin_outbound_mysql.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_mysql.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", otel.name = statement))]
     async fn execute(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -210,7 +211,7 @@ impl<C: Client> v2::HostConnection for InstanceState<C> {
             .map_err(track_db_error_on_span)
     }
 
-    #[instrument(name = "spin_outbound_mysql.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "mysql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_mysql.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", otel.name = statement))]
     async fn query(
         &mut self,
         connection: Resource<v2::Connection>,

--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -5,7 +5,7 @@ mod tls;
 use std::{collections::HashMap, sync::Arc};
 
 use futures_util::FutureExt as _;
-use opentelemetry_semantic_conventions::attribute::SERVER_PORT;
+use opentelemetry_semantic_conventions::attribute as otel_attribute;
 use spin_factor_variables::VariablesFactor;
 use spin_factor_wasi::{SocketAddrUse, SocketPermitState, WasiFactor};
 use spin_factors::{
@@ -301,16 +301,21 @@ impl FactorInstanceBuilder for InstanceBuilder {
 /// The following fields must be pre-declared as empty on the span or they will not show up.
 /// ```
 /// use tracing::field::Empty;
-/// #[tracing::instrument(fields(db.address = Empty, server.port = Empty, db.namespace = Empty))]
+/// use opentelemetry_semantic_conventions::attribute as otel_attribute;
+/// #[tracing::instrument(fields({otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
 /// fn open() {}
 /// ```
 pub fn record_address_fields(address: &str) {
     if let Ok(url) = Url::parse(address) {
         let span = tracing::Span::current();
-        // `db.address` and `db.namespace` are incubating in opentelemetry-semantic-conventions 0.28.
-        // Leaving as string literals to avoid enabling the semconv_experimental feature.
-        span.record("db.address", url.host_str().unwrap_or_default());
-        span.record(SERVER_PORT, url.port().unwrap_or_default());
-        span.record("db.namespace", url.path().trim_start_matches('/'));
+        span.record(
+            otel_attribute::SERVER_ADDRESS,
+            url.host_str().unwrap_or_default(),
+        );
+        span.record(otel_attribute::SERVER_PORT, url.port().unwrap_or_default());
+        span.record(
+            otel_attribute::DB_NAMESPACE,
+            url.path().trim_start_matches('/'),
+        );
     }
 }

--- a/crates/factor-outbound-pg/Cargo.toml
+++ b/crates/factor-outbound-pg/Cargo.toml
@@ -13,6 +13,7 @@ deadpool-postgres = { version = "0.14", features = ["rt_tokio_1"] }
 futures = { workspace = true }
 moka = { version = "0.12", features = ["sync"] }
 native-tls = "0.2"
+opentelemetry-semantic-conventions = { workspace = true }
 postgres-native-tls = "0.5"
 postgres_range = "0.11"
 rust_decimal = { version = "1.37", features = ["db-tokio-postgres"] }

--- a/crates/factor-outbound-pg/src/host.rs
+++ b/crates/factor-outbound-pg/src/host.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::result_large_err)]
 
 use anyhow::Result;
+use opentelemetry_semantic_conventions::attribute as otel_attribute;
 use spin_core::wasmtime::component::{Accessor, FutureReader, Resource, StreamReader};
 use spin_telemetry::traces::{self, Blame};
 use spin_world::MAX_HOST_BUFFERED_BYTES;
@@ -91,7 +92,7 @@ fn v3_params_to_v4(params: Vec<v3::ParameterValue>) -> Vec<v4::ParameterValue> {
 }
 
 impl<CF: ClientFactory> v3::HostConnection for InstanceState<CF> {
-    #[instrument(name = "spin_outbound_pg.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_pg.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<v3::Connection>, v3::Error> {
         spin_factor_outbound_networking::record_address_fields(&address);
 
@@ -105,7 +106,7 @@ impl<CF: ClientFactory> v3::HostConnection for InstanceState<CF> {
             .map_err(v3::Error::from)
     }
 
-    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn execute(
         &mut self,
         connection: Resource<v3::Connection>,
@@ -121,7 +122,7 @@ impl<CF: ClientFactory> v3::HostConnection for InstanceState<CF> {
             .map_err(track_db_error_on_span_v3)
     }
 
-    #[instrument(name = "spin_outbound_pg.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn query(
         &mut self,
         connection: Resource<v3::Connection>,
@@ -198,7 +199,7 @@ impl<CF: ClientFactory> v4::HostConnectionBuilder for InstanceState<CF> {
 }
 
 impl<CF: ClientFactory> v4::HostConnection for InstanceState<CF> {
-    #[instrument(name = "spin_outbound_pg.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_pg.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<v4::Connection>, v4::Error> {
         spin_factor_outbound_networking::record_address_fields(&address);
 
@@ -209,7 +210,7 @@ impl<CF: ClientFactory> v4::HostConnection for InstanceState<CF> {
         self.open_connection(&address, None).await
     }
 
-    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn execute(
         &mut self,
         connection: Resource<v4::Connection>,
@@ -223,7 +224,7 @@ impl<CF: ClientFactory> v4::HostConnection for InstanceState<CF> {
             .map_err(track_db_error_on_span_v4)
     }
 
-    #[instrument(name = "spin_outbound_pg.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn query(
         &mut self,
         connection: Resource<v4::Connection>,
@@ -246,7 +247,7 @@ impl<CF: ClientFactory> v4::HostConnection for InstanceState<CF> {
 impl<CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectionWithStore
     for crate::PgFactorData<CF>
 {
-    #[instrument(name = "spin_outbound_pg.open_async", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_pg.open_async", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open_async<T>(
         accessor: &Accessor<T, Self>,
         address: String,
@@ -259,7 +260,7 @@ impl<CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectio
         Self::open_connection_async(accessor, &address, None).await
     }
 
-    #[instrument(name = "spin_outbound_pg.execute", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.execute", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn execute_async<T>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v4::Connection>,
@@ -281,7 +282,7 @@ impl<CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectio
     }
 
     #[allow(clippy::type_complexity)] // blame bindgen, clippy, blame bindgen
-    #[instrument(name = "spin_outbound_pg.query_async", skip(accessor, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.query_async", skip(accessor, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn query_async<T>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v4::Connection>,
@@ -471,7 +472,7 @@ macro_rules! delegate {
 impl<CF: ClientFactory> v2::Host for InstanceState<CF> {}
 
 impl<CF: ClientFactory> v2::HostConnection for InstanceState<CF> {
-    #[instrument(name = "spin_outbound_pg.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_pg.open", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<v2::Connection>, v2::Error> {
         self.otel.reparent_tracing_span();
         spin_factor_outbound_networking::record_address_fields(&address);
@@ -485,7 +486,7 @@ impl<CF: ClientFactory> v2::HostConnection for InstanceState<CF> {
             .map_err(v2::Error::from)
     }
 
-    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.execute", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn execute(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -505,7 +506,7 @@ impl<CF: ClientFactory> v2::HostConnection for InstanceState<CF> {
             .map_err(track_db_error_on_span_v2)
     }
 
-    #[instrument(name = "spin_outbound_pg.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", db.system = "postgresql", otel.name = statement))]
+    #[instrument(name = "spin_outbound_pg.query", skip(self, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", otel.name = statement))]
     async fn query(
         &mut self,
         connection: Resource<v2::Connection>,

--- a/crates/factor-outbound-redis/Cargo.toml
+++ b/crates/factor-outbound-redis/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
 redis = { workspace = true , features = ["tokio-comp", "tokio-native-tls-comp", "aio"] }
 serde = { workspace = true }
 spin-core = { path = "../core" }

--- a/crates/factor-outbound-redis/src/host.rs
+++ b/crates/factor-outbound-redis/src/host.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use anyhow::Result;
+use opentelemetry_semantic_conventions::attribute as otel_attribute;
 use redis::AsyncConnectionConfig;
 use redis::io::AsyncDNSResolver;
 use redis::{AsyncCommands, FromRedisValue, Value, aio::MultiplexedConnection};
@@ -235,7 +236,7 @@ impl crate::RedisFactorData {
 }
 
 impl v3::HostConnectionWithStore for crate::RedisFactorData {
-    #[instrument(name = "spin_outbound_redis.open_connection", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_redis.open_connection", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open<T: Send>(
         accessor: &Accessor<T, Self>,
         address: String,
@@ -280,7 +281,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         })
     }
 
-    #[instrument(name = "spin_outbound_redis.publish", skip(accessor, connection, payload), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("PUBLISH {}", channel)))]
+    #[instrument(name = "spin_outbound_redis.publish", skip(accessor, connection, payload), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("PUBLISH {}", channel)))]
     async fn publish<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -291,7 +292,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::publish(&mut conn, channel, payload).await
     }
 
-    #[instrument(name = "spin_outbound_redis.get", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("GET {}", key)))]
+    #[instrument(name = "spin_outbound_redis.get", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("GET {}", key)))]
     async fn get<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -301,7 +302,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::get(&mut conn, key).await
     }
 
-    #[instrument(name = "spin_outbound_redis.set", skip(accessor, connection, value), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SET {}", key)))]
+    #[instrument(name = "spin_outbound_redis.set", skip(accessor, connection, value), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SET {}", key)))]
     async fn set<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -312,7 +313,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::set(&mut conn, key, value).await
     }
 
-    #[instrument(name = "spin_outbound_redis.incr", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("INCRBY {} 1", key)))]
+    #[instrument(name = "spin_outbound_redis.incr", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("INCRBY {} 1", key)))]
     async fn incr<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -322,7 +323,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::incr(&mut conn, key).await
     }
 
-    #[instrument(name = "spin_outbound_redis.del", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("DEL {}", keys.join(" "))))]
+    #[instrument(name = "spin_outbound_redis.del", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("DEL {}", keys.join(" "))))]
     async fn del<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -332,7 +333,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::del(&mut conn, keys).await
     }
 
-    #[instrument(name = "spin_outbound_redis.sadd", skip(accessor, connection, values), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SADD {} {}", key, values.join(" "))))]
+    #[instrument(name = "spin_outbound_redis.sadd", skip(accessor, connection, values), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SADD {} {}", key, values.join(" "))))]
     async fn sadd<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -343,7 +344,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::sadd(&mut conn, key, values).await
     }
 
-    #[instrument(name = "spin_outbound_redis.smembers", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SMEMBERS {}", key)))]
+    #[instrument(name = "spin_outbound_redis.smembers", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SMEMBERS {}", key)))]
     async fn smembers<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -353,7 +354,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::smembers(&mut conn, key).await
     }
 
-    #[instrument(name = "spin_outbound_redis.srem", skip(accessor, connection, values), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SREM {} {}", key, values.join(" "))))]
+    #[instrument(name = "spin_outbound_redis.srem", skip(accessor, connection, values), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SREM {} {}", key, values.join(" "))))]
     async fn srem<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -364,7 +365,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
         operations::srem(&mut conn, key, values).await
     }
 
-    #[instrument(name = "spin_outbound_redis.execute", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("{}", command)))]
+    #[instrument(name = "spin_outbound_redis.execute", skip(accessor, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("{}", command)))]
     async fn execute<T: Send>(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
@@ -385,7 +386,7 @@ impl v2::Host for crate::InstanceState {
 }
 
 impl v2::HostConnection for crate::InstanceState {
-    #[instrument(name = "spin_outbound_redis.open_connection", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", db.address = Empty, server.port = Empty, db.namespace = Empty))]
+    #[instrument(name = "spin_outbound_redis.open_connection", skip(self, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
     async fn open(&mut self, address: String) -> Result<Resource<v2::Connection>, v2::Error> {
         self.otel.reparent_tracing_span();
         if !self
@@ -399,7 +400,7 @@ impl v2::HostConnection for crate::InstanceState {
         self.establish_connection(address).await
     }
 
-    #[instrument(name = "spin_outbound_redis.publish", skip(self, connection, payload), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("PUBLISH {}", channel)))]
+    #[instrument(name = "spin_outbound_redis.publish", skip(self, connection, payload), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("PUBLISH {}", channel)))]
     async fn publish(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -413,7 +414,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::publish(conn, channel, payload).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.get", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("GET {}", key)))]
+    #[instrument(name = "spin_outbound_redis.get", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("GET {}", key)))]
     async fn get(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -426,7 +427,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::get(conn, key).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.set", skip(self, connection, value), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SET {}", key)))]
+    #[instrument(name = "spin_outbound_redis.set", skip(self, connection, value), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SET {}", key)))]
     async fn set(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -439,7 +440,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::set(conn, key, value).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.incr", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("INCRBY {} 1", key)))]
+    #[instrument(name = "spin_outbound_redis.incr", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("INCRBY {} 1", key)))]
     async fn incr(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -451,7 +452,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::incr(conn, key).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.del", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("DEL {}", keys.join(" "))))]
+    #[instrument(name = "spin_outbound_redis.del", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("DEL {}", keys.join(" "))))]
     async fn del(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -463,7 +464,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::del(conn, keys).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.sadd", skip(self, connection, values), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SADD {} {}", key, values.join(" "))))]
+    #[instrument(name = "spin_outbound_redis.sadd", skip(self, connection, values), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SADD {} {}", key, values.join(" "))))]
     async fn sadd(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -476,7 +477,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::sadd(conn, key, values).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.smembers", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SMEMBERS {}", key)))]
+    #[instrument(name = "spin_outbound_redis.smembers", skip(self, connection), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SMEMBERS {}", key)))]
     async fn smembers(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -488,7 +489,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::smembers(conn, key).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.srem", skip(self, connection, values), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("SREM {} {}", key, values.join(" "))))]
+    #[instrument(name = "spin_outbound_redis.srem", skip(self, connection, values), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("SREM {} {}", key, values.join(" "))))]
     async fn srem(
         &mut self,
         connection: Resource<v2::Connection>,
@@ -501,7 +502,7 @@ impl v2::HostConnection for crate::InstanceState {
         Ok(operations::srem(conn, key, values).await?)
     }
 
-    #[instrument(name = "spin_outbound_redis.execute", skip(self, connection, arguments), err(level = Level::INFO), fields(otel.kind = "client", db.system = "redis", otel.name = format!("{}", command)))]
+    #[instrument(name = "spin_outbound_redis.execute", skip(self, connection, arguments), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("{}", command)))]
     async fn execute(
         &mut self,
         connection: Resource<v2::Connection>,

--- a/crates/factor-sqlite/Cargo.toml
+++ b/crates/factor-sqlite/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }
+opentelemetry-semantic-conventions = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-otel = { path = "../factor-otel" }
 spin-factors = { path = "../factors" }

--- a/crates/factor-sqlite/src/host.rs
+++ b/crates/factor-sqlite/src/host.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use opentelemetry_semantic_conventions::attribute as otel_attribute;
 use spin_core::wasmtime::component::{Accessor, FutureReader, StreamReader};
 use spin_factor_otel::OtelFactorState;
 use spin_factors::wasmtime::component::Resource;
@@ -101,12 +102,12 @@ impl v3::Host for InstanceState {
 }
 
 impl v3::HostConnection for InstanceState {
-    #[instrument(name = "spin_sqlite.open", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", sqlite.backend = Empty))]
+    #[instrument(name = "spin_sqlite.open", skip(self), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "sqlite", sqlite.backend = Empty))]
     async fn open(&mut self, database: String) -> Result<Resource<v3::Connection>, v3::Error> {
         self.open_impl(database).await
     }
 
-    #[instrument(name = "spin_sqlite.execute", skip(self, connection, parameters), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query, sqlite.backend = Empty))]
+    #[instrument(name = "spin_sqlite.execute", skip(self, connection, parameters), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "sqlite", otel.name = query, sqlite.backend = Empty))]
     async fn execute(
         &mut self,
         connection: Resource<v3::Connection>,
@@ -274,13 +275,13 @@ impl v2::Host for InstanceState {
 }
 
 impl v2::HostConnection for InstanceState {
-    #[instrument(name = "spin_sqlite.open", skip(self), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", sqlite.backend = Empty))]
+    #[instrument(name = "spin_sqlite.open", skip(self), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "sqlite", sqlite.backend = Empty))]
     async fn open(&mut self, database: String) -> Result<Resource<v2::Connection>, v2::Error> {
         self.otel.reparent_tracing_span();
         self.open_impl(database).await.map_err(to_v2_error)
     }
 
-    #[instrument(name = "spin_sqlite.execute", skip(self, connection, parameters), err(level = Level::INFO), fields(otel.kind = "client", db.system = "sqlite", otel.name = query, sqlite.backend = Empty))]
+    #[instrument(name = "spin_sqlite.execute", skip(self, connection, parameters), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "sqlite", otel.name = query, sqlite.backend = Empty))]
     async fn execute(
         &mut self,
         connection: Resource<v2::Connection>,

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -8,9 +8,10 @@ edition = { workspace = true }
 anyhow = { workspace = true }
 http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
-opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
-opentelemetry-appender-tracing = "0.28"
+opentelemetry = { version = "0.29", features = ["metrics", "trace", "logs"] }
+opentelemetry-appender-tracing = "0.29"
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
+opentelemetry-semantic-conventions = { workspace = true }
 reqwest = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
 terminal = { path = "../terminal" }

--- a/crates/telemetry/src/detector.rs
+++ b/crates/telemetry/src/detector.rs
@@ -5,6 +5,7 @@ use opentelemetry_sdk::{
     Resource,
     resource::{EnvResourceDetector, ResourceDetector},
 };
+use opentelemetry_semantic_conventions::attribute as otel_attribute;
 
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 
@@ -36,13 +37,13 @@ impl ResourceDetector for SpinResourceDetector {
             .or_else(|| {
                 EnvResourceDetector::new()
                     .detect()
-                    .get(&Key::new("service.name"))
+                    .get(&Key::new(otel_attribute::SERVICE_NAME))
             })
             .unwrap_or_else(|| "spin".into());
         Resource::builder()
             .with_attributes(vec![
-                KeyValue::new("service.name", service_name),
-                KeyValue::new("service.version", self.spin_version.clone()),
+                KeyValue::new(otel_attribute::SERVICE_NAME, service_name),
+                KeyValue::new(otel_attribute::SERVICE_VERSION, self.spin_version.clone()),
             ])
             .build()
     }

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -15,7 +15,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { workspace = true }
+hyper-util = { workspace = true, features = ["server-auto"] }
 pin-project-lite = { workspace = true }
 rand.workspace = true
 rustls = { workspace = true }


### PR DESCRIPTION
### Summary

- Upgrade the OpenTelemetry dependency stack to the 0.29-compatible releases.
  - We can't upgrade to 0.30 cleanly due to a upstream breaking change in `opentelemetry_sdk::metrics::data::ResourceMetrics`.
- Replace hard-coded semantic convention attribute strings with constants from `opentelemetry-semantic-conventions`.
- Migrate outbound database and networking spans away from deprecated attribute names where the semantic conventions crate provides newer names. (may be **breaking**)
- Adjust OpenTelemetry SDK usage for the updated log processor resource API.

### Details

Continue previous work of compile-time references for the emitted attribute keys and makes future semantic convention migrations easier to identify during dependency updates.

The workspace enables `semconv_experimental` because Spin was already emitting experimental semantic convention attributes as string literals before this change, including attributes such as `http.response.body.size` and `db.namespace`. Enabling the feature does not introduce new telemetry concepts by itself; it lets the existing experimental attribute names come from the same upstream conventions crate as the stable attributes.

### Breaking Changes / Compatibility

This changes some emitted OpenTelemetry span attribute names as part of replacing deprecated semantic convention attributes with their newer equivalents. Consumers that collects these attributes should update their telemetry rules accordingly.

Notable replacements include:

- `db.system` -> `db.system.name`
- `db.address` (not a semantic convention) -> `server.address`