### PR TITLE
Update CI to Rust 1.94

### DIFF
--- a/.github/actions/spin-ci-dependencies/action.yml
+++ b/.github/actions/spin-ci-dependencies/action.yml
@@ -8,7 +8,7 @@ inputs:
     type: bool
   rust-version:
     description: 'Rust version to setup'
-    default: '1.93'
+    default: '1.94'
     required: false
     type: string
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ concurrency:
 
 env:
   CARGO_TERM_COLOR: always
-  RUST_VERSION: '1.93'
+  RUST_VERSION: '1.94'
 
 jobs:
   dependency-review:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  RUST_VERSION: '1.93'
+  RUST_VERSION: '1.94'
 
 jobs:
   build-and-sign:

--- a/examples/open-ai-rust/Cargo.toml
+++ b/examples/open-ai-rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "open-ai-rust"
 authors = ["Spin Framework Contributors"]
 description = "Example showing using openAI with Spin"
 version = "0.1.0"
-rust-version = "1.93"
+rust-version = "1.94"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
There's a rumour going around that Wasmtime 46 needs Rust 1.94.  Let's see what fresh hell Clippy has in store for us!
