### PR TITLE
chore(.github): rename spinframeworkbot PR PAT

### DIFF
--- a/.github/workflows/bump-wasmtime.yml
+++ b/.github/workflows/bump-wasmtime.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create Spin PR
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.SPIN_RUST_SDK_RELEASE_PAT }}
+          token: ${{ secrets.SPINFRAMEWORKBOT_PR_PAT }}
           branch: bump-wasmtime/prerelease-${{ steps.wasmtime-release.outputs.last_wasmtime }}
           commit-message: Bump Wasmtime to v${{ steps.wasmtime-release.outputs.last_wasmtime }} prerelease
           title: Bump Wasmtime to v${{ steps.wasmtime-release.outputs.last_wasmtime }} prerelease

--- a/.github/workflows/rust-sdk-release.yml
+++ b/.github/workflows/rust-sdk-release.yml
@@ -47,4 +47,4 @@ jobs:
           committer: spinframeworkbot <202838904+spinframeworkbot@users.noreply.github.com>
           author: spinframeworkbot <202838904+spinframeworkbot@users.noreply.github.com>
           signoff: true
-          token: ${{ secrets.SPIN_RUST_SDK_RELEASE_PAT }}
+          token: ${{ secrets.SPINFRAMEWORKBOT_PR_PAT }}


### PR DESCRIPTION
- renames the PAT to signify its generic purpose for creating PRs in this repo

I've created this new GH secret so this can merge when ready; I'll delete the older `SPIN_RUST_SDK_RELEASE_PAT` secret once this merges.