### PR TITLE
Set `spin new` target environment via environment variable

### DIFF
--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -80,7 +80,7 @@ pub struct TemplateNewCommandCore {
 pub struct NewCommand {
     /// The Spin platform or runtime for which you want to develop the application.
     /// If present, Spin will offer only templates tailored for that environment.
-    #[clap(long, short = 'E')]
+    #[clap(long, short = 'E', env = "SPIN_NEW_DEFAULT_ENVIRONMENT")]
     #[arg(add = clap_complete::ArgValueCandidates::new(crate::completions::environments))]
     target_environment: Option<String>,
 


### PR DESCRIPTION
Fixes #3568.

Provides an environment variable, `SPIN_NEW_DEFAULT_ENVIRONMENT`, as an equivalent for `spin new -E`.

This allows developers who are always interested in the same deployment environment to set it in their `~/.profile` or equivalent and never have to type it again.

The env var is _specifically_ for `spin new`.  I deliberately didn't alias it for `spin plugins install` or `spin plugins list`, because that would break their behaviour: the `-E` there means "list or install the plugins for this environment," so applying a `.profile` env var to it would mean you could never list or install any other plugins, which would cause unrest.
