### PR TITLE
Explicitly declare directly used dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ http-body-util = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 redis = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 runtime-tests = { path = "tests/runtime-tests" }
 test-codegen-macro = { path = "crates/test-codegen-macro" }
 test-components = { path = "tests/test-components" }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -14,4 +14,4 @@ spin-locked-app = { path = "../locked-app" }
 [dev-dependencies]
 toml = { workspace = true }
 spin-factors-test = { path = "../factors-test" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/dependency-wit/Cargo.toml
+++ b/crates/dependency-wit/Cargo.toml
@@ -11,11 +11,12 @@ indexmap = { workspace = true }
 spin-loader = { path = "../loader" }
 spin-manifest = { path = "../manifest" }
 spin-serde = { path = "../serde" }
-tokio = { workspace = true, features = ["rt", "time"] }
+tokio = { workspace = true, features = ["fs"] }
 wasmparser = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
 wit-component = { workspace = true, features = ["dummy-module"] }

--- a/crates/environments/Cargo.toml
+++ b/crates/environments/Cargo.toml
@@ -28,7 +28,7 @@ spin-loader = { path = "../loader" }
 spin-manifest = { path = "../manifest" }
 spin-serde = { path = "../serde" }
 toml = { workspace = true }
-tokio = { version = "1.23", features = ["fs"] }
+tokio = { version = "1.23", features = ["fs", "sync", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }
 wac-graph = { workspace = true }
@@ -40,6 +40,7 @@ wit-parser = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { version = "1.23", features = ["macros", "rt"] }
 wit-component = { workspace = true, features = ["dummy-module"] }
 wit-encoder = "0.235"
 

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -13,7 +13,7 @@ http = { workspace = true }
 http-body = { workspace = true }
 http-body-util = { workspace = true }
 hyper = { workspace = true }
-hyper-util = { workspace = true }
+hyper-util = { workspace = true, features = ["client-legacy", "http1", "http2"] }
 pin-project-lite = { workspace = true }
 reqwest = { workspace = true, features = ["gzip"] }
 rustls = { workspace = true }
@@ -24,7 +24,7 @@ spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
 terminal = { path = "../terminal" }
-tokio = { workspace = true, features = ["macros", "rt", "net"] }
+tokio = { workspace = true, features = ["net", "rt", "time"] }
 tokio-rustls = { workspace = true }
 tower-service = { workspace = true }
 tracing = { workspace = true }
@@ -38,6 +38,7 @@ wasmtime-wasi-http = { workspace = true }
 spin-common = { path = "../common" }
 spin-factor-variables = { path = "../factor-variables" }
 spin-factors-test = { path = "../factors-test" }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
 
 [features]

--- a/crates/factor-outbound-mysql/Cargo.toml
+++ b/crates/factor-outbound-mysql/Cargo.toml
@@ -26,13 +26,14 @@ spin-resource-table = { path = "../table" }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }
 spin-wasi-async = { path = "../wasi-async" }
-tokio = { workspace = true, features = ["rt-multi-thread", "sync"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
 tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
 spin-factor-variables = { path = "../factor-variables" }
 spin-factors-test = { path = "../factors-test" }
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/factor-sqlite/Cargo.toml
+++ b/crates/factor-sqlite/Cargo.toml
@@ -18,7 +18,7 @@ spin-locked-app = { path = "../locked-app" }
 spin-resource-table = { path = "../table" }
 spin-wasi-async = { path = "../wasi-async" }
 spin-world = { path = "../world" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/factor-variables/Cargo.toml
+++ b/crates/factor-variables/Cargo.toml
@@ -16,7 +16,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 spin-factors-test = { path = "../factors-test" }
-tokio = { workspace = true, features = ["macros", "rt"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/key-value-aws/Cargo.toml
+++ b/crates/key-value-aws/Cargo.toml
@@ -19,7 +19,7 @@ aws-sdk-dynamodb = { version = "1.49.0", default-features = false, features = ["
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/key-value-azure/Cargo.toml
+++ b/crates/key-value-azure/Cargo.toml
@@ -18,7 +18,7 @@ futures = { workspace = true }
 reqwest = { version = "0.12", default-features = false }
 serde = { workspace = true }
 spin-factor-key-value = { path = "../factor-key-value" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/key-value-redis/Cargo.toml
+++ b/crates/key-value-redis/Cargo.toml
@@ -10,7 +10,7 @@ redis = { workspace = true, features = ["tokio-comp", "tokio-native-tls-comp", "
 serde = { workspace = true }
 spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
 url = { workspace = true }
 
 [lints]

--- a/crates/key-value-spin/Cargo.toml
+++ b/crates/key-value-spin/Cargo.toml
@@ -12,7 +12,10 @@ spin-core = { path = "../core" }
 spin-factor-key-value = { path = "../factor-key-value" }
 spin-wasi-async = { path = "../wasi-async" }
 spin-world = { path = "../world" }
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt", "sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/llm-local/Cargo.toml
+++ b/crates/llm-local/Cargo.toml
@@ -17,7 +17,7 @@ spin-common = { path = "../common" }
 spin-core = { path = "../core" }
 spin-world = { path = "../world" }
 tokenizers = "0.21"
-tokio = { workspace = true, features = ["macros", "sync", "fs"] }
+tokio = { workspace = true, features = ["fs", "rt"] }
 tracing = { workspace = true }
 
 [features]

--- a/crates/loader/Cargo.toml
+++ b/crates/loader/Cargo.toml
@@ -23,7 +23,7 @@ spin-outbound-networking-config = { path = "../outbound-networking-config" }
 spin-serde = { path = "../serde" }
 tempfile = { workspace = true }
 terminal = { path = "../terminal" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["fs", "io-util", "sync"] }
 toml = { workspace = true }
 tracing = { workspace = true }
 wasm-pkg-client = { workspace = true }

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -31,7 +31,7 @@ spin-loader = { path = "../loader" }
 spin-locked-app = { path = "../locked-app" }
 tar = "0.4"
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "io-util", "rt"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = { workspace = true }
 walkdir = { workspace = true }
@@ -39,6 +39,7 @@ wasmparser = { workspace = true }
 wat = "1"
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
 wasm-encoder = { workspace = true }
 wit-component = { workspace = true, features = ["dummy-module"] }
 wit-parser = { workspace = true }

--- a/crates/runtime-config/Cargo.toml
+++ b/crates/runtime-config/Cargo.toml
@@ -42,7 +42,7 @@ toml = { workspace = true }
 spin-factors-test = { path = "../factors-test" }
 spin-world = { path = "../world" }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml = { workspace = true }
 
 [lints]

--- a/crates/sqlite-inproc/Cargo.toml
+++ b/crates/sqlite-inproc/Cargo.toml
@@ -12,7 +12,7 @@ rusqlite = { workspace = true, features = ["bundled", "hooks"] }
 spin-factor-sqlite = { path = "../factor-sqlite" }
 spin-wasi-async = { path = "../wasi-async" }
 spin-world = { path = "../world" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/trigger-http/Cargo.toml
+++ b/crates/trigger-http/Cargo.toml
@@ -9,7 +9,7 @@ doctest = false
 
 [dependencies]
 anyhow = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
 futures = { workspace = true }
 http = { workspace = true }
 http-body = { workspace = true }

--- a/crates/trigger/Cargo.toml
+++ b/crates/trigger/Cargo.toml
@@ -43,6 +43,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 spin-world = { path = "../world" }
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync"] }
 
 [lints]
 workspace = true

--- a/crates/wasi-async/Cargo.toml
+++ b/crates/wasi-async/Cargo.toml
@@ -7,4 +7,4 @@ edition.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 spin-core = { path = "../core" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }


### PR DESCRIPTION
## Summary

This PR makes dependency feature declarations match the APIs Spin uses directly, instead of relying on those features being enabled by other crates in the dependency graph.

It also narrows a few existing Tokio declarations so production dependencies only carry the features used by production code, with test-only runtime features moved to dev-dependencies.

It may be helpful to prevent future confusion like [this](https://github.com/spinframework/spin/pull/3567#discussion_r3415179943).

Fully resolve this kind of issue requires work on the Cargo side: https://github.com/rust-lang/cargo/issues/14375

## Direct feature usage

- `reqwest/json` for root integration tests: [`resp.json()`](https://github.com/spinframework/spin/blob/HEAD/tests/integration.rs#L388) and [`.json(&body)`](https://github.com/spinframework/spin/blob/HEAD/tests/integration.rs#L703).
- `clap/derive` for `spin-trigger-http`: [`#[derive(Args)]`](https://github.com/spinframework/spin/blob/HEAD/crates/trigger-http/src/lib.rs#L64).
- `clap/env` for `spin-trigger-http`: [`#[clap(..., env = ...)]`](https://github.com/spinframework/spin/blob/HEAD/crates/trigger-http/src/lib.rs#L67).
- `hyper-util/client-legacy` for `spin-factor-outbound-http`: [`hyper_util::client::legacy::{Client, connect::*}`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/src/wasi.rs#L20-L25).
- `hyper-util/http1` for `spin-factor-outbound-http`: [the HTTP/1 client build path](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/src/wasi.rs#L686).
- `hyper-util/http2` for `spin-factor-outbound-http`: [`http2_only(true)`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/src/wasi.rs#L687).
- `tokio/fs` for `spin-dependency-wit`: [`tokio::fs::remove_file`](https://github.com/spinframework/spin/blob/HEAD/crates/dependency-wit/src/lib.rs#L19), [`create_dir_all`](https://github.com/spinframework/spin/blob/HEAD/crates/dependency-wit/src/lib.rs#L30), [`write`](https://github.com/spinframework/spin/blob/HEAD/crates/dependency-wit/src/lib.rs#L37), and [`read`](https://github.com/spinframework/spin/blob/HEAD/crates/dependency-wit/src/lib.rs#L78).
- `tokio/fs` for `spin-environments`: [`tokio::fs::read_to_string`](https://github.com/spinframework/spin/blob/HEAD/crates/environments/src/environment/env_loader.rs#L61) and [`tokio::fs::read`](https://github.com/spinframework/spin/blob/HEAD/crates/environments/src/loader.rs#L194).
- `tokio/sync` for `spin-environments`: [`tokio::sync::RwLock`](https://github.com/spinframework/spin/blob/HEAD/crates/environments/src/environment/env_loader.rs#L66).
- `tokio/time` for `spin-environments`: [`tokio::time::timeout`](https://github.com/spinframework/spin/blob/HEAD/crates/environments/src/environment/catalogue.rs#L84).
- `tokio/net` for `spin-factor-outbound-http`: [`tokio::net::lookup_host`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/src/wasi.rs#L736).
- `tokio/rt` for `spin-factor-outbound-http`: [`tokio::task_local!`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/src/wasi.rs#L693).
- `tokio/time` for `spin-factor-outbound-http`: [`tokio::time::Sleep`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/src/wasi.rs#L250) and [`tokio::time::sleep`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/src/wasi.rs#L306).
- `tokio/macros` and `tokio/rt-multi-thread` for `spin-factor-outbound-http` tests: [`#[tokio::test(flavor = "multi_thread")]`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-http/tests/factor_test.rs#L39).
- `tokio/rt` for `spin-factor-outbound-mysql`: [`tokio::spawn`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-mysql/src/client.rs#L150).
- `tokio/sync` for `spin-factor-outbound-mysql`: [`tokio::sync::{Mutex, mpsc, oneshot}`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-mysql/src/client.rs#L14).
- `tokio/macros` and `tokio/rt` for `spin-factor-outbound-mysql` tests: [`#[tokio::test]`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-outbound-mysql/tests/factor_test.rs#L39).
- `tokio/sync` for `spin-factor-sqlite`: [`tokio::sync::{mpsc, oneshot}`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-sqlite/src/lib.rs#L233-L234).
- `tokio/macros` and `tokio/rt-multi-thread` for `spin-factor-variables` tests: [`#[tokio::test(flavor = "multi_thread")]`](https://github.com/spinframework/spin/blob/HEAD/crates/factor-variables/tests/factor_test.rs#L12).
- `tokio/rt` for `spin-key-value-aws`: [`tokio::spawn`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-aws/src/store.rs#L328).
- `tokio/sync` for `spin-key-value-aws`: [`tokio::sync::{mpsc, oneshot}`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-aws/src/store.rs#L295-L299).
- `tokio/rt` for `spin-key-value-azure`: [`tokio::spawn`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-azure/src/store.rs#L259).
- `tokio/sync` for `spin-key-value-azure`: [`tokio::sync::{mpsc, oneshot}`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-azure/src/store.rs#L231-L235).
- `tokio/rt` for `spin-key-value-redis`: [`tokio::spawn`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-redis/src/store.rs#L174).
- `tokio/sync` for `spin-key-value-redis`: [`tokio::sync::OnceCell`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-redis/src/store.rs#L8) and [`mpsc` / `oneshot`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-redis/src/store.rs#L149-L153).
- `tokio/rt` for `spin-key-value-spin`: [`tokio::task::spawn_blocking`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-spin/src/store.rs#L229).
- `tokio/sync` for `spin-key-value-spin`: [`tokio::sync::{mpsc, oneshot}`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-spin/src/store.rs#L196-L200).
- `tokio/macros` and `tokio/rt-multi-thread` for `spin-key-value-spin` tests: [`#[tokio::test(flavor = "multi_thread", worker_threads = 1)]`](https://github.com/spinframework/spin/blob/HEAD/crates/key-value-spin/src/store.rs#L470).
- `tokio/fs` for `spin-llm-local`: [`tokio::fs::read_dir`](https://github.com/spinframework/spin/blob/HEAD/crates/llm-local/src/lib.rs#L179).
- `tokio/rt` for `spin-llm-local`: [`tokio::task::spawn_blocking`](https://github.com/spinframework/spin/blob/HEAD/crates/llm-local/src/lib.rs#L112).
- `tokio/fs` for `spin-loader`: [`tokio::fs::write`](https://github.com/spinframework/spin/blob/HEAD/crates/loader/src/fs.rs#L9).
- `tokio/io-util` for `spin-loader`: [`tokio::io::AsyncWriteExt`](https://github.com/spinframework/spin/blob/HEAD/crates/loader/src/http.rs#L5).
- `tokio/sync` for `spin-loader`: [`tokio::sync::Semaphore`](https://github.com/spinframework/spin/blob/HEAD/crates/loader/src/local.rs#L19).
- `tokio/fs` for `spin-oci`: [`tokio::fs::read_to_string`](https://github.com/spinframework/spin/blob/HEAD/crates/oci/src/auth.rs#L86), [`tokio::fs::read`](https://github.com/spinframework/spin/blob/HEAD/crates/oci/src/loader.rs#L61), and [`tokio::fs::write`](https://github.com/spinframework/spin/blob/HEAD/crates/oci/src/client.rs#L408).
- `tokio/io-util` for `spin-oci`: [`tokio::io::AsyncWriteExt`](https://github.com/spinframework/spin/blob/HEAD/crates/oci/src/validate.rs#L60).
- `tokio/rt` for `spin-oci`: [`tokio::task::spawn_blocking`](https://github.com/spinframework/spin/blob/HEAD/crates/oci/src/utils.rs#L15).
- `tokio/macros` and `tokio/rt` for `spin-oci` tests: [`#[tokio::test]`](https://github.com/spinframework/spin/blob/HEAD/crates/oci/src/validate.rs#L62).
- `tokio/macros` and `tokio/rt-multi-thread` for `spin-runtime-config` tests: [`#[tokio::test(flavor = "multi_thread", worker_threads = 1)]`](https://github.com/spinframework/spin/blob/HEAD/crates/runtime-config/src/lib.rs#L626).
- `tokio/rt` for `spin-sqlite-inproc`: [`tokio::task::spawn_blocking`](https://github.com/spinframework/spin/blob/HEAD/crates/sqlite-inproc/src/lib.rs#L109).
- `tokio/sync` for `spin-sqlite-inproc`: [`tokio::sync::{oneshot, mpsc}`](https://github.com/spinframework/spin/blob/HEAD/crates/sqlite-inproc/src/lib.rs#L126-L128).
- `tokio/macros` and `tokio/rt` for `spin-app`, `spin-dependency-wit`, `spin-environments`, `spin-loader`, and `spin-trigger` tests: examples include [`crates/app/src/lib.rs`](https://github.com/spinframework/spin/blob/HEAD/crates/app/src/lib.rs#L348), [`crates/dependency-wit/src/lib.rs`](https://github.com/spinframework/spin/blob/HEAD/crates/dependency-wit/src/lib.rs#L509), [`crates/environments/src/environment.rs`](https://github.com/spinframework/spin/blob/HEAD/crates/environments/src/environment.rs#L320), [`crates/loader/src/cache.rs`](https://github.com/spinframework/spin/blob/HEAD/crates/loader/src/cache.rs#L176), and [`crates/trigger/src/cli/sqlite_statements.rs`](https://github.com/spinframework/spin/blob/HEAD/crates/trigger/src/cli/sqlite_statements.rs#L133).
- `tokio/sync` for `spin-trigger` tests: [`tokio::sync::{mpsc, oneshot}`](https://github.com/spinframework/spin/blob/HEAD/crates/trigger/src/cli/sqlite_statements.rs#L226-L227).
- `tokio/sync` for `spin-wasi-async`: [`tokio::sync::mpsc::Receiver`](https://github.com/spinframework/spin/blob/HEAD/crates/wasi-async/src/stream.rs#L3).

## Notes

- `spin-dependency-wit`, `spin-key-value-spin`, `spin-llm-local`, and `spin-factor-outbound-mysql`
  were narrowed where the previous declaration was broader than direct source usage required.
- Test-only Tokio runtime support is declared as dev-dependencies where possible.

## Test commands

```bash
cargo check -p spin-dependency-wit -p spin-environments -p spin-factor-outbound-http \
  -p spin-factor-outbound-mysql -p spin-factor-variables -p spin-key-value-spin \
  -p spin-llm-local -p spin-oci -p spin-runtime-config -p spin-trigger --tests
cargo check -p spin-cli --test integration
```
