### PR TITLE
Set package.license.workspace on all crates

### DIFF
--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-app"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-build"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-common"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-core"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/dependency-wit/Cargo.toml
+++ b/crates/dependency-wit/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-dependency-wit"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/doctor/Cargo.toml
+++ b/crates/doctor/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-doctor"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/environments/Cargo.toml
+++ b/crates/environments/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-environments"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/expressions/Cargo.toml
+++ b/crates/expressions/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-expressions"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-key-value"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-otel/Cargo.toml
+++ b/crates/factor-otel/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-otel"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-outbound-http"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-outbound-mqtt/Cargo.toml
+++ b/crates/factor-outbound-mqtt/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-outbound-mqtt"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-outbound-mysql"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/factor-outbound-networking/Cargo.toml
+++ b/crates/factor-outbound-networking/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-outbound-networking"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-outbound-pg/Cargo.toml
+++ b/crates/factor-outbound-pg/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-outbound-pg"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-outbound-redis/Cargo.toml
+++ b/crates/factor-outbound-redis/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-outbound-redis"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/factor-variables/Cargo.toml
+++ b/crates/factor-variables/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-variables"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 spin-core = { path = "../core" }

--- a/crates/factor-wasi/Cargo.toml
+++ b/crates/factor-wasi/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factor-wasi"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }

--- a/crates/factors-derive/Cargo.toml
+++ b/crates/factors-derive/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factors-derive"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [lib]
 proc-macro = true

--- a/crates/factors-test/Cargo.toml
+++ b/crates/factors-test/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factors-test"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 spin-app = { path = "../app" }

--- a/crates/factors/Cargo.toml
+++ b/crates/factors/Cargo.toml
@@ -3,6 +3,7 @@ name = "spin-factors"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
This helps tooling detect licenses correctly.