### PR TITLE
Use latest wkg to publish WITs

### DIFF
--- a/.github/workflows/publish-wit.yml
+++ b/.github/workflows/publish-wit.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install wkg
         shell: bash
-        run: cargo install wkg --git https://github.com/itowlson/wasm-pkg-tools --branch docker-credential-does-not-play-nice-with-schemeful-urls
+        run: cargo install wkg
 
       - name: Login to the GitHub registry
         uses: docker/login-action@v3


### PR DESCRIPTION
Publishing the Spin 4 WITs gives the dreaded "malformed component: invalid leading byte."  (Petition to find a better error!)  I think this is because I used a fork of `wkg` to work around a credential resolution bug that `wkg` had at the time.  `wkg` has moved on; my fork has not.

(cf. https://github.com/spinframework/spin/actions/runs/28415130257/job/84196320110)
