### PR TITLE
Add metrics to connection semaphore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8591,6 +8591,7 @@ dependencies = [
  "spin-app",
  "spin-build",
  "spin-common",
+ "spin-connection-semaphore",
  "spin-dependency-wit",
  "spin-doctor",
  "spin-environments",
@@ -8691,6 +8692,7 @@ dependencies = [
  "spin-telemetry",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ watchexec-filterer-globset = "8.0"
 spin-app = { path = "crates/app" }
 spin-build = { path = "crates/build" }
 spin-common = { path = "crates/common" }
+spin-connection-semaphore = { path = "crates/connection-semaphore" }
 spin-dependency-wit = { path = "crates/dependency-wit" }
 spin-factors-executor = { path = "crates/factors-executor" }
 spin-doctor = { path = "crates/doctor" }

--- a/crates/connection-semaphore/Cargo.toml
+++ b/crates/connection-semaphore/Cargo.toml
@@ -12,6 +12,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt"] }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
 
 [lints]
 workspace = true

--- a/crates/connection-semaphore/src/lib.rs
+++ b/crates/connection-semaphore/src/lib.rs
@@ -1,45 +1,88 @@
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::anyhow;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore, TryAcquireError};
 use tokio::time;
 
+/// A semaphore paired with its configured permit limit, so utilization can be computed.
+///
+/// The two are bound together because a semaphore's `available_permits()` is meaningless for
+/// utilization without knowing the limit it was created with. Construct this where the semaphore
+/// is created so the pair can never drift.
+#[derive(Clone, Debug)]
+pub struct LimitedSemaphore {
+    sem: Arc<Semaphore>,
+    limit: usize,
+}
+
+impl LimitedSemaphore {
+    /// Creates a semaphore with `limit` permits, paired with that limit. Constructing the
+    /// semaphore here (rather than accepting a pre-built one) guarantees the stored limit always
+    /// matches the semaphore's actual capacity.
+    pub fn new(limit: usize) -> Self {
+        Self {
+            sem: Arc::new(Semaphore::new(limit)),
+            limit,
+        }
+    }
+
+    /// The configured permit limit this semaphore was created with.
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// Returns a handle to the underlying semaphore so tests can inspect `available_permits()`
+    /// or acquire permits out-of-band to drive contention.
+    #[cfg(test)]
+    pub(crate) fn semaphore(&self) -> Arc<Semaphore> {
+        self.sem.clone()
+    }
+}
+
 /// Wraps an optional global and an optional factor-specific semaphore.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ConnectionSemaphore {
-    global: Option<Arc<Semaphore>>,
-    factor_specific: Option<Arc<Semaphore>>,
+    /// Optional semaphore shared across factors.
+    /// When configured, this limits the total number of concurrent connections across all factors that
+    /// share this global instance.
+    global: Option<LimitedSemaphore>,
+    /// Optional semaphore specific to this factor.
+    ///
+    /// When configured, this limits the number of concurrent connections of this specific factor,
+    /// independent of the global limit.
+    factor_specific: Option<LimitedSemaphore>,
+    /// Label for this factor, used in emitted telemetry to differentiate factors sharing a global pool.
     factor: &'static str,
+    /// Optional duration to wait for a permit before giving up and returning an error.
+    ///
+    /// When `None`, `acquire()` will wait indefinitely until a permit is available.
     wait_timeout: Option<Duration>,
+    /// Identifier of the app this semaphore is scoped to.
+    ///
+    /// Used as a structured field on rejection tracing events so operators can attribute breaches to a tenant
+    /// without putting `app_id` on any metric label (which would explode cardinality).
+    app_id: Arc<str>,
+    /// Edge-trigger guard for the rejection warning.
+    ///
+    /// Set to `true` once a rejection has been logged, and reset to `false` on the next successful acquire.
+    rejecting: Arc<AtomicBool>,
 }
 
 impl ConnectionSemaphore {
     /// Creates a new `ConnectionSemaphore`.
     ///
-    /// `global` is an optional semaphore shared across factors; `factor_specific_limit`
-    /// is an optional permit limit for this specific factor. If either is `None`, that level of
-    /// limiting is disabled. `factor` is a label used in emitted telemetry, and `wait_timeout` is
-    /// an optional duration to wait for a permit before giving up and returning an error.
+    /// `global` is an optional [`LimitedSemaphore`] shared across factors; `factor_specific` is an
+    /// optional [`LimitedSemaphore`] for this specific factor. If either is `None`, that level of
+    /// limiting is disabled. `factor` is a label used in emitted telemetry, `app_id` identifies
+    /// the owning app for tenant-attribution in tracing events, and `wait_timeout` is an optional
+    /// duration to wait for a permit before giving up and returning an error.
     pub fn new(
-        global: Option<Arc<Semaphore>>,
-        factor_specific_limit: Option<usize>,
+        global: Option<LimitedSemaphore>,
+        factor_specific: Option<LimitedSemaphore>,
         factor: &'static str,
-        wait_timeout: Option<Duration>,
-    ) -> Self {
-        Self {
-            global,
-            factor_specific: factor_specific_limit.map(|n| Arc::new(Semaphore::new(n))),
-            factor,
-            wait_timeout,
-        }
-    }
-
-    #[cfg(test)]
-    pub(crate) fn from_raw(
-        global: Option<Arc<Semaphore>>,
-        factor_specific: Option<Arc<Semaphore>>,
-        factor: &'static str,
+        app_id: Arc<str>,
         wait_timeout: Option<Duration>,
     ) -> Self {
         Self {
@@ -47,7 +90,15 @@ impl ConnectionSemaphore {
             factor_specific,
             factor,
             wait_timeout,
+            app_id,
+            rejecting: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Records that the semaphore just served a successful acquire, re-arming the rejection
+    /// warning so the next rejection is logged again.
+    fn mark_serving(&self) {
+        self.rejecting.store(false, Ordering::Relaxed);
     }
 
     /// Acquire both configured semaphore slots, returning a permit that holds
@@ -67,13 +118,26 @@ impl ConnectionSemaphore {
                 kind = self.factor,
                 waited = false
             );
+            self.mark_serving();
+            self.emit_utilization();
             return Ok(permit);
         }
 
         match self.wait_timeout {
             Some(timeout) => time::timeout(timeout, self.acquire_inner())
                 .await
-                .map_err(|_| anyhow!("connection semaphore timed out after {timeout:?}"))?,
+                .map_err(|_| {
+                    // Log a warning on the first rejection to make it easier for operators
+                    // to notice when limits are being hit, but avoid spamming.
+                    if !self.rejecting.swap(true, Ordering::Relaxed) {
+                        tracing::warn!(
+                            kind = self.factor,
+                            app_id = %self.app_id,
+                            "connection permit rejected: timeout waiting for permit"
+                        );
+                    }
+                    anyhow!("connection semaphore timed out after {timeout:?}")
+                })?,
             None => self.acquire_inner().await,
         }
     }
@@ -106,13 +170,13 @@ impl ConnectionSemaphore {
         // Acquire factor-specific first, then global. This ensures we never hold
         // the global permit while blocking on factor-specific backlog.
         let factor_specific = match &self.factor_specific {
-            Some(f) => Some(acquire_one(f, &mut waited, "factor").await?),
+            Some(f) => Some(acquire_one(&f.sem, &mut waited, "factor").await?),
             None => None,
         };
         // It's fine to hold the factor-specific permit while waiting for the global slot, since
         // other consumers of the factor-specific would also end up waiting for the same global slot.
         let global = match &self.global {
-            Some(g) => Some(acquire_one(g, &mut waited, "global").await?),
+            Some(g) => Some(acquire_one(&g.sem, &mut waited, "global").await?),
             None => None,
         };
 
@@ -128,10 +192,13 @@ impl ConnectionSemaphore {
             kind = factor,
             waited = waited
         );
+        self.mark_serving();
+        self.emit_utilization();
 
         Ok(ConnectionPermit {
-            _global: global,
-            _factor_specific: factor_specific,
+            global_permit: global,
+            factor_specific_permit: factor_specific,
+            semaphore: self.clone(),
         })
     }
 
@@ -148,6 +215,8 @@ impl ConnectionSemaphore {
                     kind = self.factor,
                     waited = false
                 );
+                self.mark_serving();
+                self.emit_utilization();
                 Some(permit)
             }
             Err(limit) => {
@@ -156,6 +225,16 @@ impl ConnectionSemaphore {
                     kind = self.factor,
                     limit = limit
                 );
+                // Log a warning on the first rejection to make it easier for operators
+                // to notice when limits are being hit, but avoid spamming.
+                if !self.rejecting.swap(true, Ordering::Relaxed) {
+                    tracing::warn!(
+                        kind = self.factor,
+                        app_id = %self.app_id,
+                        limit = limit,
+                        "connection permit rejected: limit exhausted"
+                    );
+                }
                 None
             }
         }
@@ -169,7 +248,7 @@ impl ConnectionSemaphore {
     fn try_acquire_permits(&self) -> Result<ConnectionPermit, &'static str> {
         // Acquire global first. If it fails, nothing is consumed.
         let global = match &self.global {
-            Some(s) => match s.clone().try_acquire_owned() {
+            Some(s) => match s.sem.clone().try_acquire_owned() {
                 Ok(p) => Some(p),
                 Err(_) => return Err("global"),
             },
@@ -178,28 +257,95 @@ impl ConnectionSemaphore {
         // Now attempt the factor-specific permit.
         // On failure, `global` is dropped here, releasing the global slot.
         let factor_specific = match &self.factor_specific {
-            Some(s) => match s.clone().try_acquire_owned() {
+            Some(s) => match s.sem.clone().try_acquire_owned() {
                 Ok(p) => Some(p),
                 Err(_) => return Err("factor"),
             },
             None => None,
         };
         Ok(ConnectionPermit {
-            _global: global,
-            _factor_specific: factor_specific,
+            global_permit: global,
+            factor_specific_permit: factor_specific,
+            semaphore: self.clone(),
         })
     }
+
+    /// Emits one sample each of factor-specific and global utilization (0.0..=1.0) as histograms,
+    /// for whichever limits are configured.
+    ///
+    /// Factor-specific utilization is labeled with `kind` (one series per factor). Global
+    /// utilization carries no `kind` label: the global pool is shared across factors, so its
+    /// utilization is a single value — labeling by factor would emit redundant series all
+    /// reporting the same number.
+    fn emit_utilization(&self) {
+        if let Some(util) = utilization(self.factor_specific.as_ref()) {
+            spin_telemetry::histogram!(
+                outbound_connection_factor_utilization = util,
+                kind = self.factor
+            );
+        }
+        if let Some(util) = utilization(self.global.as_ref()) {
+            spin_telemetry::histogram!(outbound_connection_global_utilization = util);
+        }
+    }
+}
+
+/// Custom histogram bucket boundaries for the utilization metrics this crate emits.
+///
+/// Both `outbound_connection_factor_utilization` and `outbound_connection_global_utilization` are
+/// recorded on a 0.0..=1.0 scale, so the OTel default boundaries (tuned for millisecond durations,
+/// topping out at 10000) would collapse every sample into the lowest bucket. These boundaries sit
+/// near typical alerting cutoffs (75%, 90%, 95%, 99%). Pass the result to `spin_telemetry::init`.
+///
+/// The metric names here must match the identifiers used in the `histogram!` calls above.
+pub fn metric_histogram_buckets() -> Vec<spin_telemetry::HistogramBuckets> {
+    let boundaries = vec![0.25, 0.5, 0.75, 0.9, 0.95, 0.99];
+    [
+        "outbound_connection_factor_utilization",
+        "outbound_connection_global_utilization",
+    ]
+    .into_iter()
+    .map(|metric_name| spin_telemetry::HistogramBuckets {
+        metric_name,
+        boundaries: boundaries.clone(),
+    })
+    .collect()
+}
+
+/// Computes utilization (0.0..=1.0) for a limited semaphore, or `None` when no limit is
+/// configured (or the limit is zero, which would make utilization undefined).
+fn utilization(limited: Option<&LimitedSemaphore>) -> Option<f64> {
+    let limited = limited?;
+    if limited.limit == 0 {
+        return None;
+    }
+    let in_flight = limited
+        .limit
+        .saturating_sub(limited.sem.available_permits());
+    Some(in_flight as f64 / limited.limit as f64)
 }
 
 /// Holds up to two semaphore permits (global + factor-specific).
 /// Both permits are released when this value is dropped.
-/// All-`None` fields are valid and represent the no-limits case.
-///
-/// Fields are intentionally prefixed with `_` — they exist solely to be dropped.
+/// All-`None` permit fields are valid and represent the no-limits case.
 #[derive(Debug)]
 pub struct ConnectionPermit {
-    _global: Option<OwnedSemaphorePermit>,
-    _factor_specific: Option<OwnedSemaphorePermit>,
+    global_permit: Option<OwnedSemaphorePermit>,
+    factor_specific_permit: Option<OwnedSemaphorePermit>,
+    /// The issuing semaphore, retained so `Drop` can re-sample utilization *after* the inner
+    /// permits are released (its `LimitedSemaphore`s share the same `Arc`s these permits came from).
+    semaphore: ConnectionSemaphore,
+}
+
+impl Drop for ConnectionPermit {
+    fn drop(&mut self) {
+        // Explicitly release the inner permits before sampling so the histogram
+        // reflects post-release state. Without this, the implicit field drop would
+        // happen after our body — meaning we'd read the *pre-release* available count.
+        self.global_permit.take();
+        self.factor_specific_permit.take();
+        self.semaphore.emit_utilization();
+    }
 }
 
 #[cfg(test)]
@@ -208,7 +354,7 @@ mod tests {
 
     #[tokio::test]
     async fn no_limits_acquire_always_succeeds() {
-        let sem = ConnectionSemaphore::new(None, None, "test", None);
+        let sem = ConnectionSemaphore::new(None, None, "test", Arc::from("test-app"), None);
         let permit = sem.acquire().await.expect("should succeed");
         drop(permit);
         let _permit2 = sem.acquire().await.expect("should succeed again");
@@ -216,7 +362,7 @@ mod tests {
 
     #[test]
     fn no_limits_try_acquire_always_succeeds() {
-        let sem = ConnectionSemaphore::new(None, None, "test", None);
+        let sem = ConnectionSemaphore::new(None, None, "test", Arc::from("test-app"), None);
         let permit = sem.try_acquire().expect("should succeed");
         drop(permit);
         let _permit2 = sem.try_acquire().expect("should succeed again");
@@ -224,21 +370,28 @@ mod tests {
 
     #[test]
     fn global_limit_only_exhausted() {
-        let global = Arc::new(Semaphore::new(1));
-        let sem = ConnectionSemaphore::new(Some(global.clone()), None, "test", None);
+        let global = LimitedSemaphore::new(1);
+        let global_sem = global.semaphore();
+        let sem = ConnectionSemaphore::new(Some(global), None, "test", Arc::from("test-app"), None);
         let permit1 = sem.try_acquire().expect("first should succeed");
         assert!(
             sem.try_acquire().is_none(),
             "second should fail: global exhausted"
         );
         drop(permit1);
-        assert_eq!(global.available_permits(), 1);
+        assert_eq!(global_sem.available_permits(), 1);
         let _permit3 = sem.try_acquire().expect("after release should succeed");
     }
 
     #[test]
     fn factor_limit_only_exhausted() {
-        let sem = ConnectionSemaphore::new(None, Some(1), "test", None);
+        let sem = ConnectionSemaphore::new(
+            None,
+            Some(LimitedSemaphore::new(1)),
+            "test",
+            Arc::from("test-app"),
+            None,
+        );
         let permit1 = sem.try_acquire().expect("first should succeed");
         assert!(
             sem.try_acquire().is_none(),
@@ -250,20 +403,26 @@ mod tests {
 
     #[test]
     fn both_limits_global_exhausted_first() {
-        let global = Arc::new(Semaphore::new(1));
-        let factor = Arc::new(Semaphore::new(2));
-        let sem =
-            ConnectionSemaphore::from_raw(Some(global.clone()), Some(factor.clone()), "test", None);
+        let global = LimitedSemaphore::new(1);
+        let factor = LimitedSemaphore::new(2);
+        let factor_sem = factor.semaphore();
+        let sem = ConnectionSemaphore::new(
+            Some(global),
+            Some(factor),
+            "test",
+            Arc::from("test-app"),
+            None,
+        );
 
         let permit1 = sem.try_acquire().expect("first should succeed");
         // After permit1: global=0, factor=1
-        let factor_before = factor.available_permits();
+        let factor_before = factor_sem.available_permits();
 
         // Second try_acquire should fail because global is exhausted.
         assert!(sem.try_acquire().is_none(), "should fail: global exhausted");
         // Factor must NOT have been consumed by the failed attempt.
         assert_eq!(
-            factor.available_permits(),
+            factor_sem.available_permits(),
             factor_before,
             "factor permits should not be consumed when global is exhausted"
         );
@@ -272,25 +431,36 @@ mod tests {
 
     #[test]
     fn both_limits_factor_exhausted_global_released() {
-        let global = Arc::new(Semaphore::new(2));
-        let factor = Arc::new(Semaphore::new(1));
-        let sem =
-            ConnectionSemaphore::from_raw(Some(global.clone()), Some(factor.clone()), "test", None);
+        let global = LimitedSemaphore::new(2);
+        let factor = LimitedSemaphore::new(1);
+        let global_sem = global.semaphore();
+        let sem = ConnectionSemaphore::new(
+            Some(global),
+            Some(factor),
+            "test",
+            Arc::from("test-app"),
+            None,
+        );
 
         let permit1 = sem.try_acquire().expect("first should succeed");
         // Global still has 1, factor exhausted
         let result = sem.try_acquire();
         assert!(result.is_none(), "should fail: factor exhausted");
         // Global slot must have been released (back to 1)
-        assert_eq!(global.available_permits(), 1);
+        assert_eq!(global_sem.available_permits(), 1);
         drop(permit1);
-        assert_eq!(global.available_permits(), 2);
+        assert_eq!(global_sem.available_permits(), 2);
     }
 
     #[tokio::test]
     async fn acquire_waits_for_release() {
-        let global = Arc::new(Semaphore::new(1));
-        let sem = ConnectionSemaphore::new(Some(global.clone()), None, "test", None);
+        let sem = ConnectionSemaphore::new(
+            Some(LimitedSemaphore::new(1)),
+            None,
+            "test",
+            Arc::from("test-app"),
+            None,
+        );
 
         let permit = sem.try_acquire().expect("first should succeed");
 
@@ -307,15 +477,21 @@ mod tests {
     /// a global permit while waiting — so other connection types aren't blocked.
     #[tokio::test]
     async fn acquire_releases_global_while_waiting_for_factor() {
-        let global = Arc::new(Semaphore::new(1));
-        let factor = Arc::new(Semaphore::new(1));
-        let sem =
-            ConnectionSemaphore::from_raw(Some(global.clone()), Some(factor.clone()), "test", None);
+        let global = LimitedSemaphore::new(1);
+        let factor = LimitedSemaphore::new(1);
+        let global_sem = global.semaphore();
+        let factor_sem = factor.semaphore();
+        let sem = ConnectionSemaphore::new(
+            Some(global),
+            Some(factor),
+            "test",
+            Arc::from("test-app"),
+            None,
+        );
 
         // Exhaust factor-specific from outside.
-        let _factor_hold = factor.clone().acquire_owned().await.unwrap();
+        let _factor_hold = factor_sem.acquire_owned().await.unwrap();
 
-        let global_clone = global.clone();
         let sem_clone = sem.clone();
         let handle = tokio::spawn(async move {
             sem_clone
@@ -330,7 +506,7 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert_eq!(
-            global_clone.available_permits(),
+            global_sem.available_permits(),
             1,
             "global should be free while acquire() waits for factor-specific"
         );
@@ -341,11 +517,11 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_times_out_when_semaphore_exhausted() {
-        let global = Arc::new(Semaphore::new(1));
         let sem = ConnectionSemaphore::new(
-            Some(global.clone()),
+            Some(LimitedSemaphore::new(1)),
             None,
             "test",
+            Arc::from("test-app"),
             Some(Duration::from_millis(10)),
         );
 
@@ -355,6 +531,196 @@ mod tests {
         assert!(
             err.to_string().contains("timed out"),
             "error message should mention timed out: {err}"
+        );
+    }
+
+    /// Captures the f64 values logged for a given tracing field name, regardless of
+    /// surrounding span context. Used to inspect the histogram samples that
+    /// `spin_telemetry::histogram!` emits as `tracing::trace!` events.
+    mod capture {
+        use std::sync::{Arc, Mutex};
+        use tracing::field::{Field, Visit};
+        use tracing_subscriber::layer::{Context, Layer};
+
+        #[derive(Clone, Default)]
+        pub(super) struct CapturedValues(pub Arc<Mutex<Vec<f64>>>);
+
+        impl CapturedValues {
+            pub fn snapshot(&self) -> Vec<f64> {
+                self.0.lock().unwrap().clone()
+            }
+        }
+
+        pub(super) struct CaptureLayer {
+            pub field_name: &'static str,
+            pub sink: CapturedValues,
+        }
+
+        impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                let mut v = FieldVisitor {
+                    target: self.field_name,
+                    found: None,
+                };
+                event.record(&mut v);
+                if let Some(val) = v.found {
+                    self.sink.0.lock().unwrap().push(val);
+                }
+            }
+        }
+
+        struct FieldVisitor {
+            target: &'static str,
+            found: Option<f64>,
+        }
+
+        impl Visit for FieldVisitor {
+            fn record_f64(&mut self, field: &Field, value: f64) {
+                if field.name() == self.target {
+                    self.found = Some(value);
+                }
+            }
+            fn record_i64(&mut self, _: &Field, _: i64) {}
+            fn record_u64(&mut self, _: &Field, _: u64) {}
+            fn record_bool(&mut self, _: &Field, _: bool) {}
+            fn record_str(&mut self, _: &Field, _: &str) {}
+            fn record_debug(&mut self, _: &Field, _: &dyn std::fmt::Debug) {}
+        }
+    }
+
+    fn with_capture<R>(field_name: &'static str, f: impl FnOnce() -> R) -> (R, Vec<f64>) {
+        use tracing_subscriber::layer::SubscriberExt;
+        let sink = capture::CapturedValues::default();
+        let layer = capture::CaptureLayer {
+            field_name,
+            sink: sink.clone(),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let result = tracing::subscriber::with_default(subscriber, f);
+        (result, sink.snapshot())
+    }
+
+    const UTIL_FIELD: &str = "histogram.outbound_connection_factor_utilization";
+    const GLOBAL_UTIL_FIELD: &str = "histogram.outbound_connection_global_utilization";
+
+    #[test]
+    fn utilization_emitted_on_acquire_and_drop_reflects_post_release_state() {
+        let (_, samples) = with_capture(UTIL_FIELD, || {
+            let sem = ConnectionSemaphore::new(
+                None,
+                Some(LimitedSemaphore::new(2)),
+                "test",
+                Arc::from("test-app"),
+                None,
+            );
+            let p1 = sem.try_acquire().expect("first acquire");
+            // After acquire: 1/2 in use
+            let p2 = sem.try_acquire().expect("second acquire");
+            // After acquire: 2/2 in use
+            drop(p1);
+            // After release: 1/2 in use
+            drop(p2);
+            // After release: 0/2 in use
+        });
+        assert_eq!(
+            samples,
+            vec![0.5, 1.0, 0.5, 0.0],
+            "expected acquire/drop transitions at 0.5, 1.0, 0.5, 0.0; got {samples:?}"
+        );
+    }
+
+    #[test]
+    fn no_utilization_emitted_when_factor_limit_is_none() {
+        let (_, samples) = with_capture(UTIL_FIELD, || {
+            let sem = ConnectionSemaphore::new(None, None, "test", Arc::from("test-app"), None);
+            let p = sem.try_acquire().expect("acquire");
+            drop(p);
+        });
+        assert!(
+            samples.is_empty(),
+            "expected no utilization samples when factor limit unset; got {samples:?}"
+        );
+    }
+
+    #[test]
+    fn global_utilization_emitted_on_acquire_and_drop_reflects_post_release_state() {
+        let (_, samples) = with_capture(GLOBAL_UTIL_FIELD, || {
+            let sem = ConnectionSemaphore::new(
+                Some(LimitedSemaphore::new(2)),
+                None,
+                "test",
+                Arc::from("test-app"),
+                None,
+            );
+            let p1 = sem.try_acquire().expect("first acquire");
+            // After acquire: 1/2 in use
+            let p2 = sem.try_acquire().expect("second acquire");
+            // After acquire: 2/2 in use
+            drop(p1);
+            // After release: 1/2 in use
+            drop(p2);
+            // After release: 0/2 in use
+        });
+        assert_eq!(
+            samples,
+            vec![0.5, 1.0, 0.5, 0.0],
+            "expected acquire/drop transitions at 0.5, 1.0, 0.5, 0.0; got {samples:?}"
+        );
+    }
+
+    #[test]
+    fn no_global_utilization_emitted_when_global_limit_is_none() {
+        let (_, samples) = with_capture(GLOBAL_UTIL_FIELD, || {
+            let sem = ConnectionSemaphore::new(
+                None,
+                Some(LimitedSemaphore::new(2)),
+                "test",
+                Arc::from("test-app"),
+                None,
+            );
+            let p = sem.try_acquire().expect("acquire");
+            drop(p);
+        });
+        assert!(
+            samples.is_empty(),
+            "expected no global utilization samples when global limit unset; got {samples:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn utilization_emitted_on_slow_path_acquire() {
+        use tracing_subscriber::layer::SubscriberExt;
+        let sink = capture::CapturedValues::default();
+        let layer = capture::CaptureLayer {
+            field_name: UTIL_FIELD,
+            sink: sink.clone(),
+        };
+        let subscriber = tracing_subscriber::registry().with(layer);
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let factor = LimitedSemaphore::new(1);
+        let factor_sem = factor.semaphore();
+        let sem = ConnectionSemaphore::new(
+            None,
+            Some(factor),
+            "test",
+            Arc::from("test-app"),
+            Some(Duration::from_secs(1)),
+        );
+        let blocker = factor_sem.acquire_owned().await.unwrap();
+        let sem_clone = sem.clone();
+        let handle = tokio::spawn(async move { sem_clone.acquire().await });
+        tokio::task::yield_now().await;
+        drop(blocker);
+        let permit = handle.await.expect("task").expect("acquire");
+        drop(permit);
+
+        let samples = sink.snapshot();
+        // Slow-path acquire fills the only slot (1.0), then drop releases it (0.0).
+        assert_eq!(
+            samples,
+            vec![1.0, 0.0],
+            "expected slow-path acquire and drop samples; got {samples:?}"
         );
     }
 }

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -56,12 +56,13 @@ impl Factor for OutboundHttpFactor {
         mut ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
         let config = ctx.take_runtime_config().unwrap_or_default();
+        let networking = ctx.app_state::<OutboundNetworkingFactor>().ok();
 
         Ok(AppState {
             wasi_http_clients: wasi::HttpClients::new(config.connection_pooling_enabled),
             connection_pooling_enabled: config.connection_pooling_enabled,
             semaphore: build_connection_semaphore(
-                ctx.app_state::<OutboundNetworkingFactor>().ok(),
+                networking,
                 "http",
                 config.max_concurrent_connections,
                 config.wait_timeout,

--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -1201,6 +1201,7 @@ fn record_content_length_header(span: &Span, headers: &HeaderMap, attr_name: &'s
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spin_factor_outbound_networking::LimitedSemaphore;
 
     /// Regression test: the connect timeout must cover permit acquisition, not
     /// just the TCP handshake.  Before the fix, a fully-saturated semaphore
@@ -1210,7 +1211,13 @@ mod tests {
     async fn connect_timeout_applies_to_permit_acquisition() {
         // Create a semaphore with exactly 1 permit and immediately exhaust it, leaving
         // 0 permits available.  This simulates all outbound-connection slots being occupied.
-        let conn_semaphore = ConnectionSemaphore::new(None, Some(1), "test", None);
+        let conn_semaphore = ConnectionSemaphore::new(
+            None,
+            Some(LimitedSemaphore::new(1)),
+            "test",
+            "app-id".into(),
+            None,
+        );
         let _held = conn_semaphore
             .try_acquire()
             .expect("exhausting the single permit");

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -58,10 +58,11 @@ impl Factor for OutboundMqttFactor {
         mut ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
         let config = ctx.take_runtime_config().unwrap_or_default();
+        let networking = ctx.app_state::<OutboundNetworkingFactor>().ok();
 
         Ok(AppState {
             semaphore: build_connection_semaphore(
-                ctx.app_state::<OutboundNetworkingFactor>().ok(),
+                networking,
                 "mqtt",
                 config.max_connections,
                 config.wait_timeout,

--- a/crates/factor-outbound-mysql/src/lib.rs
+++ b/crates/factor-outbound-mysql/src/lib.rs
@@ -44,10 +44,11 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundMysqlFactor<C> {
         mut ctx: spin_factors::ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
         let config = ctx.take_runtime_config().unwrap_or_default();
+        let networking = ctx.app_state::<OutboundNetworkingFactor>().ok();
 
         Ok(AppState {
             semaphore: build_connection_semaphore(
-                ctx.app_state::<OutboundNetworkingFactor>().ok(),
+                networking,
                 "mysql",
                 config.max_connections,
                 config.wait_timeout,

--- a/crates/factor-outbound-networking/src/lib.rs
+++ b/crates/factor-outbound-networking/src/lib.rs
@@ -12,15 +12,15 @@ use spin_factors::{
     ConfigureAppContext, Error, Factor, FactorInstanceBuilder, PrepareContext, RuntimeFactors,
     anyhow::{self, Context},
 };
+use spin_locked_app::APP_NAME_KEY;
 use spin_outbound_networking_config::allowed_hosts::{DisallowedHostHandler, OutboundAllowedHosts};
-use tokio::sync::Semaphore;
 use url::Url;
 
 use crate::{
     allowed_hosts::allowed_outbound_hosts, runtime_config::RuntimeConfig, tls::TlsClientConfigs,
 };
 pub use allowed_hosts::validate_service_chaining_for_components;
-pub use spin_connection_semaphore::{ConnectionPermit, ConnectionSemaphore};
+pub use spin_connection_semaphore::{ConnectionPermit, ConnectionSemaphore, LimitedSemaphore};
 
 pub use crate::tls::{ComponentTlsClientConfigs, TlsClientConfig};
 use config::allowed_hosts::AllowedHostsConfig;
@@ -78,8 +78,9 @@ impl Factor for OutboundNetworkingFactor {
 
         let blocked_networks = BlockedNetworks::new(block_networks, block_private_networks);
         let tls_client_configs = TlsClientConfigs::new(client_tls_configs)?;
-        let global_connection_semaphore =
-            max_total_connections.map(|n| Arc::new(Semaphore::new(n)));
+        // Build the shared global semaphore from its limit, so the two are bound together from
+        // creation as the pair is plumbed into per-factor `ConnectionSemaphore`s.
+        let global_connection_semaphore = max_total_connections.map(LimitedSemaphore::new);
 
         if let (Some(socket_cap), Some(global_cap)) =
             (max_socket_connections, max_total_connections)
@@ -92,12 +93,19 @@ impl Factor for OutboundNetworkingFactor {
             );
         }
 
+        let app_id: Arc<str> = ctx
+            .app()
+            .get_metadata(APP_NAME_KEY)?
+            .unwrap_or_else(|| "<unnamed>".into())
+            .into();
+
         let socket_connection_semaphore =
             if max_socket_connections.is_some() || global_connection_semaphore.is_some() {
                 Some(ConnectionSemaphore::new(
                     global_connection_semaphore.clone(),
-                    max_socket_connections,
+                    max_socket_connections.map(LimitedSemaphore::new),
                     "wasi-sockets",
+                    app_id.clone(),
                     wait_timeout,
                 ))
             } else {
@@ -110,7 +118,7 @@ impl Factor for OutboundNetworkingFactor {
             tls_client_configs,
             socket_connection_semaphore,
             global_connection_semaphore,
-            max_total_connections,
+            app_id,
         })
     }
 
@@ -229,11 +237,21 @@ pub struct AppState {
     /// Pre-built semaphore for TCP/UDP socket quota enforcement (global + socket-specific).
     /// `None` means no limits are configured.
     socket_connection_semaphore: Option<ConnectionSemaphore>,
-    /// App-wide semaphore capping total concurrent outbound connections across ALL types.
-    /// `None` means unlimited.
-    global_connection_semaphore: Option<Arc<Semaphore>>,
-    /// The configured global connection limit (for warning comparisons in other factors).
-    max_total_connections: Option<usize>,
+    /// App-wide semaphore capping total concurrent outbound connections across ALL types,
+    /// paired with its configured limit (the latter is used for warning comparisons in other
+    /// factors). `None` means unlimited.
+    global_connection_semaphore: Option<LimitedSemaphore>,
+    /// Identifier of this app, used for tenant attribution on tracing events emitted by
+    /// outbound factors' connection semaphores. Resolved once at configure-app time.
+    app_id: Arc<str>,
+}
+
+impl AppState {
+    /// Returns the app identifier, used by outbound factors when building per-factor
+    /// connection semaphores so rejection tracing events carry tenant attribution.
+    pub fn app_id(&self) -> Arc<str> {
+        self.app_id.clone()
+    }
 }
 
 /// Builds a [`ConnectionSemaphore`] for an outbound factor, incorporating the optional global
@@ -241,16 +259,23 @@ pub struct AppState {
 ///
 /// Emits a warning when the per-factor limit exceeds the global cap (the global limit would
 /// be the effective ceiling in that case).
+///
+/// The app identifier is taken from the networking app state (or `<unnamed>` when networking is
+/// absent) and plumbed through to the semaphore so that rejection tracing events can carry tenant
+/// attribution without app identity appearing on metric labels.
 pub fn build_connection_semaphore(
     networking: Option<&AppState>,
     factor: &'static str,
     factor_limit: Option<usize>,
     wait_timeout: Option<std::time::Duration>,
 ) -> ConnectionSemaphore {
-    if let (Some(per_factor), Some(global_limit)) = (
-        factor_limit,
-        networking.and_then(|n| n.max_total_connections),
-    ) && per_factor > global_limit
+    let app_id = networking
+        .map(|n| n.app_id())
+        .unwrap_or_else(|| Arc::from("<unnamed>"));
+    let global = networking.and_then(|n| n.global_connection_semaphore.clone());
+    if let (Some(per_factor), Some(global_limit)) =
+        (factor_limit, global.as_ref().map(LimitedSemaphore::limit))
+        && per_factor > global_limit
     {
         tracing::warn!(
             "outbound_{factor} max_connections ({per_factor}) exceeds global \
@@ -259,9 +284,10 @@ pub fn build_connection_semaphore(
         );
     }
     ConnectionSemaphore::new(
-        networking.and_then(|n| n.global_connection_semaphore.clone()),
-        factor_limit,
+        global,
+        factor_limit.map(LimitedSemaphore::new),
         factor,
+        app_id,
         wait_timeout,
     )
 }

--- a/crates/factor-outbound-pg/src/lib.rs
+++ b/crates/factor-outbound-pg/src/lib.rs
@@ -54,11 +54,12 @@ impl<CF: ClientFactory> Factor for OutboundPgFactor<CF> {
         for comp in ctx.app().components() {
             client_factories.insert(comp.id().to_string(), Arc::new(CF::default()));
         }
+        let networking = ctx.app_state::<OutboundNetworkingFactor>().ok();
 
         Ok(AppState {
             client_factories,
             semaphore: build_connection_semaphore(
-                ctx.app_state::<OutboundNetworkingFactor>().ok(),
+                networking,
                 "pg",
                 config.max_connections,
                 config.wait_timeout,

--- a/crates/factor-outbound-redis/src/lib.rs
+++ b/crates/factor-outbound-redis/src/lib.rs
@@ -50,10 +50,11 @@ impl Factor for OutboundRedisFactor {
         mut ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
         let config = ctx.take_runtime_config().unwrap_or_default();
+        let networking = ctx.app_state::<OutboundNetworkingFactor>().ok();
 
         Ok(AppState {
             semaphore: build_connection_semaphore(
-                ctx.app_state::<OutboundNetworkingFactor>().ok(),
+                networking,
                 "redis",
                 config.max_connections,
                 config.wait_timeout,

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -13,7 +13,7 @@ opentelemetry-appender-tracing = "0.29"
 opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
 opentelemetry-semantic-conventions = { workspace = true }
 reqwest = { workspace = true }
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
+opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "spec_unstable_logs_enabled", "spec_unstable_metrics_views", "metrics"] }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }
 tracing-opentelemetry = { workspace = true }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -18,6 +18,7 @@ pub mod traces;
 #[cfg(feature = "testing")]
 pub mod testing;
 
+pub use metrics::HistogramBuckets;
 pub use propagation::extract_trace_context;
 pub use propagation::inject_trace_context;
 
@@ -52,7 +53,11 @@ pub use propagation::inject_trace_context;
 /// ```no_run
 /// spin_telemetry::metrics::monotonic_counter!(spin.metric_name = 1, metric_attribute = "value");
 /// ```
-pub fn init(spin_version: String) -> anyhow::Result<()> {
+///
+/// `histogram_buckets` lets callers override the OTel default histogram boundaries for specific
+/// metrics (e.g. those recorded on a 0.0..=1.0 scale rather than millisecond durations). Pass an
+/// empty `Vec` to use the defaults for everything.
+pub fn init(spin_version: String, histogram_buckets: Vec<HistogramBuckets>) -> anyhow::Result<()> {
     // This layer will print all tracing library log messages to stderr.
     let fmt_layer = fmt::layer()
         .with_writer(std::io::stderr)
@@ -80,7 +85,7 @@ pub fn init(spin_version: String) -> anyhow::Result<()> {
 
     let otel_metrics_layer = if otel_metrics_enabled() {
         Some(
-            metrics::otel_metrics_layer(spin_version.clone())
+            metrics::otel_metrics_layer(spin_version.clone(), histogram_buckets)
                 .context("failed to initialize otel metrics")?,
         )
     } else {

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -3,7 +3,10 @@ use opentelemetry::global;
 use opentelemetry_otlp::WithHttpConfig;
 use opentelemetry_sdk::{
     Resource,
-    metrics::{SdkMeterProvider, periodic_reader_with_async_runtime::PeriodicReader},
+    metrics::{
+        Aggregation, Instrument, SdkMeterProvider, Stream, new_view,
+        periodic_reader_with_async_runtime::PeriodicReader,
+    },
     resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
     runtime::Tokio,
 };
@@ -13,6 +16,20 @@ use tracing_subscriber::{Layer, registry::LookupSpan};
 
 use crate::{detector::SpinResourceDetector, env::OtlpProtocol};
 
+/// A custom histogram bucketing for a named metric.
+///
+/// OTel's default histogram boundaries are tuned for millisecond-scale durations (they top out at
+/// 10000). Metrics recorded on a different scale (e.g. a 0.0..=1.0 ratio) need their own
+/// boundaries, or every sample collapses into a single bucket. Callers describe such metrics with
+/// this type and hand them to [`crate::init`]; this crate has no built-in knowledge of which
+/// metrics need it.
+pub struct HistogramBuckets {
+    /// The instrument (metric) name these boundaries apply to.
+    pub metric_name: &'static str,
+    /// Explicit upper bounds for the histogram buckets.
+    pub boundaries: Vec<f64>,
+}
+
 /// Constructs a layer for the tracing subscriber that sends metrics to an OTEL collector.
 ///
 /// It pulls OTEL configuration from the environment based on the variables defined
@@ -20,6 +37,7 @@ use crate::{detector::SpinResourceDetector, env::OtlpProtocol};
 /// [here](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration).
 pub(crate) fn otel_metrics_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
     spin_version: String,
+    histogram_buckets: Vec<HistogramBuckets>,
 ) -> Result<impl Layer<S>> {
     let resource = Resource::builder()
         .with_detectors(&[
@@ -49,10 +67,21 @@ pub(crate) fn otel_metrics_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
     };
 
     let reader = PeriodicReader::builder(exporter, Tokio).build();
-    let meter_provider = SdkMeterProvider::builder()
+    let mut provider_builder = SdkMeterProvider::builder()
         .with_reader(reader)
-        .with_resource(resource)
-        .build();
+        .with_resource(resource);
+    // Apply any caller-supplied histogram bucket overrides as views. This crate stays agnostic
+    // about which metrics need custom boundaries — the owning crate describes them.
+    for buckets in histogram_buckets {
+        provider_builder = provider_builder.with_view(new_view(
+            Instrument::new().name(buckets.metric_name),
+            Stream::new().aggregation(Aggregation::ExplicitBucketHistogram {
+                boundaries: buckets.boundaries,
+                record_min_max: true,
+            }),
+        )?);
+    }
+    let meter_provider = provider_builder.build();
 
     global::set_meter_provider(meter_provider.clone());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,11 @@ pub async fn run() -> anyhow::Result<()> {
     }
 
     let version = build_info();
-    spin_telemetry::init(version.clone()).context("Failed to initialize telemetry")?;
+    spin_telemetry::init(
+        version.clone(),
+        spin_connection_semaphore::metric_histogram_buckets(),
+    )
+    .context("Failed to initialize telemetry")?;
 
     let plugin_help_entries = plugin_help_entries();
 


### PR DESCRIPTION
This adds better metrics to ConnectionSemaphore so that operators have a clearer view when they are reaching limits. 

We now emit a histogram of utilization as well as warnings when limits are reached.