### PR TITLE
Miscellaneous integration test fixes

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1223,8 +1223,12 @@ route = "/..."
         impl Drop for Uninstaller<'_> {
             fn drop(&mut self) {
                 let mut uninstall = std::process::Command::new(spin_binary());
-                uninstall.args(["plugins", "uninstall", "example"]);
-                self.0.run_in(&mut uninstall).unwrap();
+                uninstall
+                    .args(["plugins", "uninstall", "example"])
+                    .env("SPIN_DATA_DIR", "./plugins");
+                self.0
+                    .run_in(&mut uninstall)
+                    .expect("failed to uninstall test plugin");
             }
         }
         let _u = Uninstaller(&env);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1362,7 +1362,7 @@ route = "/..."
     #[test]
     fn test_wasi_http_p3_double_echo() -> anyhow::Result<()> {
         wasi_http_echo(
-            "wasi-http-p2-streaming",
+            "wasi-http-p3-streaming",
             "double-echo".into(),
             Some("echo".into()),
         )

--- a/tests/test-components/components/integration-wasi-http-p3-streaming/src/lib.rs
+++ b/tests/test-components/components/integration-wasi-http-p3-streaming/src/lib.rs
@@ -131,8 +131,17 @@ impl Guest for Component {
                         let method = request.get_method();
                         let (rx, trailers) =
                             Request::consume_body(request, wit_future::new(|| Ok(())).1);
+                        // Forward content-type so the echoed response carries it back
+                        // (matches what /echo round-trips).
+                        let outgoing_headers = Fields::from_list(
+                            &headers
+                                .into_iter()
+                                .filter(|(k, _)| k == "content-type")
+                                .collect::<Vec<_>>(),
+                        )
+                        .unwrap();
                         let outgoing_request =
-                            Request::new(Fields::new(), Some(rx), trailers, None).0;
+                            Request::new(outgoing_headers, Some(rx), trailers, None).0;
                         outgoing_request.set_method(&method).unwrap();
                         outgoing_request
                             .set_path_with_query(Some(url.path()))

--- a/tests/testing-framework/src/runtimes/spin_cli.rs
+++ b/tests/testing-framework/src/runtimes/spin_cli.rs
@@ -285,8 +285,6 @@ fn kill_process(process: &mut std::process::Child) {
     // Hard-kill the process. On Windows this is the only termination
     // (TerminateProcess); on Unix it's the SIGKILL
     let _ = process.kill();
-
-    let _ = process.wait();
 }
 
 /// How this Spin instance is communicating with the outside world

--- a/tests/testing-framework/src/runtimes/spin_cli.rs
+++ b/tests/testing-framework/src/runtimes/spin_cli.rs
@@ -257,15 +257,36 @@ pub struct SpinConfig {
 }
 
 fn kill_process(process: &mut std::process::Child) {
-    #[cfg(windows)]
-    {
-        let _ = process.kill();
+    match process.try_wait() {
+        Ok(Some(_)) => return,
+        Ok(None) => {}
+        Err(e) => {
+            log::warn!("failed to check Spin process status before cleanup: {e}");
+            return;
+        }
     }
+
     #[cfg(not(windows))]
     {
         let pid = nix::unistd::Pid::from_raw(process.id() as i32);
         let _ = nix::sys::signal::kill(pid, nix::sys::signal::SIGTERM);
+        for _ in 0..100 {
+            match process.try_wait() {
+                Ok(Some(_)) => return, // already reaped — skip the wait below
+                Ok(None) => std::thread::sleep(std::time::Duration::from_millis(50)),
+                Err(e) => {
+                    log::warn!("failed to check Spin process status after SIGTERM: {e}");
+                    return;
+                }
+            }
+        }
+        log::warn!("Spin did not exit within ~5s of SIGTERM; escalating to SIGKILL");
     }
+    // Hard-kill the process. On Windows this is the only termination
+    // (TerminateProcess); on Unix it's the SIGKILL
+    let _ = process.kill();
+
+    let _ = process.wait();
 }
 
 /// How this Spin instance is communicating with the outside world


### PR DESCRIPTION
Three small test-reliability fixes:

- **WASI HTTP p3 fixture:** `test_wasi_http_p3_double_echo` ran the p2 fixture; point it at `wasi-http-p3-streaming`.
- **Plugin uninstall:** the cleanup `Drop` now sets `SPIN_DATA_DIR=./plugins` (matching install) so uninstall doesn't fail/panic.
- **Process teardown:** `kill_process` now SIGTERMs with a ~5s grace, escalates to SIGKILL, and reaps with `wait()` — no more stray/zombie Spin processes (Windows hard-kills + reaps).

