### PR TITLE
chore(MAINTAINERS.md): update vdice as emeritus

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -16,8 +16,9 @@ _Listed in alphabetical order by first name_
 | Radu Matei | radu-matei |
 | Rajat Jindal | rajatjindal |
 | Ryan Levick | rylev |
-| Vaughn Dice | vdice |
 
 ## Emeritus Maintainers
 
-None
+| Name | GitHub Username |
+| --- | --- |
+| Vaughn Dice | vdice |


### PR DESCRIPTION
I will be taking an open-ended sabbatical from software development for a good 6 months at minimum, so per [Spin's governance guidelines](https://github.com/spinframework/governance/blob/main/GOVERNANCE.md#project-maintainers), I'm updating my maintainer status to emeritus.