### PR TITLE
Update to Wasmtime 46 and WASI 0.3.0, retaining support for 0.3.0-rc-2026-03-15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ jobs:
   dependency-review:
     name: Review new dependencies for known vulnerabilities
     runs-on: "ubuntu-22.04"
-    if: ${{ github.event_name == 'pull_request' }}
+    # TODO: re-enable once https://github.com/spinframework/spin/issues/3598 has been addressed:
+    if: false
+    #if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,7 +1381,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "smallvec",
 ]
 
@@ -1397,20 +1397,10 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -1422,7 +1412,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -1435,7 +1425,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "winx",
 ]
 
@@ -1518,6 +1508,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1887,27 +1888,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb5bdd1af46714e3224a017fabbbd57f70df4e840eb5ad6a7429dc456119d6"
+checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a819599186e1b1a1f88d464e06045696afc7aa3e0cc018aa0b2999cb63d1d088"
+checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e2c152d488e03c87b913bc2ed3414416eb1e0d66d61b49af60bf456a9665c7"
+checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1915,9 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6559d4fbc253d1396e1f6beeae57fa88a244f02aaf0cde2a735afd3492d9b2e"
+checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1926,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d9315d98d6e0a64454d4c83be2ee0e8055c3f80c3b2d7bcad7079f281a06ff"
+checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1940,13 +1941,16 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
+ "serde_derive",
+ "sha2 0.10.8",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -1954,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89c00a88081c55e3087c45bebc77e0cc973de2d7b44ef6a943c7122647b89f5"
+checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1967,24 +1971,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f77c497a1eb6273482aa1ac3b23cb8563ff04edb39ed5dfcfd28c8deff8f5"
+checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498dc1f17a6910c88316d49c7176d8fa97cf10c30859c32a266040449317f963"
+checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2acba797f6a46042ce82aaf7680d0c3567fe2001e238db9df649fd104a2727f"
+checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1994,11 +1998,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dca3df1d107d98d88f159ad1d5eaa2d5cdb678b3d5bcfadc6fc83d8ebb448ea"
+checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -2006,15 +2011,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62dd18116d88bed649871feceda79dad7b59cc685ea8998c2b3e64d0e689602"
+checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f843b80360d7fdf61a6124642af7597f6d55724cf521210c34af8a1c66daca6e"
+checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -2023,9 +2028,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090ee5de58c6f17eb5e3a5ae8cf1695c7efea04ec4dd0ecba6a5b996c9bad7dc"
+checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
 
 [[package]]
 name = "crc32fast"
@@ -3153,7 +3158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3613,8 +3618,20 @@ checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3939,9 +3956,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.6"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4018,8 +4035,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -4256,22 +4271,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.6",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -4319,7 +4333,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.3.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
@@ -4336,7 +4350,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4351,7 +4365,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -4371,12 +4385,12 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -5064,9 +5078,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -5226,9 +5240,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "liquid"
@@ -5366,12 +5380,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "macro_rules_attribute"
@@ -5441,7 +5452,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -5539,14 +5550,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7061,9 +7072,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df866b7fd522992ccc6682e58b2741cc7972b163b661db24c4328f4c914cb09d"
+checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -7073,9 +7084,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dfa8354acc622b3857e1bb1a4e4315d3bc1a44ad31d5653c3e87c0da9306d7"
+checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7173,6 +7184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7223,6 +7240,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7253,6 +7281,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7278,6 +7316,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -7382,7 +7426,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -7442,15 +7486,16 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -7511,11 +7556,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.6",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.3",
  "hyper-tls",
  "hyper-util",
@@ -7565,7 +7610,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -7857,14 +7902,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -7875,7 +7920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -8646,12 +8691,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8747,7 +8792,7 @@ dependencies = [
  "hex",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "indicatif",
  "itertools 0.15.0",
@@ -8757,7 +8802,7 @@ dependencies = [
  "openssl",
  "path-absolutize",
  "pretty_assertions",
- "rand 0.9.4",
+ "rand 0.10.1",
  "redis",
  "regex",
  "reqwest 0.12.9",
@@ -8828,9 +8873,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "cap-std",
- "rand 0.9.4",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
+ "rand 0.10.1",
+ "rand_chacha 0.10.0",
+ "rand_core 0.10.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -9057,7 +9102,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "opentelemetry-semantic-conventions",
  "pin-project-lite",
@@ -9327,7 +9372,7 @@ dependencies = [
  "anyhow",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "indexmap 2.14.0",
  "percent-encoding",
  "routefinder",
@@ -9421,7 +9466,7 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "candle-transformers",
- "rand 0.9.4",
+ "rand 0.10.1",
  "safetensors 0.5.3",
  "serde",
  "serde_json",
@@ -9806,11 +9851,11 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "opentelemetry-semantic-conventions",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.10.1",
  "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
@@ -10166,22 +10211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.10.0",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.40",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10206,9 +10235,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.1"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc12939a1c9b9d391e0b7135f72fd30508b73450753e28341fed159317582a77"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "temp-dir"
@@ -10218,14 +10247,14 @@ checksum = "bc1ee6eef34f12f765cb94725905c6312b6610ab2b0940889cfe58dae7bc3c72"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.2.0",
- "getrandom 0.3.2",
+ "getrandom 0.4.3",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -10251,7 +10280,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -10489,9 +10518,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -10499,16 +10528,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10713,11 +10742,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.6",
+ "h2 0.4.15",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -11502,9 +11531,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
+checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -11512,8 +11541,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wat",
 ]
 
@@ -11559,22 +11588,32 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.246.2",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -11774,19 +11813,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
-dependencies = [
- "bitflags 2.10.0",
- "hashbrown 0.16.1",
- "indexmap 2.14.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
@@ -11796,6 +11822,30 @@ dependencies = [
  "indexmap 2.14.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags 2.10.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.10.0",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -11810,20 +11860,20 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
+checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca3f777dfb4db45915f95eeb25cac7f2eeb268797a27e5eb78b072618135c7f"
+checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -11846,7 +11896,7 @@ dependencies = [
  "postcard",
  "pulley-interpreter",
  "rayon",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_derive",
@@ -11854,9 +11904,9 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "tempfile",
- "wasm-compose 0.246.2",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-compose 0.251.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -11868,16 +11918,16 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5ca1af838cec374931242d07af5d354aedf63f297f95b3625ac863e516ef67"
+checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -11885,7 +11935,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli 0.33.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "log",
  "object 0.39.0",
@@ -11897,24 +11947,24 @@ dependencies = [
  "sha2 0.10.8",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
- "wasmprinter 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
+ "wasmprinter 0.251.0",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2004f7c86ebeb116550655377cdf16dbf7b03ae5aa6b4b1c1458cfa23aaa306"
+checksum = "438bc7dc45fb75297d75f79a9a0ce852345d13ebc6a6863f6f688f013836a9dd"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "sha2 0.10.8",
@@ -11926,9 +11976,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b31927f7b613d8fe019609744e226f6458d8aa5e6289e92fbbc60e521cd026"
+checksum = "f1e48f8d4966d62a10b6d70722bc432c1e163890be2801d3b5784589ad36ffc3"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -11936,32 +11986,32 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc29e3478928b93979831ba02a997ce7f707c673ce47180d643091cf4fa4f561"
+checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816a61a75275c6be435131fc625a4f5956daf24d9f9f59443e81cbef228929b3"
+checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ceb5e079877e7e4565c1e2d86d9db889175d55f7ca0001315576d08c71e634"
+checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -11977,7 +12027,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -11986,14 +12036,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18f8bb05d25e0d4cca7278147c9f9e2f26f66886ef754b562bf729128f1e537"
+checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
@@ -12001,21 +12051,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357f1070b31154ee463937b477ca0b2962bf450b40fc59799bef2f656b15da73"
+checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
 dependencies = [
  "cc",
  "object 0.39.0",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd683a94490bf755d016a09697b0955602c50106b1ded97d16983ab2ded9fed"
+checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
 dependencies = [
  "cfg-if",
  "libc",
@@ -12025,9 +12075,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471746ce113c3c1862ce2c0674acb35399a4b3ed3ef4531dc087f333c74f064"
+checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -12038,9 +12088,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6af582ec18b674bf7a17775d6fbfbddfcc143f0edbd89c9c1778239c8aa92ed"
+checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12048,55 +12098,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31be8916bb60ea756d2f0ae1f634d9258442aa71e773c893e2f4cead30501b5"
-dependencies = [
- "cranelift-codegen",
- "gimli 0.33.0",
- "log",
- "object 0.39.0",
- "target-lexicon",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2150e63d502ab2d64754e5abe8eb737ae674b7dd4ad53144fd16bbeceaf4a19"
+checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
 dependencies = [
  "anyhow",
  "bitflags 2.10.0",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f5109b4fd619b9796b9c9901de59d83e3575cd1226c1a36d1901371f43db28"
+checksum = "e9f65ef30a2c5478873cdb619085a7a649d3ce41cc3eaf298a7ce3dee96a8e11"
 dependencies = [
  "async-trait",
  "bitflags 2.10.0",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
- "cap-rand",
  "cap-std",
  "cap-time-ext",
- "fs-set-times",
+ "cfg-if",
  "futures",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.2",
- "system-interface",
+ "rand 0.10.1",
+ "rustix 1.1.4",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -12109,9 +12141,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798e6e48005406983ba6a7b27f3832f1571e53f1401ef2d60111c96eab534b4"
+checksum = "cb65eeb8116615c2a22f51b19672c0d5b652ca7b051086da5c7c0a9eb39f4af7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12119,7 +12151,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "rustls 0.23.37",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -12133,9 +12165,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ebe14c586e98d2fdc32c76ca0005ef28348e98ed737e776d378b3b0cc2afd0"
+checksum = "cee57d5fef4976b1ab542615f4cef2c43278eb549d8078939668ea0f13d5c696"
 dependencies = [
  "async-trait",
  "bytes",
@@ -12155,24 +12187,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "247.0.0"
+version = "252.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.252.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.247.0"
+version = "1.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
 dependencies = [
- "wast 247.0.0",
+ "wast 252.0.0",
 ]
 
 [[package]]
@@ -12305,7 +12337,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -12322,9 +12354,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cff414ef7dce0cc1cf8a033ff80d3f38e3987c37e3efeec7926ecb5ffaaae6"
+checksum = "e03df88bf1a6068b02851aa3ef9427d285118f5c1c153b068a8995c69dd9562a"
 dependencies = [
  "bitflags 2.10.0",
  "thiserror 2.0.17",
@@ -12336,9 +12368,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf9dc7272b151a9616a2699e7f94ea1d4ae253b47b63a79fbc8f38e2cca5fa6"
+checksum = "e014aec8661b613154377e4b49dbbb0dfc4f424efcee749782054576c00537d9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -12350,9 +12382,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7c29fcf738630cba4e35f1805da5e42dde20ee9809ee9202b0648ae671602f"
+checksum = "f67310a8ae5190b7f3dcacf8697f2890701a3a8427b3e77ed91d3632dcedaceb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12390,25 +12422,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9339858ad222412200fd8b1af9e270712201aaec440c7618991443af3446481f"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli 0.33.0",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.17",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "windows"
@@ -13052,25 +13065,6 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.246.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
-dependencies = [
- "anyhow",
- "hashbrown 0.16.1",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.246.2",
-]
-
-[[package]]
-name = "wit-parser"
 version = "0.247.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc"
@@ -13086,6 +13080,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9113,6 +9113,7 @@ dependencies = [
  "spin-factor-otel",
  "spin-factor-outbound-networking",
  "spin-factor-variables",
+ "spin-factor-wasi",
  "spin-factors",
  "spin-factors-test",
  "spin-telemetry",
@@ -9304,6 +9305,8 @@ version = "4.1.0-pre0"
 dependencies = [
  "async-trait",
  "bytes",
+ "futures",
+ "pin-project-lite",
  "spin-common",
  "spin-connection-semaphore",
  "spin-factors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ opentelemetry-semantic-conventions = { version = "0.29", features = ["semconv_ex
 path-absolutize = "3"
 pin-project-lite = "0.2.16"
 quote = "1"
-rand = "0.9"
+rand = "0.10.1"
 redis = "0.32.5"
 regex = "1"
 reqwest = { version = "0.12", features = ["stream", "blocking", "rustls-tls-native-roots"] }
@@ -205,9 +205,9 @@ wasm-metadata = "0.247.0"
 wasm-pkg-client = "0.11"
 wasm-pkg-common = "0.11"
 wasmparser = "0.247.0"
-wasmtime = { version = "44.0.0", features = ["component-model-async"] }
-wasmtime-wasi = { version = "44.0.0", features = ["p3"] }
-wasmtime-wasi-http = { version = "44.0.0", features = ["p3", "component-model-async"] }
+wasmtime = "46.0.1"
+wasmtime-wasi = { version = "46.0.1", features = ["p3"] }
+wasmtime-wasi-http = { version = "46.0.1", features = ["p3", "component-model-async"] }
 wit-component = "0.247.0"
 wit-parser = "0.247.0"
 

--- a/crates/componentize/Cargo.toml
+++ b/crates/componentize/Cargo.toml
@@ -21,8 +21,8 @@ wit-parser = { workspace = true }
 async-trait = { workspace = true }
 cap-std = "3"
 rand = { workspace = true }
-rand_chacha = "0.3"
-rand_core = "0.6"
+rand_chacha = "0.10.0"
+rand_core = "0.10.1"
 serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/componentize/src/abi_conformance/test_wasi.rs
+++ b/crates/componentize/src/abi_conformance/test_wasi.rs
@@ -1,20 +1,22 @@
 use super::{Context, TestConfig};
 use anyhow::{Result, ensure};
+use rand::TryRng;
 use rand_chacha::ChaCha12Core;
 use rand_core::{
     SeedableRng,
-    block::{BlockRng, BlockRngCore},
+    block::{BlockRng, Generator},
 };
 use serde::Serialize;
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
 use std::{
     collections::HashSet,
+    convert::Infallible,
     fs::File,
     io::Write,
     ops::Deref,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, SystemTime},
 };
 use wasmtime::{Engine, component::InstancePre};
@@ -154,22 +156,43 @@ pub(crate) async fn test(
                 called: Arc<AtomicBool>,
             }
 
-            impl BlockRngCore for MyRngCore {
-                type Item = <ChaCha12Core as BlockRngCore>::Item;
-                type Results = <ChaCha12Core as BlockRngCore>::Results;
+            impl Generator for MyRngCore {
+                type Output = <ChaCha12Core as Generator>::Output;
 
-                fn generate(&mut self, results: &mut Self::Results) {
+                fn generate(&mut self, results: &mut Self::Output) {
                     self.called.store(true, Ordering::Relaxed);
                     self.cha_cha_12.generate(results)
                 }
             }
 
+            struct MyRng(BlockRng<MyRngCore>);
+
+            impl TryRng for MyRng {
+                type Error = Infallible;
+
+                #[inline]
+                fn try_next_u32(&mut self) -> Result<u32, Infallible> {
+                    Ok(self.0.next_word())
+                }
+
+                #[inline]
+                fn try_next_u64(&mut self) -> Result<u64, Infallible> {
+                    Ok(self.0.next_u64_from_u32())
+                }
+
+                #[inline]
+                fn try_fill_bytes(&mut self, bytes: &mut [u8]) -> Result<(), Infallible> {
+                    self.0.fill_bytes(bytes);
+                    Ok(())
+                }
+            }
+
             let called = Arc::new(AtomicBool::default());
             let mut store = super::create_store_with_wasi(engine, test_config.clone(), |wasi| {
-                wasi.insecure_random(Box::new(BlockRng::new(MyRngCore {
+                wasi.insecure_random(Box::new(MyRng(BlockRng::new(MyRngCore {
                     cha_cha_12: ChaCha12Core::seed_from_u64(42),
                     called: called.clone(),
-                })));
+                }))));
             });
 
             super::run_command(&mut store, pre, &["wasi-random"], move |_| {

--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -248,8 +248,8 @@ impl v3::HostStore for KeyValueDispatch {
     }
 }
 
-impl v3::HostStoreWithStore for crate::KeyValueFactorData {
-    async fn open<T>(
+impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
+    async fn open(
         accessor: &Accessor<T, Self>,
         label: String,
     ) -> Result<Resource<v3::Store>, v3::Error> {
@@ -275,7 +275,7 @@ impl v3::HostStoreWithStore for crate::KeyValueFactorData {
         })
     }
 
-    async fn get<T>(
+    async fn get(
         accessor: &Accessor<T, Self>,
         store: Resource<v3::Store>,
         key: String,
@@ -294,7 +294,7 @@ impl v3::HostStoreWithStore for crate::KeyValueFactorData {
             .map_err(track_error_on_span_v3)
     }
 
-    async fn set<T>(
+    async fn set(
         accessor: &Accessor<T, Self>,
         store: Resource<v3::Store>,
         key: String,
@@ -314,7 +314,7 @@ impl v3::HostStoreWithStore for crate::KeyValueFactorData {
             .map_err(track_error_on_span_v3)
     }
 
-    async fn delete<T>(
+    async fn delete(
         accessor: &Accessor<T, Self>,
         store: Resource<v3::Store>,
         key: String,
@@ -333,7 +333,7 @@ impl v3::HostStoreWithStore for crate::KeyValueFactorData {
             .map_err(track_error_on_span_v3)
     }
 
-    async fn exists<T>(
+    async fn exists(
         accessor: &Accessor<T, Self>,
         store: Resource<v3::Store>,
         key: String,
@@ -352,7 +352,7 @@ impl v3::HostStoreWithStore for crate::KeyValueFactorData {
             .map_err(track_error_on_span_v3)
     }
 
-    async fn get_keys<T>(
+    async fn get_keys(
         accessor: &Accessor<T, Self>,
         store: Resource<v3::Store>,
     ) -> Result<(StreamReader<String>, FutureReader<Result<(), v3::Error>>)> {

--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -44,7 +44,7 @@ impl Factor for KeyValueFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceBuilder;
 
-    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::key_value::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(spin_world::v2::key_value::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(

--- a/crates/factor-llm/src/lib.rs
+++ b/crates/factor-llm/src/lib.rs
@@ -37,7 +37,7 @@ impl Factor for LlmFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: spin_factors::InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::llm::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(spin_world::v2::llm::add_to_linker::<_, FactorData<Self>>)?;
         Ok(())

--- a/crates/factor-otel/src/lib.rs
+++ b/crates/factor-otel/src/lib.rs
@@ -34,7 +34,7 @@ impl Factor for OtelFactor {
     type AppState = ();
     type InstanceBuilder = InstanceState;
 
-    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: spin_factors::InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         // Only link the WASI OTel bindings if experimental support is enabled. This means that if
         // the user tries to run a guest component that consumes the WASI OTel WIT without enabling
         // experimental support they'll see an error like "component imports instance

--- a/crates/factor-outbound-http/Cargo.toml
+++ b/crates/factor-outbound-http/Cargo.toml
@@ -20,6 +20,7 @@ rustls = { workspace = true }
 serde = { workspace = true }
 spin-factor-otel = { path = "../factor-otel" }
 spin-factor-outbound-networking = { path = "../factor-outbound-networking" }
+spin-factor-wasi = { path = "../factor-wasi" }
 spin-factors = { path = "../factors" }
 spin-telemetry = { path = "../telemetry" }
 spin-world = { path = "../world" }

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -4,7 +4,7 @@ mod spin;
 mod wasi;
 pub mod wasi_2023_10_18;
 pub mod wasi_2023_11_10;
-mod wasi_2026_03_15;
+pub mod wasi_2026_03_15;
 
 use std::{net::SocketAddr, sync::Arc};
 

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -33,8 +33,6 @@ pub use wasmtime_wasi_http::p2::{
     types::{HostFutureIncomingResponse, OutgoingRequestConfig},
 };
 
-pub use wasi::{MutexBody, NotifyOnDropBody, p2_to_p3_error_code, p3_to_p2_error_code};
-
 #[derive(Default)]
 pub struct OutboundHttpFactor {
     _priv: (),
@@ -45,7 +43,7 @@ impl Factor for OutboundHttpFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: spin_factors::InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::http::add_to_linker::<_, FactorData<Self>>)?;
         wasi::add_to_linker(ctx)?;
         Ok(())

--- a/crates/factor-outbound-http/src/lib.rs
+++ b/crates/factor-outbound-http/src/lib.rs
@@ -4,6 +4,7 @@ mod spin;
 mod wasi;
 pub mod wasi_2023_10_18;
 pub mod wasi_2023_11_10;
+mod wasi_2026_03_15;
 
 use std::{net::SocketAddr, sync::Arc};
 

--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -3,15 +3,13 @@ use std::{
     future::Future,
     io::IoSlice,
     net::SocketAddr,
-    ops::DerefMut,
     pin::Pin,
-    sync::{Arc, Mutex},
+    sync::Arc,
     task::{self, Context, Poll},
     time::Duration,
 };
 
 use bytes::{Buf, Bytes};
-use futures::channel::oneshot;
 use http::{
     HeaderMap, Uri,
     header::{CONTENT_LENGTH, HOST},
@@ -64,67 +62,6 @@ use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(600);
 
-pub struct MutexBody<T>(Mutex<T>);
-
-impl<T> MutexBody<T> {
-    pub fn new(body: T) -> Self {
-        Self(Mutex::new(body))
-    }
-}
-
-impl<T: Body + Unpin> Body for MutexBody<T> {
-    type Data = T::Data;
-    type Error = T::Error;
-
-    fn poll_frame(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        Pin::new(self.0.lock().unwrap().deref_mut()).poll_frame(cx)
-    }
-
-    fn is_end_stream(&self) -> bool {
-        self.0.lock().unwrap().is_end_stream()
-    }
-
-    fn size_hint(&self) -> SizeHint {
-        self.0.lock().unwrap().size_hint()
-    }
-}
-
-/// Body which, when dropped, will notify the receiver corresponding to the
-/// specified sender.
-pub struct NotifyOnDropBody<B> {
-    body: B,
-    _tx: oneshot::Sender<()>,
-}
-
-impl<B> NotifyOnDropBody<B> {
-    pub fn new(body: B, tx: oneshot::Sender<()>) -> Self {
-        Self { body, _tx: tx }
-    }
-}
-
-impl<B: Body + Unpin> Body for NotifyOnDropBody<B> {
-    type Data = B::Data;
-    type Error = B::Error;
-
-    fn poll_frame(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
-        Pin::new(&mut self.body).poll_frame(cx)
-    }
-
-    fn is_end_stream(&self) -> bool {
-        self.body.is_end_stream()
-    }
-
-    fn size_hint(&self) -> SizeHint {
-        self.body.size_hint()
-    }
-}
-
 pub(crate) struct HasHttp;
 
 impl HasData for HasHttp {
@@ -175,8 +112,6 @@ impl p3::WasiHttpHooks for InstanceHttpHooks {
         // connection).
         _ = fut;
 
-        let request = request.map(|body| MutexBody::new(body).boxed());
-
         let request_sender = RequestSender {
             allowed_hosts: self.allowed_hosts.clone(),
             component_tls_configs: self.component_tls_configs.clone(),
@@ -202,7 +137,7 @@ impl p3::WasiHttpHooks for InstanceHttpHooks {
             async {
                 match request_sender
                     .send(
-                        request.map(|body| body.map_err(p3_to_p2_error_code).boxed_unsync()),
+                        request.map(|body| body.map_err(p2_types::ErrorCode::from).boxed_unsync()),
                         config,
                     )
                     .await
@@ -231,7 +166,7 @@ impl p3::WasiHttpHooks for InstanceHttpHooks {
                     )),
                     Err(http_error) => match http_error.downcast() {
                         Ok(error_code) => {
-                            Err(TrappableError::from(p2_to_p3_error_code(error_code)))
+                            Err(TrappableError::from(p3_types::ErrorCode::from(error_code)))
                         }
                         Err(trap) => Err(TrappableError::trap(trap)),
                     },
@@ -299,7 +234,7 @@ impl<B: Body<Error = p2_types::ErrorCode> + Unpin> Body for BetweenBytesTimeoutB
                     }
                 }
 
-                Poll::Ready(value.map(|v| v.map_err(p2_to_p3_error_code)))
+                Poll::Ready(value.map(|v| v.map_err(p3_types::ErrorCode::from)))
             }
             Poll::Pending => {
                 if me.sleep.is_none() {
@@ -984,210 +919,6 @@ fn dns_error(rcode: String, info_code: u16) -> ErrorCode {
             info_code: Some(info_code),
         },
     )
-}
-
-// TODO: Remove this (and uses of it) once
-// https://github.com/spinframework/spin/issues/3274 has been addressed.
-pub fn p2_to_p3_error_code(code: p2_types::ErrorCode) -> p3_types::ErrorCode {
-    match code {
-        p2_types::ErrorCode::DnsTimeout => p3_types::ErrorCode::DnsTimeout,
-        p2_types::ErrorCode::DnsError(payload) => {
-            p3_types::ErrorCode::DnsError(p3_types::DnsErrorPayload {
-                rcode: payload.rcode,
-                info_code: payload.info_code,
-            })
-        }
-        p2_types::ErrorCode::DestinationNotFound => p3_types::ErrorCode::DestinationNotFound,
-        p2_types::ErrorCode::DestinationUnavailable => p3_types::ErrorCode::DestinationUnavailable,
-        p2_types::ErrorCode::DestinationIpProhibited => {
-            p3_types::ErrorCode::DestinationIpProhibited
-        }
-        p2_types::ErrorCode::DestinationIpUnroutable => {
-            p3_types::ErrorCode::DestinationIpUnroutable
-        }
-        p2_types::ErrorCode::ConnectionRefused => p3_types::ErrorCode::ConnectionRefused,
-        p2_types::ErrorCode::ConnectionTerminated => p3_types::ErrorCode::ConnectionTerminated,
-        p2_types::ErrorCode::ConnectionTimeout => p3_types::ErrorCode::ConnectionTimeout,
-        p2_types::ErrorCode::ConnectionReadTimeout => p3_types::ErrorCode::ConnectionReadTimeout,
-        p2_types::ErrorCode::ConnectionWriteTimeout => p3_types::ErrorCode::ConnectionWriteTimeout,
-        p2_types::ErrorCode::ConnectionLimitReached => p3_types::ErrorCode::ConnectionLimitReached,
-        p2_types::ErrorCode::TlsProtocolError => p3_types::ErrorCode::TlsProtocolError,
-        p2_types::ErrorCode::TlsCertificateError => p3_types::ErrorCode::TlsCertificateError,
-        p2_types::ErrorCode::TlsAlertReceived(payload) => {
-            p3_types::ErrorCode::TlsAlertReceived(p3_types::TlsAlertReceivedPayload {
-                alert_id: payload.alert_id,
-                alert_message: payload.alert_message,
-            })
-        }
-        p2_types::ErrorCode::HttpRequestDenied => p3_types::ErrorCode::HttpRequestDenied,
-        p2_types::ErrorCode::HttpRequestLengthRequired => {
-            p3_types::ErrorCode::HttpRequestLengthRequired
-        }
-        p2_types::ErrorCode::HttpRequestBodySize(payload) => {
-            p3_types::ErrorCode::HttpRequestBodySize(payload)
-        }
-        p2_types::ErrorCode::HttpRequestMethodInvalid => {
-            p3_types::ErrorCode::HttpRequestMethodInvalid
-        }
-        p2_types::ErrorCode::HttpRequestUriInvalid => p3_types::ErrorCode::HttpRequestUriInvalid,
-        p2_types::ErrorCode::HttpRequestUriTooLong => p3_types::ErrorCode::HttpRequestUriTooLong,
-        p2_types::ErrorCode::HttpRequestHeaderSectionSize(payload) => {
-            p3_types::ErrorCode::HttpRequestHeaderSectionSize(payload)
-        }
-        p2_types::ErrorCode::HttpRequestHeaderSize(payload) => {
-            p3_types::ErrorCode::HttpRequestHeaderSize(payload.map(|payload| {
-                p3_types::FieldSizePayload {
-                    field_name: payload.field_name,
-                    field_size: payload.field_size,
-                }
-            }))
-        }
-        p2_types::ErrorCode::HttpRequestTrailerSectionSize(payload) => {
-            p3_types::ErrorCode::HttpRequestTrailerSectionSize(payload)
-        }
-        p2_types::ErrorCode::HttpRequestTrailerSize(payload) => {
-            p3_types::ErrorCode::HttpRequestTrailerSize(p3_types::FieldSizePayload {
-                field_name: payload.field_name,
-                field_size: payload.field_size,
-            })
-        }
-        p2_types::ErrorCode::HttpResponseIncomplete => p3_types::ErrorCode::HttpResponseIncomplete,
-        p2_types::ErrorCode::HttpResponseHeaderSectionSize(payload) => {
-            p3_types::ErrorCode::HttpResponseHeaderSectionSize(payload)
-        }
-        p2_types::ErrorCode::HttpResponseHeaderSize(payload) => {
-            p3_types::ErrorCode::HttpResponseHeaderSize(p3_types::FieldSizePayload {
-                field_name: payload.field_name,
-                field_size: payload.field_size,
-            })
-        }
-        p2_types::ErrorCode::HttpResponseBodySize(payload) => {
-            p3_types::ErrorCode::HttpResponseBodySize(payload)
-        }
-        p2_types::ErrorCode::HttpResponseTrailerSectionSize(payload) => {
-            p3_types::ErrorCode::HttpResponseTrailerSectionSize(payload)
-        }
-        p2_types::ErrorCode::HttpResponseTrailerSize(payload) => {
-            p3_types::ErrorCode::HttpResponseTrailerSize(p3_types::FieldSizePayload {
-                field_name: payload.field_name,
-                field_size: payload.field_size,
-            })
-        }
-        p2_types::ErrorCode::HttpResponseTransferCoding(payload) => {
-            p3_types::ErrorCode::HttpResponseTransferCoding(payload)
-        }
-        p2_types::ErrorCode::HttpResponseContentCoding(payload) => {
-            p3_types::ErrorCode::HttpResponseContentCoding(payload)
-        }
-        p2_types::ErrorCode::HttpResponseTimeout => p3_types::ErrorCode::HttpResponseTimeout,
-        p2_types::ErrorCode::HttpUpgradeFailed => p3_types::ErrorCode::HttpUpgradeFailed,
-        p2_types::ErrorCode::HttpProtocolError => p3_types::ErrorCode::HttpProtocolError,
-        p2_types::ErrorCode::LoopDetected => p3_types::ErrorCode::LoopDetected,
-        p2_types::ErrorCode::ConfigurationError => p3_types::ErrorCode::ConfigurationError,
-        p2_types::ErrorCode::InternalError(payload) => p3_types::ErrorCode::InternalError(payload),
-    }
-}
-
-// TODO: Remove this (and uses of it) once
-// https://github.com/spinframework/spin/issues/3274 has been addressed.
-pub fn p3_to_p2_error_code(code: p3_types::ErrorCode) -> p2_types::ErrorCode {
-    match code {
-        p3_types::ErrorCode::DnsTimeout => p2_types::ErrorCode::DnsTimeout,
-        p3_types::ErrorCode::DnsError(payload) => {
-            p2_types::ErrorCode::DnsError(p2_types::DnsErrorPayload {
-                rcode: payload.rcode,
-                info_code: payload.info_code,
-            })
-        }
-        p3_types::ErrorCode::DestinationNotFound => p2_types::ErrorCode::DestinationNotFound,
-        p3_types::ErrorCode::DestinationUnavailable => p2_types::ErrorCode::DestinationUnavailable,
-        p3_types::ErrorCode::DestinationIpProhibited => {
-            p2_types::ErrorCode::DestinationIpProhibited
-        }
-        p3_types::ErrorCode::DestinationIpUnroutable => {
-            p2_types::ErrorCode::DestinationIpUnroutable
-        }
-        p3_types::ErrorCode::ConnectionRefused => p2_types::ErrorCode::ConnectionRefused,
-        p3_types::ErrorCode::ConnectionTerminated => p2_types::ErrorCode::ConnectionTerminated,
-        p3_types::ErrorCode::ConnectionTimeout => p2_types::ErrorCode::ConnectionTimeout,
-        p3_types::ErrorCode::ConnectionReadTimeout => p2_types::ErrorCode::ConnectionReadTimeout,
-        p3_types::ErrorCode::ConnectionWriteTimeout => p2_types::ErrorCode::ConnectionWriteTimeout,
-        p3_types::ErrorCode::ConnectionLimitReached => p2_types::ErrorCode::ConnectionLimitReached,
-        p3_types::ErrorCode::TlsProtocolError => p2_types::ErrorCode::TlsProtocolError,
-        p3_types::ErrorCode::TlsCertificateError => p2_types::ErrorCode::TlsCertificateError,
-        p3_types::ErrorCode::TlsAlertReceived(payload) => {
-            p2_types::ErrorCode::TlsAlertReceived(p2_types::TlsAlertReceivedPayload {
-                alert_id: payload.alert_id,
-                alert_message: payload.alert_message,
-            })
-        }
-        p3_types::ErrorCode::HttpRequestDenied => p2_types::ErrorCode::HttpRequestDenied,
-        p3_types::ErrorCode::HttpRequestLengthRequired => {
-            p2_types::ErrorCode::HttpRequestLengthRequired
-        }
-        p3_types::ErrorCode::HttpRequestBodySize(payload) => {
-            p2_types::ErrorCode::HttpRequestBodySize(payload)
-        }
-        p3_types::ErrorCode::HttpRequestMethodInvalid => {
-            p2_types::ErrorCode::HttpRequestMethodInvalid
-        }
-        p3_types::ErrorCode::HttpRequestUriInvalid => p2_types::ErrorCode::HttpRequestUriInvalid,
-        p3_types::ErrorCode::HttpRequestUriTooLong => p2_types::ErrorCode::HttpRequestUriTooLong,
-        p3_types::ErrorCode::HttpRequestHeaderSectionSize(payload) => {
-            p2_types::ErrorCode::HttpRequestHeaderSectionSize(payload)
-        }
-        p3_types::ErrorCode::HttpRequestHeaderSize(payload) => {
-            p2_types::ErrorCode::HttpRequestHeaderSize(payload.map(|payload| {
-                p2_types::FieldSizePayload {
-                    field_name: payload.field_name,
-                    field_size: payload.field_size,
-                }
-            }))
-        }
-        p3_types::ErrorCode::HttpRequestTrailerSectionSize(payload) => {
-            p2_types::ErrorCode::HttpRequestTrailerSectionSize(payload)
-        }
-        p3_types::ErrorCode::HttpRequestTrailerSize(payload) => {
-            p2_types::ErrorCode::HttpRequestTrailerSize(p2_types::FieldSizePayload {
-                field_name: payload.field_name,
-                field_size: payload.field_size,
-            })
-        }
-        p3_types::ErrorCode::HttpResponseIncomplete => p2_types::ErrorCode::HttpResponseIncomplete,
-        p3_types::ErrorCode::HttpResponseHeaderSectionSize(payload) => {
-            p2_types::ErrorCode::HttpResponseHeaderSectionSize(payload)
-        }
-        p3_types::ErrorCode::HttpResponseHeaderSize(payload) => {
-            p2_types::ErrorCode::HttpResponseHeaderSize(p2_types::FieldSizePayload {
-                field_name: payload.field_name,
-                field_size: payload.field_size,
-            })
-        }
-        p3_types::ErrorCode::HttpResponseBodySize(payload) => {
-            p2_types::ErrorCode::HttpResponseBodySize(payload)
-        }
-        p3_types::ErrorCode::HttpResponseTrailerSectionSize(payload) => {
-            p2_types::ErrorCode::HttpResponseTrailerSectionSize(payload)
-        }
-        p3_types::ErrorCode::HttpResponseTrailerSize(payload) => {
-            p2_types::ErrorCode::HttpResponseTrailerSize(p2_types::FieldSizePayload {
-                field_name: payload.field_name,
-                field_size: payload.field_size,
-            })
-        }
-        p3_types::ErrorCode::HttpResponseTransferCoding(payload) => {
-            p2_types::ErrorCode::HttpResponseTransferCoding(payload)
-        }
-        p3_types::ErrorCode::HttpResponseContentCoding(payload) => {
-            p2_types::ErrorCode::HttpResponseContentCoding(payload)
-        }
-        p3_types::ErrorCode::HttpResponseTimeout => p2_types::ErrorCode::HttpResponseTimeout,
-        p3_types::ErrorCode::HttpUpgradeFailed => p2_types::ErrorCode::HttpUpgradeFailed,
-        p3_types::ErrorCode::HttpProtocolError => p2_types::ErrorCode::HttpProtocolError,
-        p3_types::ErrorCode::LoopDetected => p2_types::ErrorCode::LoopDetected,
-        p3_types::ErrorCode::ConfigurationError => p2_types::ErrorCode::ConfigurationError,
-        p3_types::ErrorCode::InternalError(payload) => p2_types::ErrorCode::InternalError(payload),
-    }
 }
 
 fn record_content_length_header(span: &Span, headers: &HeaderMap, attr_name: &'static str) {

--- a/crates/factor-outbound-http/src/wasi.rs
+++ b/crates/factor-outbound-http/src/wasi.rs
@@ -55,7 +55,7 @@ use spin_factor_outbound_networking::{ConnectionPermit, ConnectionSemaphore};
 use crate::{
     InstanceHttpHooks, OutboundHttpFactor, SelfRequestOrigin,
     intercept::{InterceptOutcome, OutboundHttpInterceptor},
-    wasi_2023_10_18, wasi_2023_11_10,
+    wasi_2023_10_18, wasi_2023_11_10, wasi_2026_03_15,
 };
 
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
@@ -312,6 +312,7 @@ where
 
     wasi_2023_10_18::add_to_linker(linker, get_http)?;
     wasi_2023_11_10::add_to_linker(linker, get_http)?;
+    wasi_2026_03_15::add_to_linker(linker, get_http_p3)?;
 
     Ok(())
 }

--- a/crates/factor-outbound-http/src/wasi_2023_10_18.rs
+++ b/crates/factor-outbound-http/src/wasi_2023_10_18.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use spin_factor_wasi::convert;
 use wasmtime::component::{Linker, Resource};
 use wasmtime_wasi_http::p2::WasiHttpCtxView;
 use wasmtime_wasi_http::p2::bindings as latest;
@@ -513,61 +514,6 @@ impl wasi::http::outgoing_handler::Host for WasiHttpCtxView<'_> {
         }
     }
 }
-
-macro_rules! convert {
-    () => {};
-    ($kind:ident $from:path [<=>] $to:path { $($body:tt)* } $($rest:tt)*) => {
-        convert!($kind $from => $to { $($body)* });
-        convert!($kind $to => $from { $($body)* });
-
-        convert!($($rest)*);
-    };
-    (struct $from:ty => $to:path { $($field:ident,)* } $($rest:tt)*) => {
-        impl From<$from> for $to {
-            fn from(e: $from) -> $to {
-                $to {
-                    $( $field: e.$field.into(), )*
-                }
-            }
-        }
-
-        convert!($($rest)*);
-    };
-    (enum $from:path => $to:path { $($variant:ident $(($e:ident))?,)* } $($rest:tt)*) => {
-        impl From<$from> for $to {
-            fn from(e: $from) -> $to {
-                use $from as A;
-                use $to as B;
-                match e {
-                    $(
-                        A::$variant $(($e))? => B::$variant $(($e.into()))?,
-                    )*
-                }
-            }
-        }
-
-        convert!($($rest)*);
-    };
-    (flags $from:path => $to:path { $($flag:ident,)* } $($rest:tt)*) => {
-        impl From<$from> for $to {
-            fn from(e: $from) -> $to {
-                use $from as A;
-                use $to as B;
-                let mut out = B::empty();
-                $(
-                    if e.contains(A::$flag) {
-                        out |= B::$flag;
-                    }
-                )*
-                out
-            }
-        }
-
-        convert!($($rest)*);
-    };
-}
-
-pub(crate) use convert;
 
 convert! {
     enum latest::http::types::Method [<=>] Method {

--- a/crates/factor-outbound-http/src/wasi_2023_11_10.rs
+++ b/crates/factor-outbound-http/src/wasi_2023_11_10.rs
@@ -1,7 +1,7 @@
 #![doc(hidden)] // internal implementation detail used in tests and spin-trigger
 
-use super::wasi_2023_10_18::convert;
 use anyhow::Result;
+use spin_factor_wasi::convert;
 use wasmtime::component::{Linker, Resource};
 use wasmtime_wasi_http::p2::WasiHttpCtxView;
 use wasmtime_wasi_http::p2::bindings as latest;

--- a/crates/factor-outbound-http/src/wasi_2026_03_15.rs
+++ b/crates/factor-outbound-http/src/wasi_2026_03_15.rs
@@ -29,6 +29,8 @@ mod bindings {
     });
 }
 
+pub use bindings::{Service, ServiceIndices};
+
 mod wasi {
     pub use super::bindings::wasi::http0_3_0_rc_2026_03_15 as http;
 }

--- a/crates/factor-outbound-http/src/wasi_2026_03_15.rs
+++ b/crates/factor-outbound-http/src/wasi_2026_03_15.rs
@@ -1,0 +1,709 @@
+use spin_factor_wasi::{FutureReaderExt as _, convert, convert_result, reborrow};
+use wasmtime::AsContextMut;
+use wasmtime::component::{Access, Accessor, FutureReader, Linker, Resource, StreamReader};
+use wasmtime_wasi_http::p3::{WasiHttp, WasiHttpCtxView, bindings as latest};
+
+mod bindings {
+    use super::latest;
+
+    wasmtime::component::bindgen!({
+        path: "../../wit",
+        world: "wasi:http/service@0.3.0-rc-2026-03-15",
+        imports: {
+            "wasi:http/client.send": store | trappable,
+            "wasi:http/types.[drop]request": store | trappable,
+            "wasi:http/types.[drop]response": store | trappable,
+            "wasi:http/types.[static]request.consume-body": store | trappable,
+            "wasi:http/types.[static]request.new": store | trappable,
+            "wasi:http/types.[static]response.consume-body": store | trappable,
+            "wasi:http/types.[static]response.new": store | trappable,
+            default: trappable,
+        },
+        exports: { default: async | store },
+        with: {
+            "wasi:http/types.fields": latest::http::types::Fields,
+            "wasi:http/types.request": latest::http::types::Request,
+            "wasi:http/types.request-options": latest::http::types::RequestOptions,
+            "wasi:http/types.response": latest::http::types::Response,
+        },
+    });
+}
+
+mod wasi {
+    pub use super::bindings::wasi::http0_3_0_rc_2026_03_15 as http;
+}
+
+pub(crate) fn add_to_linker<T>(
+    linker: &mut Linker<T>,
+    closure: fn(&mut T) -> WasiHttpCtxView<'_>,
+) -> anyhow::Result<()>
+where
+    T: Send + 'static,
+{
+    wasi::http::types::add_to_linker::<_, WasiHttp>(linker, closure)?;
+    wasi::http::client::add_to_linker::<_, WasiHttp>(linker, closure)?;
+    Ok(())
+}
+
+impl wasi::http::types::Host for WasiHttpCtxView<'_> {}
+
+impl wasi::http::types::HostResponse for WasiHttpCtxView<'_> {
+    fn get_status_code(
+        &mut self,
+        res: Resource<wasi::http::types::Response>,
+    ) -> wasmtime::Result<wasi::http::types::StatusCode> {
+        latest::http::types::HostResponse::get_status_code(self, res)
+    }
+
+    fn set_status_code(
+        &mut self,
+        res: Resource<wasi::http::types::Response>,
+        status_code: wasi::http::types::StatusCode,
+    ) -> wasmtime::Result<Result<(), ()>> {
+        latest::http::types::HostResponse::set_status_code(self, res, status_code)
+    }
+
+    fn get_headers(
+        &mut self,
+        res: Resource<wasi::http::types::Response>,
+    ) -> wasmtime::Result<Resource<wasi::http::types::Headers>> {
+        latest::http::types::HostResponse::get_headers(self, res)
+    }
+}
+
+impl wasi::http::types::HostRequestOptions for WasiHttpCtxView<'_> {
+    fn new(&mut self) -> wasmtime::Result<Resource<wasi::http::types::RequestOptions>> {
+        latest::http::types::HostRequestOptions::new(self)
+    }
+
+    fn get_connect_timeout(
+        &mut self,
+        opts: Resource<wasi::http::types::RequestOptions>,
+    ) -> wasmtime::Result<Option<wasi::http::types::Duration>> {
+        latest::http::types::HostRequestOptions::get_connect_timeout(self, opts)
+    }
+
+    fn set_connect_timeout(
+        &mut self,
+        opts: Resource<wasi::http::types::RequestOptions>,
+        duration: Option<wasi::http::types::Duration>,
+    ) -> wasmtime::Result<Result<(), wasi::http::types::RequestOptionsError>> {
+        convert_result(
+            latest::http::types::HostRequestOptions::set_connect_timeout(self, opts, duration),
+        )
+    }
+
+    fn get_first_byte_timeout(
+        &mut self,
+        opts: Resource<wasi::http::types::RequestOptions>,
+    ) -> wasmtime::Result<Option<wasi::http::types::Duration>> {
+        latest::http::types::HostRequestOptions::get_first_byte_timeout(self, opts)
+    }
+
+    fn set_first_byte_timeout(
+        &mut self,
+        opts: Resource<wasi::http::types::RequestOptions>,
+        duration: Option<wasi::http::types::Duration>,
+    ) -> wasmtime::Result<Result<(), wasi::http::types::RequestOptionsError>> {
+        convert_result(
+            latest::http::types::HostRequestOptions::set_first_byte_timeout(self, opts, duration),
+        )
+    }
+
+    fn get_between_bytes_timeout(
+        &mut self,
+        opts: Resource<wasi::http::types::RequestOptions>,
+    ) -> wasmtime::Result<Option<wasi::http::types::Duration>> {
+        latest::http::types::HostRequestOptions::get_between_bytes_timeout(self, opts)
+    }
+
+    fn set_between_bytes_timeout(
+        &mut self,
+        opts: Resource<wasi::http::types::RequestOptions>,
+        duration: Option<wasi::http::types::Duration>,
+    ) -> wasmtime::Result<Result<(), wasi::http::types::RequestOptionsError>> {
+        convert_result(
+            latest::http::types::HostRequestOptions::set_between_bytes_timeout(
+                self, opts, duration,
+            ),
+        )
+    }
+
+    fn clone(
+        &mut self,
+        opts: Resource<wasi::http::types::RequestOptions>,
+    ) -> wasmtime::Result<Resource<wasi::http::types::RequestOptions>> {
+        latest::http::types::HostRequestOptions::clone(self, opts)
+    }
+
+    fn drop(&mut self, opts: Resource<wasi::http::types::RequestOptions>) -> wasmtime::Result<()> {
+        latest::http::types::HostRequestOptions::drop(self, opts)
+    }
+}
+
+impl<T> wasi::http::types::HostRequestWithStore<T> for WasiHttp {
+    fn new(
+        mut store: Access<T, Self>,
+        headers: Resource<wasi::http::types::Headers>,
+        contents: Option<StreamReader<u8>>,
+        trailers: FutureReader<
+            Result<Option<Resource<wasi::http::types::Trailers>>, wasi::http::types::ErrorCode>,
+        >,
+        options: Option<Resource<wasi::http::types::RequestOptions>>,
+    ) -> wasmtime::Result<(
+        Resource<wasi::http::types::Request>,
+        FutureReader<Result<(), wasi::http::types::ErrorCode>>,
+    )> {
+        let trailers = trailers.try_map(store.as_context_mut(), |v| v.map_err(|v| v.into()))?;
+        latest::http::types::HostRequestWithStore::new(
+            reborrow(&mut store),
+            headers,
+            contents,
+            trailers,
+            options,
+        )
+        .and_then(|(req, future)| Ok((req, future.try_map(store, |v| v.map_err(|v| v.into()))?)))
+    }
+
+    fn consume_body(
+        mut store: Access<T, Self>,
+        req: Resource<wasi::http::types::Request>,
+        fut: FutureReader<Result<(), wasi::http::types::ErrorCode>>,
+    ) -> wasmtime::Result<(
+        StreamReader<u8>,
+        FutureReader<
+            Result<Option<Resource<wasi::http::types::Trailers>>, wasi::http::types::ErrorCode>,
+        >,
+    )> {
+        let fut = fut.try_map(store.as_context_mut(), |v| v.map_err(|v| v.into()))?;
+        latest::http::types::HostRequestWithStore::consume_body(reborrow(&mut store), req, fut)
+            .and_then(|(stream, future)| {
+                Ok((stream, future.try_map(store, |v| v.map_err(|v| v.into()))?))
+            })
+    }
+
+    fn drop(
+        store: Access<'_, T, Self>,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<()> {
+        latest::http::types::HostRequestWithStore::drop(store, req)
+    }
+}
+
+impl wasi::http::types::HostRequest for WasiHttpCtxView<'_> {
+    fn get_method(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<wasi::http::types::Method> {
+        latest::http::types::HostRequest::get_method(self, req).map(|v| v.into())
+    }
+
+    fn set_method(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+        method: wasi::http::types::Method,
+    ) -> wasmtime::Result<Result<(), ()>> {
+        latest::http::types::HostRequest::set_method(self, req, method.into())
+    }
+
+    fn get_path_with_query(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<Option<String>> {
+        latest::http::types::HostRequest::get_path_with_query(self, req)
+    }
+
+    fn set_path_with_query(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+        path_with_query: Option<String>,
+    ) -> wasmtime::Result<Result<(), ()>> {
+        latest::http::types::HostRequest::set_path_with_query(self, req, path_with_query)
+    }
+
+    fn get_scheme(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<Option<wasi::http::types::Scheme>> {
+        latest::http::types::HostRequest::get_scheme(self, req).map(|v| v.map(|v| v.into()))
+    }
+
+    fn set_scheme(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+        scheme: Option<wasi::http::types::Scheme>,
+    ) -> wasmtime::Result<Result<(), ()>> {
+        latest::http::types::HostRequest::set_scheme(self, req, scheme.map(|v| v.into()))
+    }
+
+    fn get_authority(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<Option<String>> {
+        latest::http::types::HostRequest::get_authority(self, req)
+    }
+
+    fn set_authority(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+        authority: Option<String>,
+    ) -> wasmtime::Result<Result<(), ()>> {
+        latest::http::types::HostRequest::set_authority(self, req, authority)
+    }
+
+    fn get_options(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<Option<Resource<wasi::http::types::RequestOptions>>> {
+        latest::http::types::HostRequest::get_options(self, req)
+    }
+
+    fn get_headers(
+        &mut self,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<Resource<wasi::http::types::Headers>> {
+        latest::http::types::HostRequest::get_headers(self, req)
+    }
+}
+
+impl wasi::http::types::HostFields for WasiHttpCtxView<'_> {
+    fn new(&mut self) -> wasmtime::Result<Resource<wasi::http::types::Fields>> {
+        latest::http::types::HostFields::new(self)
+    }
+
+    fn from_list(
+        &mut self,
+        entries: Vec<(wasi::http::types::FieldName, wasi::http::types::FieldValue)>,
+    ) -> wasmtime::Result<Result<Resource<wasi::http::types::Fields>, wasi::http::types::HeaderError>>
+    {
+        convert_result(latest::http::types::HostFields::from_list(self, entries))
+    }
+
+    fn get(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+        name: wasi::http::types::FieldName,
+    ) -> wasmtime::Result<Vec<wasi::http::types::FieldValue>> {
+        latest::http::types::HostFields::get(self, fields, name)
+    }
+
+    fn has(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+        name: wasi::http::types::FieldName,
+    ) -> wasmtime::Result<bool> {
+        latest::http::types::HostFields::has(self, fields, name)
+    }
+
+    fn set(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+        name: wasi::http::types::FieldName,
+        value: Vec<wasi::http::types::FieldValue>,
+    ) -> wasmtime::Result<Result<(), wasi::http::types::HeaderError>> {
+        convert_result(latest::http::types::HostFields::set(
+            self, fields, name, value,
+        ))
+    }
+
+    fn delete(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+        name: wasi::http::types::FieldName,
+    ) -> wasmtime::Result<Result<(), wasi::http::types::HeaderError>> {
+        convert_result(latest::http::types::HostFields::delete(self, fields, name))
+    }
+
+    fn get_and_delete(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+        name: wasi::http::types::FieldName,
+    ) -> wasmtime::Result<Result<Vec<wasi::http::types::FieldValue>, wasi::http::types::HeaderError>>
+    {
+        convert_result(latest::http::types::HostFields::get_and_delete(
+            self, fields, name,
+        ))
+    }
+
+    fn append(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+        name: wasi::http::types::FieldName,
+        value: wasi::http::types::FieldValue,
+    ) -> wasmtime::Result<Result<(), wasi::http::types::HeaderError>> {
+        convert_result(latest::http::types::HostFields::append(
+            self, fields, name, value,
+        ))
+    }
+
+    fn copy_all(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+    ) -> wasmtime::Result<Vec<(wasi::http::types::FieldName, wasi::http::types::FieldValue)>> {
+        latest::http::types::HostFields::copy_all(self, fields)
+    }
+
+    fn clone(
+        &mut self,
+        fields: Resource<wasi::http::types::Fields>,
+    ) -> wasmtime::Result<Resource<wasi::http::types::Fields>> {
+        latest::http::types::HostFields::clone(self, fields)
+    }
+
+    fn drop(&mut self, fields: Resource<wasi::http::types::Fields>) -> wasmtime::Result<()> {
+        latest::http::types::HostFields::drop(self, fields)
+    }
+}
+
+impl<T> wasi::http::types::HostResponseWithStore<T> for WasiHttp {
+    fn new(
+        mut store: Access<T, Self>,
+        headers: Resource<wasi::http::types::Headers>,
+        contents: Option<StreamReader<u8>>,
+        trailers: FutureReader<
+            Result<Option<Resource<wasi::http::types::Trailers>>, wasi::http::types::ErrorCode>,
+        >,
+    ) -> wasmtime::Result<(
+        Resource<wasi::http::types::Response>,
+        FutureReader<Result<(), wasi::http::types::ErrorCode>>,
+    )> {
+        let trailers = trailers.try_map(store.as_context_mut(), |v| v.map_err(|v| v.into()))?;
+        latest::http::types::HostResponseWithStore::new(
+            reborrow(&mut store),
+            headers,
+            contents,
+            trailers,
+        )
+        .and_then(|(res, future)| Ok((res, future.try_map(store, |v| v.map_err(|v| v.into()))?)))
+    }
+
+    fn consume_body(
+        mut store: Access<T, Self>,
+        res: Resource<wasi::http::types::Response>,
+        fut: FutureReader<Result<(), wasi::http::types::ErrorCode>>,
+    ) -> wasmtime::Result<(
+        StreamReader<u8>,
+        FutureReader<
+            Result<Option<Resource<wasi::http::types::Trailers>>, wasi::http::types::ErrorCode>,
+        >,
+    )> {
+        let fut = fut.try_map(store.as_context_mut(), |v| v.map_err(|v| v.into()))?;
+        latest::http::types::HostResponseWithStore::consume_body(reborrow(&mut store), res, fut)
+            .and_then(|(stream, future)| {
+                Ok((stream, future.try_map(store, |v| v.map_err(|v| v.into()))?))
+            })
+    }
+
+    fn drop(
+        store: Access<'_, T, Self>,
+        res: Resource<wasi::http::types::Response>,
+    ) -> wasmtime::Result<()> {
+        latest::http::types::HostResponseWithStore::drop(store, res)
+    }
+}
+
+impl<T> wasi::http::client::HostWithStore<T> for WasiHttp {
+    async fn send(
+        store: &Accessor<T, Self>,
+        req: Resource<wasi::http::types::Request>,
+    ) -> wasmtime::Result<Result<Resource<wasi::http::types::Response>, wasi::http::types::ErrorCode>>
+    {
+        convert_result(latest::http::client::HostWithStore::send(store, req).await)
+    }
+}
+
+impl wasi::http::client::Host for WasiHttpCtxView<'_> {}
+
+convert! {
+    struct latest::http::types::DnsErrorPayload [<=>] wasi::http::types::DnsErrorPayload {
+        rcode,
+        info_code,
+    }
+
+    struct latest::http::types::TlsAlertReceivedPayload [<=>] wasi::http::types::TlsAlertReceivedPayload {
+        alert_id,
+        alert_message,
+    }
+
+    struct latest::http::types::FieldSizePayload [<=>] wasi::http::types::FieldSizePayload {
+        field_name,
+        field_size,
+    }
+
+    enum latest::http::types::RequestOptionsError => wasi::http::types::RequestOptionsError {
+        NotSupported,
+        Immutable,
+        Other(v),
+    }
+
+    enum latest::http::types::Method [<=>] wasi::http::types::Method {
+        Get,
+        Head,
+        Post,
+        Put,
+        Delete,
+        Connect,
+        Options,
+        Trace,
+        Patch,
+        Other(v),
+    }
+
+    enum latest::http::types::Scheme [<=>] wasi::http::types::Scheme {
+        Http,
+        Https,
+        Other(v),
+    }
+
+    enum latest::http::types::HeaderError [<=>] wasi::http::types::HeaderError {
+        InvalidSyntax,
+        Forbidden,
+        Immutable,
+        SizeExceeded,
+        Other(v),
+    }
+}
+
+impl From<wasi::http::types::ErrorCode> for latest::http::types::ErrorCode {
+    fn from(e: wasi::http::types::ErrorCode) -> Self {
+        match e {
+            wasi::http::types::ErrorCode::DnsTimeout => latest::http::types::ErrorCode::DnsTimeout,
+            wasi::http::types::ErrorCode::DnsError(e) => {
+                latest::http::types::ErrorCode::DnsError(e.into())
+            }
+            wasi::http::types::ErrorCode::DestinationNotFound => {
+                latest::http::types::ErrorCode::DestinationNotFound
+            }
+            wasi::http::types::ErrorCode::DestinationUnavailable => {
+                latest::http::types::ErrorCode::DestinationUnavailable
+            }
+            wasi::http::types::ErrorCode::DestinationIpProhibited => {
+                latest::http::types::ErrorCode::DestinationIpProhibited
+            }
+            wasi::http::types::ErrorCode::DestinationIpUnroutable => {
+                latest::http::types::ErrorCode::DestinationIpUnroutable
+            }
+            wasi::http::types::ErrorCode::ConnectionRefused => {
+                latest::http::types::ErrorCode::ConnectionRefused
+            }
+            wasi::http::types::ErrorCode::ConnectionTerminated => {
+                latest::http::types::ErrorCode::ConnectionTerminated
+            }
+            wasi::http::types::ErrorCode::ConnectionTimeout => {
+                latest::http::types::ErrorCode::ConnectionTimeout
+            }
+            wasi::http::types::ErrorCode::ConnectionReadTimeout => {
+                latest::http::types::ErrorCode::ConnectionReadTimeout
+            }
+            wasi::http::types::ErrorCode::ConnectionWriteTimeout => {
+                latest::http::types::ErrorCode::ConnectionWriteTimeout
+            }
+            wasi::http::types::ErrorCode::ConnectionLimitReached => {
+                latest::http::types::ErrorCode::ConnectionLimitReached
+            }
+            wasi::http::types::ErrorCode::TlsProtocolError => {
+                latest::http::types::ErrorCode::TlsProtocolError
+            }
+            wasi::http::types::ErrorCode::TlsCertificateError => {
+                latest::http::types::ErrorCode::TlsCertificateError
+            }
+            wasi::http::types::ErrorCode::TlsAlertReceived(e) => {
+                latest::http::types::ErrorCode::TlsAlertReceived(e.into())
+            }
+            wasi::http::types::ErrorCode::HttpRequestDenied => {
+                latest::http::types::ErrorCode::HttpRequestDenied
+            }
+            wasi::http::types::ErrorCode::HttpRequestLengthRequired => {
+                latest::http::types::ErrorCode::HttpRequestLengthRequired
+            }
+            wasi::http::types::ErrorCode::HttpRequestBodySize(e) => {
+                latest::http::types::ErrorCode::HttpRequestBodySize(e)
+            }
+            wasi::http::types::ErrorCode::HttpRequestMethodInvalid => {
+                latest::http::types::ErrorCode::HttpRequestMethodInvalid
+            }
+            wasi::http::types::ErrorCode::HttpRequestUriInvalid => {
+                latest::http::types::ErrorCode::HttpRequestUriInvalid
+            }
+            wasi::http::types::ErrorCode::HttpRequestUriTooLong => {
+                latest::http::types::ErrorCode::HttpRequestUriTooLong
+            }
+            wasi::http::types::ErrorCode::HttpRequestHeaderSectionSize(e) => {
+                latest::http::types::ErrorCode::HttpRequestHeaderSectionSize(e)
+            }
+            wasi::http::types::ErrorCode::HttpRequestHeaderSize(e) => {
+                latest::http::types::ErrorCode::HttpRequestHeaderSize(e.map(|e| e.into()))
+            }
+            wasi::http::types::ErrorCode::HttpRequestTrailerSectionSize(e) => {
+                latest::http::types::ErrorCode::HttpRequestTrailerSectionSize(e)
+            }
+            wasi::http::types::ErrorCode::HttpRequestTrailerSize(e) => {
+                latest::http::types::ErrorCode::HttpRequestTrailerSize(e.into())
+            }
+            wasi::http::types::ErrorCode::HttpResponseIncomplete => {
+                latest::http::types::ErrorCode::HttpResponseIncomplete
+            }
+            wasi::http::types::ErrorCode::HttpResponseHeaderSectionSize(e) => {
+                latest::http::types::ErrorCode::HttpResponseHeaderSectionSize(e)
+            }
+            wasi::http::types::ErrorCode::HttpResponseHeaderSize(e) => {
+                latest::http::types::ErrorCode::HttpResponseHeaderSize(e.into())
+            }
+            wasi::http::types::ErrorCode::HttpResponseBodySize(e) => {
+                latest::http::types::ErrorCode::HttpResponseBodySize(e)
+            }
+            wasi::http::types::ErrorCode::HttpResponseTrailerSectionSize(e) => {
+                latest::http::types::ErrorCode::HttpResponseTrailerSectionSize(e)
+            }
+            wasi::http::types::ErrorCode::HttpResponseTrailerSize(e) => {
+                latest::http::types::ErrorCode::HttpResponseTrailerSize(e.into())
+            }
+            wasi::http::types::ErrorCode::HttpResponseTransferCoding(e) => {
+                latest::http::types::ErrorCode::HttpResponseTransferCoding(e)
+            }
+            wasi::http::types::ErrorCode::HttpResponseContentCoding(e) => {
+                latest::http::types::ErrorCode::HttpResponseContentCoding(e)
+            }
+            wasi::http::types::ErrorCode::HttpResponseTimeout => {
+                latest::http::types::ErrorCode::HttpResponseTimeout
+            }
+            wasi::http::types::ErrorCode::HttpUpgradeFailed => {
+                latest::http::types::ErrorCode::HttpUpgradeFailed
+            }
+            wasi::http::types::ErrorCode::HttpProtocolError => {
+                latest::http::types::ErrorCode::HttpProtocolError
+            }
+            wasi::http::types::ErrorCode::LoopDetected => {
+                latest::http::types::ErrorCode::LoopDetected
+            }
+            wasi::http::types::ErrorCode::ConfigurationError => {
+                latest::http::types::ErrorCode::ConfigurationError
+            }
+            wasi::http::types::ErrorCode::InternalError(e) => {
+                latest::http::types::ErrorCode::InternalError(e)
+            }
+        }
+    }
+}
+
+impl From<latest::http::types::ErrorCode> for wasi::http::types::ErrorCode {
+    fn from(e: latest::http::types::ErrorCode) -> Self {
+        match e {
+            latest::http::types::ErrorCode::DnsTimeout => wasi::http::types::ErrorCode::DnsTimeout,
+            latest::http::types::ErrorCode::DnsError(e) => {
+                wasi::http::types::ErrorCode::DnsError(e.into())
+            }
+            latest::http::types::ErrorCode::DestinationNotFound => {
+                wasi::http::types::ErrorCode::DestinationNotFound
+            }
+            latest::http::types::ErrorCode::DestinationUnavailable => {
+                wasi::http::types::ErrorCode::DestinationUnavailable
+            }
+            latest::http::types::ErrorCode::DestinationIpProhibited => {
+                wasi::http::types::ErrorCode::DestinationIpProhibited
+            }
+            latest::http::types::ErrorCode::DestinationIpUnroutable => {
+                wasi::http::types::ErrorCode::DestinationIpUnroutable
+            }
+            latest::http::types::ErrorCode::ConnectionRefused => {
+                wasi::http::types::ErrorCode::ConnectionRefused
+            }
+            latest::http::types::ErrorCode::ConnectionTerminated => {
+                wasi::http::types::ErrorCode::ConnectionTerminated
+            }
+            latest::http::types::ErrorCode::ConnectionTimeout => {
+                wasi::http::types::ErrorCode::ConnectionTimeout
+            }
+            latest::http::types::ErrorCode::ConnectionReadTimeout => {
+                wasi::http::types::ErrorCode::ConnectionReadTimeout
+            }
+            latest::http::types::ErrorCode::ConnectionWriteTimeout => {
+                wasi::http::types::ErrorCode::ConnectionWriteTimeout
+            }
+            latest::http::types::ErrorCode::ConnectionLimitReached => {
+                wasi::http::types::ErrorCode::ConnectionLimitReached
+            }
+            latest::http::types::ErrorCode::TlsProtocolError => {
+                wasi::http::types::ErrorCode::TlsProtocolError
+            }
+            latest::http::types::ErrorCode::TlsCertificateError => {
+                wasi::http::types::ErrorCode::TlsCertificateError
+            }
+            latest::http::types::ErrorCode::TlsAlertReceived(e) => {
+                wasi::http::types::ErrorCode::TlsAlertReceived(e.into())
+            }
+            latest::http::types::ErrorCode::HttpRequestDenied => {
+                wasi::http::types::ErrorCode::HttpRequestDenied
+            }
+            latest::http::types::ErrorCode::HttpRequestLengthRequired => {
+                wasi::http::types::ErrorCode::HttpRequestLengthRequired
+            }
+            latest::http::types::ErrorCode::HttpRequestBodySize(e) => {
+                wasi::http::types::ErrorCode::HttpRequestBodySize(e)
+            }
+            latest::http::types::ErrorCode::HttpRequestMethodInvalid => {
+                wasi::http::types::ErrorCode::HttpRequestMethodInvalid
+            }
+            latest::http::types::ErrorCode::HttpRequestUriInvalid => {
+                wasi::http::types::ErrorCode::HttpRequestUriInvalid
+            }
+            latest::http::types::ErrorCode::HttpRequestUriTooLong => {
+                wasi::http::types::ErrorCode::HttpRequestUriTooLong
+            }
+            latest::http::types::ErrorCode::HttpRequestHeaderSectionSize(e) => {
+                wasi::http::types::ErrorCode::HttpRequestHeaderSectionSize(e)
+            }
+            latest::http::types::ErrorCode::HttpRequestHeaderSize(e) => {
+                wasi::http::types::ErrorCode::HttpRequestHeaderSize(e.map(|e| e.into()))
+            }
+            latest::http::types::ErrorCode::HttpRequestTrailerSectionSize(e) => {
+                wasi::http::types::ErrorCode::HttpRequestTrailerSectionSize(e)
+            }
+            latest::http::types::ErrorCode::HttpRequestTrailerSize(e) => {
+                wasi::http::types::ErrorCode::HttpRequestTrailerSize(e.into())
+            }
+            latest::http::types::ErrorCode::HttpResponseIncomplete => {
+                wasi::http::types::ErrorCode::HttpResponseIncomplete
+            }
+            latest::http::types::ErrorCode::HttpResponseHeaderSectionSize(e) => {
+                wasi::http::types::ErrorCode::HttpResponseHeaderSectionSize(e)
+            }
+            latest::http::types::ErrorCode::HttpResponseHeaderSize(e) => {
+                wasi::http::types::ErrorCode::HttpResponseHeaderSize(e.into())
+            }
+            latest::http::types::ErrorCode::HttpResponseBodySize(e) => {
+                wasi::http::types::ErrorCode::HttpResponseBodySize(e)
+            }
+            latest::http::types::ErrorCode::HttpResponseTrailerSectionSize(e) => {
+                wasi::http::types::ErrorCode::HttpResponseTrailerSectionSize(e)
+            }
+            latest::http::types::ErrorCode::HttpResponseTrailerSize(e) => {
+                wasi::http::types::ErrorCode::HttpResponseTrailerSize(e.into())
+            }
+            latest::http::types::ErrorCode::HttpResponseTransferCoding(e) => {
+                wasi::http::types::ErrorCode::HttpResponseTransferCoding(e)
+            }
+            latest::http::types::ErrorCode::HttpResponseContentCoding(e) => {
+                wasi::http::types::ErrorCode::HttpResponseContentCoding(e)
+            }
+            latest::http::types::ErrorCode::HttpResponseTimeout => {
+                wasi::http::types::ErrorCode::HttpResponseTimeout
+            }
+            latest::http::types::ErrorCode::HttpUpgradeFailed => {
+                wasi::http::types::ErrorCode::HttpUpgradeFailed
+            }
+            latest::http::types::ErrorCode::HttpProtocolError => {
+                wasi::http::types::ErrorCode::HttpProtocolError
+            }
+            latest::http::types::ErrorCode::LoopDetected => {
+                wasi::http::types::ErrorCode::LoopDetected
+            }
+            latest::http::types::ErrorCode::ConfigurationError => {
+                wasi::http::types::ErrorCode::ConfigurationError
+            }
+            latest::http::types::ErrorCode::InternalError(e) => {
+                wasi::http::types::ErrorCode::InternalError(e)
+            }
+        }
+    }
+}

--- a/crates/factor-outbound-mqtt/src/host.rs
+++ b/crates/factor-outbound-mqtt/src/host.rs
@@ -112,9 +112,9 @@ impl v3::HostConnection for InstanceState {
     }
 }
 
-impl v3::HostConnectionWithStore for crate::MqttFactorData {
+impl<T: Send> v3::HostConnectionWithStore<T> for crate::MqttFactorData {
     #[instrument(name = "spin_outbound_mqtt.open_connection", skip(accessor, password), err(level = Level::INFO), fields(otel.kind = "client"))]
-    async fn open<T: Send>(
+    async fn open(
         accessor: &Accessor<T, Self>,
         address: String,
         username: String,
@@ -169,7 +169,7 @@ impl v3::HostConnectionWithStore for crate::MqttFactorData {
             messaging.system = "mqtt",
             messaging.destination.name = topic,
         ))]
-    async fn publish<T: Send>(
+    async fn publish(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         topic: String,

--- a/crates/factor-outbound-mqtt/src/lib.rs
+++ b/crates/factor-outbound-mqtt/src/lib.rs
@@ -47,7 +47,7 @@ impl Factor for OutboundMqttFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: spin_factors::InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(v2::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(v3::add_to_linker::<_, MqttFactorData>)?;
         Ok(())

--- a/crates/factor-outbound-mysql/src/host.rs
+++ b/crates/factor-outbound-mysql/src/host.rs
@@ -94,9 +94,9 @@ type QueryTuple = (
     FutureReader<Result<(), v3::Error>>,
 );
 
-impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
+impl<C: Client, T> v3::HostConnectionWithStore<T> for MysqlFactorData<C> {
     #[instrument(name = "spin_outbound_mysql.open", skip(accessor, address), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
-    async fn open<T>(
+    async fn open(
         accessor: &Accessor<T, Self>,
         address: String,
     ) -> Result<Resource<v3::Connection>, v3::Error> {
@@ -116,7 +116,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
     }
 
     #[instrument(name = "spin_outbound_mysql.execute", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", otel.name = statement))]
-    async fn execute<T>(
+    async fn execute(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         statement: String,
@@ -138,7 +138,7 @@ impl<C: Client> v3::HostConnectionWithStore for MysqlFactorData<C> {
     }
 
     #[instrument(name = "spin_outbound_mysql.query", skip(accessor, connection, params), err(level = Level::INFO), fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "mysql", otel.name = statement))]
-    async fn query<T>(
+    async fn query(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         statement: String,

--- a/crates/factor-outbound-mysql/src/lib.rs
+++ b/crates/factor-outbound-mysql/src/lib.rs
@@ -32,7 +32,7 @@ impl<C: Send + Sync + Client + 'static> Factor for OutboundMysqlFactor<C> {
     type AppState = AppState;
     type InstanceBuilder = InstanceState<C>;
 
-    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(v1::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(v2::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(v3::add_to_linker::<_, MysqlFactorData<C>>)?;

--- a/crates/factor-outbound-networking/tests/factor_test.rs
+++ b/crates/factor-outbound-networking/tests/factor_test.rs
@@ -17,7 +17,7 @@ use wasmtime_wasi::p2::bindings::sockets::network::{ErrorCode, IpAddressFamily};
 use wasmtime_wasi::p2::bindings::sockets::tcp as p2_tcp;
 use wasmtime_wasi::p2::bindings::sockets::tcp_create_socket as p2_tcp_create;
 use wasmtime_wasi::p2::bindings::sockets::udp_create_socket as p2_udp_create;
-use wasmtime_wasi::sockets::SocketAddrUse;
+use wasmtime_wasi::sockets::{SocketAddrUse, WasiSocketsCtxView};
 
 struct MockMqttClient;
 
@@ -53,11 +53,27 @@ struct TestFactorsWithMqtt {
     mqtt: OutboundMqttFactor,
 }
 
+fn get_sockets_view_with_mqtt(
+    state: &mut TestFactorsWithMqttInstanceState,
+) -> WasiSocketsCtxView<'_> {
+    WasiSocketsCtxView {
+        ctx: state.wasi.ctx().sockets(),
+        table: &mut state.__table,
+    }
+}
+
 #[derive(RuntimeFactors)]
 struct TestFactors {
     wasi: WasiFactor,
     variables: VariablesFactor,
     networking: OutboundNetworkingFactor,
+}
+
+fn get_sockets_view(state: &mut TestFactorsInstanceState) -> WasiSocketsCtxView<'_> {
+    WasiSocketsCtxView {
+        ctx: state.wasi.ctx().sockets(),
+        table: &mut state.__table,
+    }
 }
 
 #[tokio::test]
@@ -81,7 +97,7 @@ async fn configures_wasi_socket_addr_check() -> anyhow::Result<()> {
             ..Default::default()
         })?;
     let mut state = env.build_instance_state().await?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
 
     let network_resource = sockets.instance_network()?;
     let network = sockets.table.get(&network_resource)?;
@@ -150,7 +166,7 @@ async fn socket_quota_blocks_excess_connections() -> anyhow::Result<()> {
         })?;
 
     let mut state = env.build_instance_state().await?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
     let addr: std::net::SocketAddr = "123.0.2.1:12345".parse().unwrap();
 
     // First two connections should be accepted (non-blocking connect initiated)
@@ -215,7 +231,7 @@ async fn socket_quota_releases_on_instance_drop() -> anyhow::Result<()> {
     {
         let builders = factors.prepare(&configured_app, &component_id)?;
         let mut state = factors.build_instance_state(builders)?;
-        let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+        let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
         let net = sockets.instance_network()?;
         let sock = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
         p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock, net, addr.into()).await?;
@@ -225,7 +241,7 @@ async fn socket_quota_releases_on_instance_drop() -> anyhow::Result<()> {
     // Second instance: quota should be fully available again
     let builders = factors.prepare(&configured_app, &component_id)?;
     let mut state = factors.build_instance_state(builders)?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
     let net = sockets.instance_network()?;
     let sock = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
     p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock, net, addr.into()).await?;
@@ -246,7 +262,7 @@ async fn no_socket_quota_allows_unlimited() -> anyhow::Result<()> {
     });
 
     let mut state = env.build_instance_state().await?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
     let addr: std::net::SocketAddr = "123.0.2.1:12345".parse().unwrap();
 
     for _ in 0..10 {
@@ -279,7 +295,7 @@ async fn socket_quota_still_enforces_allowed_hosts() -> anyhow::Result<()> {
         })?;
 
     let mut state = env.build_instance_state().await?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
 
     // Allowed host succeeds
     let net = sockets.instance_network()?;
@@ -321,7 +337,7 @@ async fn socket_quota_releases_on_socket_drop() -> anyhow::Result<()> {
         })?;
 
     let mut state = env.build_instance_state().await?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
     let addr: std::net::SocketAddr = "123.0.2.1:12345".parse().unwrap();
 
     // Acquire the only permit via start_connect. Save the rep so we can reconstruct
@@ -375,7 +391,7 @@ async fn socket_quota_blocks_excess_udp_sockets() -> anyhow::Result<()> {
         })?;
 
     let mut state = env.build_instance_state().await?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
 
     // First two UDP socket creations should succeed.
     p2_udp_create::Host::create_udp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
@@ -410,7 +426,7 @@ async fn socket_quota_shared_between_tcp_and_udp() -> anyhow::Result<()> {
         })?;
 
     let mut state = env.build_instance_state().await?;
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
     let addr: std::net::SocketAddr = "123.0.2.1:12345".parse().unwrap();
 
     // Consume one permit with a TCP connection.
@@ -476,7 +492,7 @@ async fn global_connection_limit_enforced_across_factors() -> anyhow::Result<()>
         .await?;
 
     // With the global permit held by MQTT, a TCP socket start_connect must fail immediately.
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view_with_mqtt).unwrap();
     let addr: std::net::SocketAddr = "123.0.2.1:12345".parse().unwrap();
     let net = sockets.instance_network()?;
     let sock = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
@@ -494,7 +510,7 @@ async fn global_connection_limit_enforced_across_factors() -> anyhow::Result<()>
     state.mqtt.drop(conn).await?;
 
     // Now the TCP socket start_connect must succeed.
-    let mut sockets = WasiFactor::get_sockets_impl(&mut state).unwrap();
+    let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view_with_mqtt).unwrap();
     let net = sockets.instance_network()?;
     let sock = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
     p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock, net, addr.into())

--- a/crates/factor-outbound-pg/src/host.rs
+++ b/crates/factor-outbound-pg/src/host.rs
@@ -250,12 +250,12 @@ impl<CF: ClientFactory> v4::HostConnection for InstanceState<CF> {
     }
 }
 
-impl<CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectionWithStore
+impl<T, CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectionWithStore<T>
     for crate::PgFactorData<CF>
 {
     #[instrument(name = "spin_outbound_pg.open_async", skip(accessor, address), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
-    async fn open_async<T>(
+    async fn open_async(
         accessor: &Accessor<T, Self>,
         address: String,
     ) -> Result<Resource<v4::Connection>, v4::Error> {
@@ -269,7 +269,7 @@ impl<CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectio
 
     #[instrument(name = "spin_outbound_pg.execute", skip(accessor, connection, params), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql"))]
-    async fn execute_async<T>(
+    async fn execute_async(
         accessor: &Accessor<T, Self>,
         connection: Resource<v4::Connection>,
         statement: String,
@@ -292,7 +292,7 @@ impl<CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectio
     #[allow(clippy::type_complexity)] // blame bindgen, clippy, blame bindgen
     #[instrument(name = "spin_outbound_pg.query_async", skip(accessor, params), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "postgresql"))]
-    async fn query_async<T>(
+    async fn query_async(
         accessor: &Accessor<T, Self>,
         connection: Resource<v4::Connection>,
         statement: String,
@@ -423,10 +423,11 @@ impl<CF: ClientFactory> crate::PgFactorData<CF> {
     }
 }
 
-impl<CF: ClientFactory> spin_world::spin::postgres4_2_0::postgres::HostConnectionBuilderWithStore
+impl<T, CF: ClientFactory>
+    spin_world::spin::postgres4_2_0::postgres::HostConnectionBuilderWithStore<T>
     for crate::PgFactorData<CF>
 {
-    async fn build_async<T>(
+    async fn build_async(
         accessor: &Accessor<T, Self>,
         builder: Resource<v4::ConnectionBuilder>,
     ) -> Result<Resource<v4::Connection>, v4::Error> {

--- a/crates/factor-outbound-pg/src/lib.rs
+++ b/crates/factor-outbound-pg/src/lib.rs
@@ -33,7 +33,7 @@ impl<CF: ClientFactory> Factor for OutboundPgFactor<CF> {
     type AppState = AppState<CF>;
     type InstanceBuilder = InstanceState<CF>;
 
-    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: spin_factors::InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::postgres::add_to_linker::<_, PgFactorData<CF>>)?;
         ctx.link_bindings(spin_world::v2::postgres::add_to_linker::<_, PgFactorData<CF>>)?;
         ctx.link_bindings(

--- a/crates/factor-outbound-redis/src/host.rs
+++ b/crates/factor-outbound-redis/src/host.rs
@@ -235,10 +235,10 @@ impl crate::RedisFactorData {
     }
 }
 
-impl v3::HostConnectionWithStore for crate::RedisFactorData {
+impl<T: Send> v3::HostConnectionWithStore<T> for crate::RedisFactorData {
     #[instrument(name = "spin_outbound_redis.open_connection", skip(accessor, address), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", {otel_attribute::SERVER_ADDRESS} = Empty, {otel_attribute::SERVER_PORT} = Empty, {otel_attribute::DB_NAMESPACE} = Empty))]
-    async fn open<T: Send>(
+    async fn open(
         accessor: &Accessor<T, Self>,
         address: String,
     ) -> Result<Resource<v3::Connection>, v3::Error> {
@@ -284,7 +284,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.publish", skip(accessor, connection, payload), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "PUBLISH"))]
-    async fn publish<T: Send>(
+    async fn publish(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         channel: String,
@@ -296,7 +296,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.get", skip(accessor, connection), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "GET"))]
-    async fn get<T: Send>(
+    async fn get(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         key: String,
@@ -307,7 +307,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.set", skip(accessor, connection, value), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "SET"))]
-    async fn set<T: Send>(
+    async fn set(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         key: String,
@@ -319,7 +319,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.incr", skip(accessor, connection), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "INCRBY"))]
-    async fn incr<T: Send>(
+    async fn incr(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         key: String,
@@ -330,7 +330,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.del", skip(accessor, connection), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "DEL"))]
-    async fn del<T: Send>(
+    async fn del(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         keys: Vec<String>,
@@ -341,7 +341,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.sadd", skip(accessor, connection, values), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "SADD"))]
-    async fn sadd<T: Send>(
+    async fn sadd(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         key: String,
@@ -353,7 +353,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.smembers", skip(accessor, connection), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "SMEMBERS"))]
-    async fn smembers<T: Send>(
+    async fn smembers(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         key: String,
@@ -364,7 +364,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.srem", skip(accessor, connection, values), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = "SREM"))]
-    async fn srem<T: Send>(
+    async fn srem(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         key: String,
@@ -376,7 +376,7 @@ impl v3::HostConnectionWithStore for crate::RedisFactorData {
 
     #[instrument(name = "spin_outbound_redis.execute", skip(accessor, connection), err(level = Level::INFO),
         fields(otel.kind = "client", {otel_attribute::DB_SYSTEM_NAME} = "redis", otel.name = format!("{}", command)))]
-    async fn execute<T: Send>(
+    async fn execute(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         command: String,

--- a/crates/factor-outbound-redis/src/lib.rs
+++ b/crates/factor-outbound-redis/src/lib.rs
@@ -38,7 +38,7 @@ impl Factor for OutboundRedisFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: spin_factors::InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::redis::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(spin_world::v2::redis::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(v3::add_to_linker::<_, RedisFactorData>)?;

--- a/crates/factor-sqlite/src/host.rs
+++ b/crates/factor-sqlite/src/host.rs
@@ -152,8 +152,8 @@ impl v3::HostConnection for InstanceState {
     }
 }
 
-impl v3::HostConnectionWithStore for crate::SqliteFactorData {
-    async fn open_async<T>(
+impl<T> v3::HostConnectionWithStore<T> for crate::SqliteFactorData {
+    async fn open_async(
         accessor: &Accessor<T, Self>,
         database: String,
     ) -> Result<Resource<v3::Connection>, v3::Error> {
@@ -186,7 +186,7 @@ impl v3::HostConnectionWithStore for crate::SqliteFactorData {
         })
     }
 
-    async fn execute_async<T>(
+    async fn execute_async(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
         query: String,
@@ -229,7 +229,7 @@ impl v3::HostConnectionWithStore for crate::SqliteFactorData {
         Ok((columns, sr, efr))
     }
 
-    async fn changes_async<T>(
+    async fn changes_async(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
     ) -> anyhow::Result<u64> {
@@ -249,7 +249,7 @@ impl v3::HostConnectionWithStore for crate::SqliteFactorData {
         conn.changes().await.map_err(|e| e.into())
     }
 
-    async fn last_insert_rowid_async<T>(
+    async fn last_insert_rowid_async(
         accessor: &Accessor<T, Self>,
         connection: Resource<v3::Connection>,
     ) -> anyhow::Result<i64> {

--- a/crates/factor-sqlite/src/lib.rs
+++ b/crates/factor-sqlite/src/lib.rs
@@ -33,7 +33,7 @@ impl Factor for SqliteFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init(&mut self, ctx: &mut impl spin_factors::InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: spin_factors::InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(v1::add_to_linker::<_, SqliteFactorData>)?;
         ctx.link_bindings(v2::add_to_linker::<_, SqliteFactorData>)?;
         ctx.link_bindings(v3::add_to_linker::<_, SqliteFactorData>)?;

--- a/crates/factor-variables/src/host.rs
+++ b/crates/factor-variables/src/host.rs
@@ -8,9 +8,9 @@ use tracing::instrument;
 
 use crate::{InstanceState, VariablesFactorData};
 
-impl v3::HostWithStore for VariablesFactorData {
+impl<T: Send> v3::HostWithStore<T> for VariablesFactorData {
     #[instrument(name = "spin_variables.get", skip(accessor), fields(otel.kind = "client"))]
-    async fn get<T: Send>(accessor: &Accessor<T, Self>, key: String) -> Result<String, v3::Error> {
+    async fn get(accessor: &Accessor<T, Self>, key: String) -> Result<String, v3::Error> {
         let (resolver, component_id) = accessor.with(|mut access| {
             let host = access.get();
             host.otel.reparent_tracing_span();

--- a/crates/factor-variables/src/lib.rs
+++ b/crates/factor-variables/src/lib.rs
@@ -30,7 +30,7 @@ impl Factor for VariablesFactor {
     type AppState = AppState;
     type InstanceBuilder = InstanceState;
 
-    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         ctx.link_bindings(spin_world::v1::config::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(spin_world::v2::variables::add_to_linker::<_, FactorData<Self>>)?;
         ctx.link_bindings(spin_world::wasi::config::store::add_to_linker::<_, FactorData<Self>>)?;

--- a/crates/factor-wasi/Cargo.toml
+++ b/crates/factor-wasi/Cargo.toml
@@ -8,6 +8,8 @@ license = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 bytes = { workspace = true }
+futures = { workspace = true }
+pin-project-lite = { workspace = true }
 spin-common = { path = "../common" }
 spin-connection-semaphore = { path = "../connection-semaphore" }
 spin-factors = { path = "../factors" }

--- a/crates/factor-wasi/src/lib.rs
+++ b/crates/factor-wasi/src/lib.rs
@@ -3,6 +3,7 @@ pub mod sockets;
 pub mod spin;
 mod wasi_2023_10_18;
 mod wasi_2023_11_10;
+mod wasi_2026_03_15;
 
 use std::{
     future::Future,
@@ -26,6 +27,8 @@ use wasmtime_wasi::sockets::{WasiSockets, WasiSocketsCtxView};
 use wasmtime_wasi::{DirPerms, FilePerms, ResourceTable, WasiCtx, WasiCtxBuilder, WasiCtxView};
 
 pub use sockets::{SocketPermitState, SpinSockets, SpinSocketsView};
+pub use wasi_2023_10_18::convert_result;
+pub use wasi_2026_03_15::{FutureReaderExt, StreamReaderExt, reborrow};
 pub use wasmtime_wasi::sockets::SocketAddrUse;
 
 pub struct WasiFactor {
@@ -248,6 +251,29 @@ trait InitContextExt: InitContext<WasiFactor> {
             Self::get_spin_sockets,
         )
     }
+
+    fn link_all_p3_bindings(
+        &mut self,
+        add_to_linker: fn(
+            &mut wasmtime::component::Linker<Self::StoreData>,
+            fn(&mut Self::StoreData) -> &mut WasiRandomCtx,
+            fn(&mut Self::StoreData) -> WasiClocksCtxView<'_>,
+            fn(&mut Self::StoreData) -> WasiCliCtxView<'_>,
+            fn(&mut Self::StoreData) -> WasiFilesystemCtxView<'_>,
+            fn(&mut Self::StoreData) -> SpinSocketsView<'_, Self::StoreData>,
+            fn(&mut Self::StoreData) -> WasiSocketsCtxView<'_>,
+        ) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        add_to_linker(
+            self.linker(),
+            Self::get_random,
+            Self::get_clocks,
+            Self::get_cli,
+            Self::get_filesystem,
+            Self::get_spin_sockets,
+            Self::get_wasi_sockets,
+        )
+    }
 }
 
 impl<T> InitContextExt for T where T: InitContext<WasiFactor> {}
@@ -351,6 +377,7 @@ impl Factor for WasiFactor {
 
         ctx.link_all_bindings(wasi_2023_10_18::add_to_linker)?;
         ctx.link_all_bindings(wasi_2023_11_10::add_to_linker)?;
+        ctx.link_all_p3_bindings(wasi_2026_03_15::add_to_linker)?;
         Ok(())
     }
 

--- a/crates/factor-wasi/src/lib.rs
+++ b/crates/factor-wasi/src/lib.rs
@@ -59,9 +59,10 @@ impl WasiFactor {
         })
     }
 
-    pub fn get_sockets_impl(
+    pub fn get_sockets_impl<T>(
         runtime_instance_state: &mut impl RuntimeFactorsInstanceState,
-    ) -> Option<SpinSocketsView<'_>> {
+        getter: fn(&mut T) -> WasiSocketsCtxView<'_>,
+    ) -> Option<SpinSocketsView<'_, T>> {
         let (state, table) = runtime_instance_state.get_with_table::<WasiFactor>()?;
         Some(SpinSocketsView {
             inner: WasiSocketsCtxView {
@@ -69,6 +70,7 @@ impl WasiFactor {
                 table,
             },
             permit_state: state.socket_permit_state.clone(),
+            getter,
         })
     }
 }
@@ -124,17 +126,6 @@ trait InitContextExt: InitContext<WasiFactor> {
         add_to_linker(self.linker(), Self::get_cli)
     }
 
-    fn link_cli_default_bindings<O: Default>(
-        &mut self,
-        add_to_linker: fn(
-            &mut wasmtime::component::Linker<Self::StoreData>,
-            &O,
-            fn(&mut Self::StoreData) -> WasiCliCtxView<'_>,
-        ) -> wasmtime::Result<()>,
-    ) -> wasmtime::Result<()> {
-        add_to_linker(self.linker(), &O::default(), Self::get_cli)
-    }
-
     fn get_filesystem(data: &mut Self::StoreData) -> WasiFilesystemCtxView<'_> {
         let (state, table) = Self::get_data_with_table(data);
         WasiFilesystemCtxView {
@@ -182,7 +173,7 @@ trait InitContextExt: InitContext<WasiFactor> {
         add_to_linker(self.linker(), &O::default(), Self::get_sockets)
     }
 
-    fn get_spin_sockets(data: &mut Self::StoreData) -> SpinSocketsView<'_> {
+    fn get_spin_sockets(data: &mut Self::StoreData) -> SpinSocketsView<'_, Self::StoreData> {
         let (state, table) = Self::get_data_with_table(data);
         SpinSocketsView {
             inner: WasiSocketsCtxView {
@@ -190,6 +181,15 @@ trait InitContextExt: InitContext<WasiFactor> {
                 table,
             },
             permit_state: state.socket_permit_state.clone(),
+            getter: Self::get_wasi_sockets,
+        }
+    }
+
+    fn get_wasi_sockets(data: &mut Self::StoreData) -> WasiSocketsCtxView<'_> {
+        let (state, table) = Self::get_data_with_table(data);
+        WasiSocketsCtxView {
+            ctx: state.ctx.sockets(),
+            table,
         }
     }
 
@@ -197,7 +197,7 @@ trait InitContextExt: InitContext<WasiFactor> {
         &mut self,
         add_to_linker: fn(
             &mut wasmtime::component::Linker<Self::StoreData>,
-            fn(&mut Self::StoreData) -> SpinSocketsView<'_>,
+            fn(&mut Self::StoreData) -> SpinSocketsView<'_, Self::StoreData>,
         ) -> wasmtime::Result<()>,
     ) -> wasmtime::Result<()> {
         add_to_linker(self.linker(), Self::get_spin_sockets)
@@ -235,7 +235,7 @@ trait InitContextExt: InitContext<WasiFactor> {
             fn(&mut Self::StoreData) -> WasiClocksCtxView<'_>,
             fn(&mut Self::StoreData) -> WasiCliCtxView<'_>,
             fn(&mut Self::StoreData) -> WasiFilesystemCtxView<'_>,
-            fn(&mut Self::StoreData) -> SpinSocketsView<'_>,
+            fn(&mut Self::StoreData) -> SpinSocketsView<'_, Self::StoreData>,
         ) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         add_to_linker(
@@ -263,7 +263,7 @@ impl Factor for WasiFactor {
     type AppState = ();
     type InstanceBuilder = InstanceBuilder;
 
-    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         use wasmtime_wasi::{p2, p3};
 
         ctx.link_clocks_bindings(p2::bindings::clocks::wall_clock::add_to_linker::<_, WasiClocks>)?;
@@ -301,8 +301,8 @@ impl Factor for WasiFactor {
         ctx.link_random_bindings(
             p3::bindings::random::insecure_seed::add_to_linker::<_, WasiRandom>,
         )?;
-        ctx.link_cli_default_bindings(p2::bindings::cli::exit::add_to_linker::<_, WasiCli>)?;
-        ctx.link_cli_default_bindings(p3::bindings::cli::exit::add_to_linker::<_, WasiCli>)?;
+        ctx.link_cli_bindings(p2::bindings::cli::exit::add_to_linker::<_, WasiCli>)?;
+        ctx.link_cli_bindings(p3::bindings::cli::exit::add_to_linker::<_, WasiCli>)?;
         ctx.link_cli_bindings(p2::bindings::cli::environment::add_to_linker::<_, WasiCli>)?;
         ctx.link_cli_bindings(p3::bindings::cli::environment::add_to_linker::<_, WasiCli>)?;
         ctx.link_cli_bindings(p2::bindings::cli::stdin::add_to_linker::<_, WasiCli>)?;
@@ -322,16 +322,16 @@ impl Factor for WasiFactor {
         ctx.link_cli_bindings(p2::bindings::cli::terminal_stderr::add_to_linker::<_, WasiCli>)?;
         ctx.link_cli_bindings(p3::bindings::cli::terminal_stderr::add_to_linker::<_, WasiCli>)?;
         ctx.link_spin_sockets_bindings(
-            p2::bindings::sockets::tcp::add_to_linker::<_, SpinSockets>,
+            p2::bindings::sockets::tcp::add_to_linker::<_, SpinSockets<T::StoreData>>,
         )?;
         ctx.link_spin_sockets_bindings(
-            p2::bindings::sockets::tcp_create_socket::add_to_linker::<_, SpinSockets>,
+            p2::bindings::sockets::tcp_create_socket::add_to_linker::<_, SpinSockets<T::StoreData>>,
         )?;
         ctx.link_spin_sockets_bindings(
-            p2::bindings::sockets::udp::add_to_linker::<_, SpinSockets>,
+            p2::bindings::sockets::udp::add_to_linker::<_, SpinSockets<T::StoreData>>,
         )?;
         ctx.link_spin_sockets_bindings(
-            p2::bindings::sockets::udp_create_socket::add_to_linker::<_, SpinSockets>,
+            p2::bindings::sockets::udp_create_socket::add_to_linker::<_, SpinSockets<T::StoreData>>,
         )?;
         ctx.link_sockets_bindings(
             p2::bindings::sockets::instance_network::add_to_linker::<_, WasiSockets>,
@@ -345,8 +345,9 @@ impl Factor for WasiFactor {
         ctx.link_sockets_bindings(
             p3::bindings::sockets::ip_name_lookup::add_to_linker::<_, WasiSockets>,
         )?;
-        // TODO(rylev): switch to SpinSockets once possible
-        ctx.link_sockets_bindings(p3::bindings::sockets::types::add_to_linker::<_, WasiSockets>)?;
+        ctx.link_spin_sockets_bindings(
+            p3::bindings::sockets::types::add_to_linker::<_, SpinSockets<T::StoreData>>,
+        )?;
 
         ctx.link_all_bindings(wasi_2023_10_18::add_to_linker)?;
         ctx.link_all_bindings(wasi_2023_11_10::add_to_linker)?;
@@ -542,4 +543,10 @@ impl InstanceBuilder {
 pub struct InstanceState {
     ctx: WasiCtx,
     socket_permit_state: Option<Arc<SocketPermitState>>,
+}
+
+impl InstanceState {
+    pub fn ctx(&mut self) -> &mut WasiCtx {
+        &mut self.ctx
+    }
 }

--- a/crates/factor-wasi/src/sockets.rs
+++ b/crates/factor-wasi/src/sockets.rs
@@ -7,6 +7,7 @@
 
 use std::{
     collections::HashMap,
+    marker::PhantomData,
     sync::{Arc, Mutex},
 };
 
@@ -20,7 +21,7 @@ use wasmtime_wasi::p2::bindings::sockets::tcp_create_socket as p2_tcp_create;
 use wasmtime_wasi::p2::bindings::sockets::udp as p2_udp;
 use wasmtime_wasi::p2::bindings::sockets::udp_create_socket as p2_udp_create;
 use wasmtime_wasi::p2::{DynInputStream, DynOutputStream, DynPollable};
-use wasmtime_wasi::sockets::{TcpSocket, UdpSocket, WasiSocketsCtxView};
+use wasmtime_wasi::sockets::{TcpSocket, UdpSocket, WasiSockets, WasiSocketsCtxView};
 
 /// Shared state for tracking per-socket semaphore permits. Permits are
 /// acquired when a socket is allocated (at `start_connect` for TCP, at
@@ -42,19 +43,20 @@ impl SocketPermitState {
 
 /// A view over WASI socket state that carries an optional per-instance socket
 /// permit store, enabling per-connection quota tracking.
-pub struct SpinSocketsView<'a> {
+pub struct SpinSocketsView<'a, T> {
     pub(crate) inner: WasiSocketsCtxView<'a>,
     pub(crate) permit_state: Option<Arc<SocketPermitState>>,
+    pub(crate) getter: fn(&mut T) -> WasiSocketsCtxView<'_>,
 }
 
-impl<'a> std::ops::Deref for SpinSocketsView<'a> {
+impl<'a, T> std::ops::Deref for SpinSocketsView<'a, T> {
     type Target = WasiSocketsCtxView<'a>;
     fn deref(&self) -> &Self::Target {
         &self.inner
     }
 }
 
-impl std::ops::DerefMut for SpinSocketsView<'_> {
+impl<T> std::ops::DerefMut for SpinSocketsView<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.inner
     }
@@ -63,13 +65,20 @@ impl std::ops::DerefMut for SpinSocketsView<'_> {
 /// [`HasData`] accessor for [`SpinSocketsView`], used in place of [`WasiSockets`]
 /// when registering TCP socket bindings so that `start_connect` and `drop` can
 /// participate in socket quota tracking.
-pub struct SpinSockets;
+pub struct SpinSockets<T>(PhantomData<fn() -> T>);
 
-impl HasData for SpinSockets {
-    type Data<'a> = SpinSocketsView<'a>;
+impl<T: 'static> HasData for SpinSockets<T> {
+    type Data<'a> = SpinSocketsView<'a, T>;
 }
 
-impl SpinSocketsView<'_> {
+impl<'a, T> SpinSocketsView<'a, T> {
+    /// Consumes this view and returns the inner [`WasiSocketsCtxView`].
+    pub fn into_wasi(self) -> WasiSocketsCtxView<'a> {
+        self.inner
+    }
+}
+
+impl<T> SpinSocketsView<'_, T> {
     /// Attempts to acquire a connection permit from the semaphore.
     ///
     /// Returns `Ok(None)` when no quota is configured, `Ok(Some(permit))` on
@@ -109,9 +118,9 @@ impl SpinSocketsView<'_> {
     }
 }
 
-impl p2_tcp::Host for SpinSocketsView<'_> {}
+impl<T> p2_tcp::Host for SpinSocketsView<'_, T> {}
 
-impl p2_tcp::HostTcpSocket for SpinSocketsView<'_> {
+impl<T> p2_tcp::HostTcpSocket for SpinSocketsView<'_, T> {
     async fn start_bind(
         &mut self,
         this: Resource<TcpSocket>,
@@ -330,7 +339,7 @@ impl p2_tcp::HostTcpSocket for SpinSocketsView<'_> {
     }
 }
 
-impl NetworkHost for SpinSocketsView<'_> {
+impl<T> NetworkHost for SpinSocketsView<'_, T> {
     fn convert_error_code(
         &mut self,
         error: wasmtime_wasi::p2::SocketError,
@@ -346,13 +355,13 @@ impl NetworkHost for SpinSocketsView<'_> {
     }
 }
 
-impl wasmtime_wasi::p2::bindings::sockets::network::HostNetwork for SpinSocketsView<'_> {
+impl<T> wasmtime_wasi::p2::bindings::sockets::network::HostNetwork for SpinSocketsView<'_, T> {
     fn drop(&mut self, this: Resource<Network>) -> wasmtime::Result<()> {
         wasmtime_wasi::p2::bindings::sockets::network::HostNetwork::drop(&mut self.inner, this)
     }
 }
 
-impl p2_tcp_create::Host for SpinSocketsView<'_> {
+impl<T> p2_tcp_create::Host for SpinSocketsView<'_, T> {
     fn create_tcp_socket(
         &mut self,
         address_family: wasmtime_wasi::p2::bindings::sockets::network::IpAddressFamily,
@@ -361,9 +370,9 @@ impl p2_tcp_create::Host for SpinSocketsView<'_> {
     }
 }
 
-impl p2_udp::Host for SpinSocketsView<'_> {}
+impl<T> p2_udp::Host for SpinSocketsView<'_, T> {}
 
-impl p2_udp::HostUdpSocket for SpinSocketsView<'_> {
+impl<T> p2_udp::HostUdpSocket for SpinSocketsView<'_, T> {
     async fn start_bind(
         &mut self,
         this: Resource<p2_udp::UdpSocket>,
@@ -470,7 +479,7 @@ impl p2_udp::HostUdpSocket for SpinSocketsView<'_> {
     }
 }
 
-impl p2_udp::HostIncomingDatagramStream for SpinSocketsView<'_> {
+impl<T> p2_udp::HostIncomingDatagramStream for SpinSocketsView<'_, T> {
     fn receive(
         &mut self,
         this: Resource<p2_udp::IncomingDatagramStream>,
@@ -491,7 +500,7 @@ impl p2_udp::HostIncomingDatagramStream for SpinSocketsView<'_> {
     }
 }
 
-impl p2_udp::HostOutgoingDatagramStream for SpinSocketsView<'_> {
+impl<T> p2_udp::HostOutgoingDatagramStream for SpinSocketsView<'_, T> {
     fn check_send(
         &mut self,
         this: Resource<p2_udp::OutgoingDatagramStream>,
@@ -519,7 +528,7 @@ impl p2_udp::HostOutgoingDatagramStream for SpinSocketsView<'_> {
     }
 }
 
-impl p2_udp_create::Host for SpinSocketsView<'_> {
+impl<T> p2_udp_create::Host for SpinSocketsView<'_, T> {
     fn create_udp_socket(
         &mut self,
         address_family: wasmtime_wasi::p2::bindings::sockets::network::IpAddressFamily,
@@ -534,5 +543,387 @@ impl p2_udp_create::Host for SpinSocketsView<'_> {
         let sock = p2_udp_create::Host::create_udp_socket(&mut self.inner, address_family)?;
         self.register_permit(sock.rep(), permit);
         Ok(sock)
+    }
+}
+
+// ===== p3 impls =====
+
+use wasmtime::AsContextMut as _;
+use wasmtime::component::{Access, Accessor};
+use wasmtime_wasi::p3::bindings::sockets::types::{
+    self as p3_types, Duration as p3_Duration, ErrorCode as p3_ErrorCode, Host as p3_Host,
+    HostTcpSocket as p3_HostTcpSocket, HostTcpSocketWithStore, HostUdpSocket as p3_HostUdpSocket,
+    HostUdpSocketWithStore, IpAddressFamily as p3_IpAddressFamily,
+    IpSocketAddress as p3_IpSocketAddress,
+};
+use wasmtime_wasi::p3::sockets::SocketResult as P3SocketResult;
+
+impl<T> p3_Host for SpinSocketsView<'_, T> {
+    fn convert_error_code(
+        &mut self,
+        error: wasmtime_wasi::p3::sockets::SocketError,
+    ) -> wasmtime::Result<p3_ErrorCode> {
+        p3_Host::convert_error_code(&mut self.inner, error)
+    }
+}
+
+impl<T> p3_HostTcpSocket for SpinSocketsView<'_, T> {
+    async fn bind(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        local_address: p3_IpSocketAddress,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::bind(&mut self.inner, socket, local_address).await
+    }
+
+    fn create(
+        &mut self,
+        address_family: p3_IpAddressFamily,
+    ) -> P3SocketResult<Resource<p3_types::TcpSocket>> {
+        p3_HostTcpSocket::create(&mut self.inner, address_family)
+    }
+
+    fn get_local_address(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<p3_IpSocketAddress> {
+        p3_HostTcpSocket::get_local_address(&mut self.inner, socket)
+    }
+
+    fn get_remote_address(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<p3_IpSocketAddress> {
+        p3_HostTcpSocket::get_remote_address(&mut self.inner, socket)
+    }
+
+    fn get_is_listening(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> wasmtime::Result<bool> {
+        p3_HostTcpSocket::get_is_listening(&mut self.inner, socket)
+    }
+
+    fn get_address_family(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> wasmtime::Result<p3_IpAddressFamily> {
+        p3_HostTcpSocket::get_address_family(&mut self.inner, socket)
+    }
+
+    fn set_listen_backlog_size(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: u64,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_listen_backlog_size(&mut self.inner, socket, value)
+    }
+
+    fn get_keep_alive_enabled(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<bool> {
+        p3_HostTcpSocket::get_keep_alive_enabled(&mut self.inner, socket)
+    }
+
+    fn set_keep_alive_enabled(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: bool,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_keep_alive_enabled(&mut self.inner, socket, value)
+    }
+
+    fn get_keep_alive_idle_time(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<p3_Duration> {
+        p3_HostTcpSocket::get_keep_alive_idle_time(&mut self.inner, socket)
+    }
+
+    fn set_keep_alive_idle_time(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: p3_Duration,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_keep_alive_idle_time(&mut self.inner, socket, value)
+    }
+
+    fn get_keep_alive_interval(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<p3_Duration> {
+        p3_HostTcpSocket::get_keep_alive_interval(&mut self.inner, socket)
+    }
+
+    fn set_keep_alive_interval(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: p3_Duration,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_keep_alive_interval(&mut self.inner, socket, value)
+    }
+
+    fn get_keep_alive_count(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<u32> {
+        p3_HostTcpSocket::get_keep_alive_count(&mut self.inner, socket)
+    }
+
+    fn set_keep_alive_count(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: u32,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_keep_alive_count(&mut self.inner, socket, value)
+    }
+
+    fn get_hop_limit(&mut self, socket: Resource<p3_types::TcpSocket>) -> P3SocketResult<u8> {
+        p3_HostTcpSocket::get_hop_limit(&mut self.inner, socket)
+    }
+
+    fn set_hop_limit(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: u8,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_hop_limit(&mut self.inner, socket, value)
+    }
+
+    fn get_receive_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<u64> {
+        p3_HostTcpSocket::get_receive_buffer_size(&mut self.inner, socket)
+    }
+
+    fn set_receive_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: u64,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_receive_buffer_size(&mut self.inner, socket, value)
+    }
+
+    fn get_send_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<u64> {
+        p3_HostTcpSocket::get_send_buffer_size(&mut self.inner, socket)
+    }
+
+    fn set_send_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::TcpSocket>,
+        value: u64,
+    ) -> P3SocketResult<()> {
+        p3_HostTcpSocket::set_send_buffer_size(&mut self.inner, socket, value)
+    }
+
+    fn drop(&mut self, sock: Resource<p3_types::TcpSocket>) -> wasmtime::Result<()> {
+        self.release_permit(sock.rep());
+        p3_HostTcpSocket::drop(&mut self.inner, sock)
+    }
+}
+
+impl<T> p3_HostUdpSocket for SpinSocketsView<'_, T> {
+    async fn bind(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+        local_address: p3_IpSocketAddress,
+    ) -> P3SocketResult<()> {
+        p3_HostUdpSocket::bind(&mut self.inner, socket, local_address).await
+    }
+
+    async fn connect(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+        remote_address: p3_IpSocketAddress,
+    ) -> P3SocketResult<()> {
+        p3_HostUdpSocket::connect(&mut self.inner, socket, remote_address).await
+    }
+
+    fn create(
+        &mut self,
+        address_family: p3_IpAddressFamily,
+    ) -> P3SocketResult<Resource<p3_types::UdpSocket>> {
+        // Check quota before allocating the socket resource.
+        // See the analogous comment in `start_connect` for why we fail
+        // immediately rather than waiting (as outbound HTTP does).
+        let Ok(permit) = self.try_acquire() else {
+            tracing::warn!("UDP socket creation refused: connection quota exhausted");
+            return Err(p3_ErrorCode::Other(Some("connection quota exhausted".into())).into());
+        };
+        let sock = p3_HostUdpSocket::create(&mut self.inner, address_family)?;
+        self.register_permit(sock.rep(), permit);
+        Ok(sock)
+    }
+
+    fn disconnect(&mut self, socket: Resource<p3_types::UdpSocket>) -> P3SocketResult<()> {
+        p3_HostUdpSocket::disconnect(&mut self.inner, socket)
+    }
+
+    fn get_local_address(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+    ) -> P3SocketResult<p3_IpSocketAddress> {
+        p3_HostUdpSocket::get_local_address(&mut self.inner, socket)
+    }
+
+    fn get_remote_address(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+    ) -> P3SocketResult<p3_IpSocketAddress> {
+        p3_HostUdpSocket::get_remote_address(&mut self.inner, socket)
+    }
+
+    fn get_address_family(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+    ) -> wasmtime::Result<p3_IpAddressFamily> {
+        p3_HostUdpSocket::get_address_family(&mut self.inner, socket)
+    }
+
+    fn get_unicast_hop_limit(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+    ) -> P3SocketResult<u8> {
+        p3_HostUdpSocket::get_unicast_hop_limit(&mut self.inner, socket)
+    }
+
+    fn set_unicast_hop_limit(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+        value: u8,
+    ) -> P3SocketResult<()> {
+        p3_HostUdpSocket::set_unicast_hop_limit(&mut self.inner, socket, value)
+    }
+
+    fn get_receive_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+    ) -> P3SocketResult<u64> {
+        p3_HostUdpSocket::get_receive_buffer_size(&mut self.inner, socket)
+    }
+
+    fn set_receive_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+        value: u64,
+    ) -> P3SocketResult<()> {
+        p3_HostUdpSocket::set_receive_buffer_size(&mut self.inner, socket, value)
+    }
+
+    fn get_send_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+    ) -> P3SocketResult<u64> {
+        p3_HostUdpSocket::get_send_buffer_size(&mut self.inner, socket)
+    }
+
+    fn set_send_buffer_size(
+        &mut self,
+        socket: Resource<p3_types::UdpSocket>,
+        value: u64,
+    ) -> P3SocketResult<()> {
+        p3_HostUdpSocket::set_send_buffer_size(&mut self.inner, socket, value)
+    }
+
+    fn drop(&mut self, sock: Resource<p3_types::UdpSocket>) -> wasmtime::Result<()> {
+        self.release_permit(sock.rep());
+        p3_HostUdpSocket::drop(&mut self.inner, sock)
+    }
+}
+
+impl<T: 'static> HostTcpSocketWithStore<T> for SpinSockets<T> {
+    async fn connect(
+        store: &Accessor<T, Self>,
+        socket: Resource<p3_types::TcpSocket>,
+        remote_address: p3_IpSocketAddress,
+    ) -> P3SocketResult<()> {
+        let socket_rep = socket.rep();
+        // Unlike outbound HTTP (which queues when its permit pool is exhausted),
+        // sockets fail immediately. See p2 `start_connect` for rationale.
+        let permit = match store.with(|mut access| access.get().try_acquire()) {
+            Ok(p) => p,
+            Err(()) => {
+                tracing::warn!("TCP socket connection refused: connection quota exhausted");
+                return Err(p3_ErrorCode::Other(Some("connection quota exhausted".into())).into());
+            }
+        };
+        let getter = store.with(|mut store| store.get().getter);
+        let wasi_accessor = store.with_getter::<WasiSockets>(getter);
+        let result: P3SocketResult<()> = <WasiSockets as HostTcpSocketWithStore<T>>::connect(
+            &wasi_accessor,
+            socket,
+            remote_address,
+        )
+        .await;
+        if result.is_ok() {
+            store.with(|mut access| {
+                access.get().register_permit(socket_rep, permit);
+            });
+        }
+        result
+    }
+
+    fn listen(
+        mut store: Access<'_, T, Self>,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> P3SocketResult<wasmtime::component::StreamReader<Resource<p3_types::TcpSocket>>> {
+        let getter = store.get().getter;
+        let wasi_store = Access::<T, WasiSockets>::new(store.as_context_mut(), getter);
+        <WasiSockets as HostTcpSocketWithStore<T>>::listen(wasi_store, socket)
+    }
+
+    fn send(
+        mut store: Access<'_, T, Self>,
+        socket: Resource<p3_types::TcpSocket>,
+        data: wasmtime::component::StreamReader<u8>,
+    ) -> wasmtime::Result<wasmtime::component::FutureReader<Result<(), p3_ErrorCode>>> {
+        let getter = store.get().getter;
+        let wasi_store = Access::<T, WasiSockets>::new(store.as_context_mut(), getter);
+        <WasiSockets as HostTcpSocketWithStore<T>>::send(wasi_store, socket, data)
+    }
+
+    fn receive(
+        mut store: Access<'_, T, Self>,
+        socket: Resource<p3_types::TcpSocket>,
+    ) -> wasmtime::Result<(
+        wasmtime::component::StreamReader<u8>,
+        wasmtime::component::FutureReader<Result<(), p3_ErrorCode>>,
+    )> {
+        let getter = store.get().getter;
+        let wasi_store = Access::<T, WasiSockets>::new(store.as_context_mut(), getter);
+        <WasiSockets as HostTcpSocketWithStore<T>>::receive(wasi_store, socket)
+    }
+}
+
+impl<T: 'static> HostUdpSocketWithStore<T> for SpinSockets<T> {
+    async fn send(
+        store: &Accessor<T, Self>,
+        socket: Resource<p3_types::UdpSocket>,
+        data: Vec<u8>,
+        remote_address: Option<p3_IpSocketAddress>,
+    ) -> P3SocketResult<()> {
+        let getter = store.with(|mut store| store.get().getter);
+        let wasi_accessor = store.with_getter::<WasiSockets>(getter);
+        <WasiSockets as HostUdpSocketWithStore<T>>::send(
+            &wasi_accessor,
+            socket,
+            data,
+            remote_address,
+        )
+        .await
+    }
+
+    async fn receive(
+        store: &Accessor<T, Self>,
+        socket: Resource<p3_types::UdpSocket>,
+    ) -> P3SocketResult<(Vec<u8>, p3_IpSocketAddress)> {
+        let getter = store.with(|mut store| store.get().getter);
+        let wasi_accessor = store.with_getter::<WasiSockets>(getter);
+        <WasiSockets as HostUdpSocketWithStore<T>>::receive(&wasi_accessor, socket).await
     }
 }

--- a/crates/factor-wasi/src/wasi_2023_10_18.rs
+++ b/crates/factor-wasi/src/wasi_2023_10_18.rs
@@ -1630,6 +1630,7 @@ where
     }
 }
 
+#[macro_export]
 macro_rules! convert {
     () => {};
     ($kind:ident $from:path [<=>] $to:path { $($body:tt)* } $($rest:tt)*) => {
@@ -1682,8 +1683,6 @@ macro_rules! convert {
         convert!($($rest)*);
     };
 }
-
-pub(crate) use convert;
 
 convert! {
     struct latest::clocks::wall_clock::Datetime [<=>] Datetime {

--- a/crates/factor-wasi/src/wasi_2023_10_18.rs
+++ b/crates/factor-wasi/src/wasi_2023_10_18.rs
@@ -127,7 +127,7 @@ pub fn add_to_linker<T>(
     clocks_closure: fn(&mut T) -> WasiClocksCtxView<'_>,
     cli_closure: fn(&mut T) -> WasiCliCtxView<'_>,
     filesystem_closure: fn(&mut T) -> WasiFilesystemCtxView<'_>,
-    sockets_closure: fn(&mut T) -> SpinSocketsView<'_>,
+    sockets_closure: fn(&mut T) -> SpinSocketsView<'_, T>,
 ) -> Result<()>
 where
     T: Send + 'static,
@@ -151,13 +151,13 @@ where
     wasi::cli::terminal_stdin::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
     wasi::cli::terminal_stdout::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
     wasi::cli::terminal_stderr::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
-    wasi::sockets::tcp::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::tcp_create_socket::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::udp::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::udp_create_socket::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::instance_network::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::network::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::ip_name_lookup::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
+    wasi::sockets::tcp::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::tcp_create_socket::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::udp::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::udp_create_socket::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::instance_network::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::network::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::ip_name_lookup::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
     Ok(())
 }
 
@@ -901,9 +901,9 @@ impl wasi::cli::terminal_output::HostTerminalOutput for WasiCliCtxView<'_> {
     }
 }
 
-impl wasi::sockets::tcp::Host for SpinSocketsView<'_> {}
+impl<T> wasi::sockets::tcp::Host for SpinSocketsView<'_, T> {}
 
-impl wasi::sockets::tcp::HostTcpSocket for SpinSocketsView<'_> {
+impl<T> wasi::sockets::tcp::HostTcpSocket for SpinSocketsView<'_, T> {
     async fn start_bind(
         &mut self,
         self_: Resource<TcpSocket>,
@@ -1152,7 +1152,7 @@ impl wasi::sockets::tcp::HostTcpSocket for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::tcp_create_socket::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::tcp_create_socket::Host for SpinSocketsView<'_, T> {
     fn create_tcp_socket(
         &mut self,
         address_family: IpAddressFamily,
@@ -1164,7 +1164,7 @@ impl wasi::sockets::tcp_create_socket::Host for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::udp::Host for SpinSocketsView<'_> {}
+impl<T> wasi::sockets::udp::Host for SpinSocketsView<'_, T> {}
 
 /// Between the snapshot of WASI that this file is implementing and the current
 /// implementation of WASI UDP sockets were redesigned slightly to deal with
@@ -1184,8 +1184,8 @@ pub enum UdpSocket {
 }
 
 impl UdpSocket {
-    async fn finish_connect(
-        table: &mut SpinSocketsView<'_>,
+    async fn finish_connect<T>(
+        table: &mut SpinSocketsView<'_, T>,
         socket: &Resource<UdpSocket>,
         explicit: bool,
     ) -> wasmtime::Result<Result<(), SocketErrorCode>> {
@@ -1232,7 +1232,7 @@ impl UdpSocket {
     }
 }
 
-impl wasi::sockets::udp::HostUdpSocket for SpinSocketsView<'_> {
+impl<T> wasi::sockets::udp::HostUdpSocket for SpinSocketsView<'_, T> {
     async fn start_bind(
         &mut self,
         self_: Resource<UdpSocket>,
@@ -1511,7 +1511,7 @@ impl wasi::sockets::udp::HostUdpSocket for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::udp_create_socket::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::udp_create_socket::Host for SpinSocketsView<'_, T> {
     fn create_udp_socket(
         &mut self,
         address_family: IpAddressFamily,
@@ -1542,21 +1542,21 @@ impl wasi::sockets::udp_create_socket::Host for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::instance_network::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::instance_network::Host for SpinSocketsView<'_, T> {
     fn instance_network(&mut self) -> wasmtime::Result<Resource<Network>> {
         latest::sockets::instance_network::Host::instance_network(&mut self.inner)
     }
 }
 
-impl wasi::sockets::network::Host for SpinSocketsView<'_> {}
+impl<T> wasi::sockets::network::Host for SpinSocketsView<'_, T> {}
 
-impl wasi::sockets::network::HostNetwork for SpinSocketsView<'_> {
+impl<T> wasi::sockets::network::HostNetwork for SpinSocketsView<'_, T> {
     fn drop(&mut self, rep: Resource<Network>) -> wasmtime::Result<()> {
         latest::sockets::network::HostNetwork::drop(&mut self.inner, rep)
     }
 }
 
-impl wasi::sockets::ip_name_lookup::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::ip_name_lookup::Host for SpinSocketsView<'_, T> {
     fn resolve_addresses(
         &mut self,
         network: Resource<Network>,
@@ -1572,7 +1572,7 @@ impl wasi::sockets::ip_name_lookup::Host for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::ip_name_lookup::HostResolveAddressStream for SpinSocketsView<'_> {
+impl<T> wasi::sockets::ip_name_lookup::HostResolveAddressStream for SpinSocketsView<'_, T> {
     fn resolve_next_address(
         &mut self,
         self_: Resource<ResolveAddressStream>,

--- a/crates/factor-wasi/src/wasi_2023_11_10.rs
+++ b/crates/factor-wasi/src/wasi_2023_11_10.rs
@@ -119,7 +119,7 @@ pub fn add_to_linker<T>(
     clocks_closure: fn(&mut T) -> WasiClocksCtxView<'_>,
     cli_closure: fn(&mut T) -> WasiCliCtxView<'_>,
     filesystem_closure: fn(&mut T) -> WasiFilesystemCtxView<'_>,
-    sockets_closure: fn(&mut T) -> SpinSocketsView<'_>,
+    sockets_closure: fn(&mut T) -> SpinSocketsView<'_, T>,
 ) -> Result<()>
 where
     T: Send + 'static,
@@ -144,13 +144,13 @@ where
     wasi::cli::terminal_stdin::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
     wasi::cli::terminal_stdout::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
     wasi::cli::terminal_stderr::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
-    wasi::sockets::tcp::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::tcp_create_socket::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::udp::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::udp_create_socket::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::instance_network::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::network::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
-    wasi::sockets::ip_name_lookup::add_to_linker::<_, SpinSockets>(linker, sockets_closure)?;
+    wasi::sockets::tcp::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::tcp_create_socket::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::udp::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::udp_create_socket::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::instance_network::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::network::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::ip_name_lookup::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
     Ok(())
 }
 
@@ -830,9 +830,9 @@ impl wasi::cli::terminal_output::HostTerminalOutput for WasiCliCtxView<'_> {
     }
 }
 
-impl wasi::sockets::tcp::Host for SpinSocketsView<'_> {}
+impl<T> wasi::sockets::tcp::Host for SpinSocketsView<'_, T> {}
 
-impl wasi::sockets::tcp::HostTcpSocket for SpinSocketsView<'_> {
+impl<T> wasi::sockets::tcp::HostTcpSocket for SpinSocketsView<'_, T> {
     async fn start_bind(
         &mut self,
         self_: Resource<TcpSocket>,
@@ -1127,7 +1127,7 @@ impl wasi::sockets::tcp::HostTcpSocket for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::tcp_create_socket::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::tcp_create_socket::Host for SpinSocketsView<'_, T> {
     fn create_tcp_socket(
         &mut self,
         address_family: IpAddressFamily,
@@ -1139,9 +1139,9 @@ impl wasi::sockets::tcp_create_socket::Host for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::udp::Host for SpinSocketsView<'_> {}
+impl<T> wasi::sockets::udp::Host for SpinSocketsView<'_, T> {}
 
-impl wasi::sockets::udp::HostUdpSocket for SpinSocketsView<'_> {
+impl<T> wasi::sockets::udp::HostUdpSocket for SpinSocketsView<'_, T> {
     async fn start_bind(
         &mut self,
         self_: Resource<UdpSocket>,
@@ -1294,7 +1294,7 @@ impl wasi::sockets::udp::HostUdpSocket for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::udp::HostOutgoingDatagramStream for SpinSocketsView<'_> {
+impl<T> wasi::sockets::udp::HostOutgoingDatagramStream for SpinSocketsView<'_, T> {
     fn check_send(
         &mut self,
         self_: Resource<OutgoingDatagramStream>,
@@ -1329,7 +1329,7 @@ impl wasi::sockets::udp::HostOutgoingDatagramStream for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::udp::HostIncomingDatagramStream for SpinSocketsView<'_> {
+impl<T> wasi::sockets::udp::HostIncomingDatagramStream for SpinSocketsView<'_, T> {
     fn receive(
         &mut self,
         self_: Resource<IncomingDatagramStream>,
@@ -1355,7 +1355,7 @@ impl wasi::sockets::udp::HostIncomingDatagramStream for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::udp_create_socket::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::udp_create_socket::Host for SpinSocketsView<'_, T> {
     fn create_udp_socket(
         &mut self,
         address_family: IpAddressFamily,
@@ -1367,21 +1367,21 @@ impl wasi::sockets::udp_create_socket::Host for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::instance_network::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::instance_network::Host for SpinSocketsView<'_, T> {
     fn instance_network(&mut self) -> wasmtime::Result<Resource<Network>> {
         latest::sockets::instance_network::Host::instance_network(&mut self.inner)
     }
 }
 
-impl wasi::sockets::network::Host for SpinSocketsView<'_> {}
+impl<T> wasi::sockets::network::Host for SpinSocketsView<'_, T> {}
 
-impl wasi::sockets::network::HostNetwork for SpinSocketsView<'_> {
+impl<T> wasi::sockets::network::HostNetwork for SpinSocketsView<'_, T> {
     fn drop(&mut self, rep: Resource<Network>) -> wasmtime::Result<()> {
         latest::sockets::network::HostNetwork::drop(&mut self.inner, rep)
     }
 }
 
-impl wasi::sockets::ip_name_lookup::Host for SpinSocketsView<'_> {
+impl<T> wasi::sockets::ip_name_lookup::Host for SpinSocketsView<'_, T> {
     fn resolve_addresses(
         &mut self,
         network: Resource<Network>,
@@ -1395,7 +1395,7 @@ impl wasi::sockets::ip_name_lookup::Host for SpinSocketsView<'_> {
     }
 }
 
-impl wasi::sockets::ip_name_lookup::HostResolveAddressStream for SpinSocketsView<'_> {
+impl<T> wasi::sockets::ip_name_lookup::HostResolveAddressStream for SpinSocketsView<'_, T> {
     fn resolve_next_address(
         &mut self,
         self_: Resource<ResolveAddressStream>,

--- a/crates/factor-wasi/src/wasi_2023_11_10.rs
+++ b/crates/factor-wasi/src/wasi_2023_11_10.rs
@@ -1,4 +1,4 @@
-use super::wasi_2023_10_18::{convert, convert_result};
+use super::{convert, wasi_2023_10_18::convert_result};
 use crate::sockets::{SpinSockets, SpinSocketsView};
 use spin_factors::anyhow::Result;
 use wasmtime::component::{Linker, Resource, ResourceTable};

--- a/crates/factor-wasi/src/wasi_2026_03_15.rs
+++ b/crates/factor-wasi/src/wasi_2026_03_15.rs
@@ -36,7 +36,7 @@ mod bindings {
             "wasi:filesystem/types.[method]descriptor.append-via-stream": store | trappable,
             "wasi:filesystem/types.[method]descriptor.read-directory": store | trappable,
             "wasi:sockets/types.[method]tcp-socket.bind": async | trappable,
-            "wasi:sockets/types.[method]tcp-socket.listen": async | store | trappable,
+            "wasi:sockets/types.[method]tcp-socket.listen": store | trappable,
             "wasi:sockets/types.[method]tcp-socket.send": store | trappable,
             "wasi:sockets/types.[method]tcp-socket.receive": store | trappable,
             "wasi:sockets/types.[method]udp-socket.bind": async | trappable,
@@ -823,8 +823,8 @@ impl<T: Send + 'static> wasi::sockets::types::HostTcpSocketWithStore<T> for Spin
         )
     }
 
-    async fn listen(
-        store: &Accessor<T, Self>,
+    fn listen(
+        store: Access<'_, T, Self>,
         socket: Resource<wasi::sockets::types::TcpSocket>,
     ) -> wasmtime::Result<
         Result<
@@ -832,11 +832,9 @@ impl<T: Send + 'static> wasi::sockets::types::HostTcpSocketWithStore<T> for Spin
             wasi::sockets::types::ErrorCode,
         >,
     > {
-        store.with(|store| {
-            convert_result(latest::sockets::types::HostTcpSocketWithStore::listen(
-                store, socket,
-            ))
-        })
+        convert_result(latest::sockets::types::HostTcpSocketWithStore::listen(
+            store, socket,
+        ))
     }
 
     fn send(

--- a/crates/factor-wasi/src/wasi_2026_03_15.rs
+++ b/crates/factor-wasi/src/wasi_2026_03_15.rs
@@ -1,0 +1,1443 @@
+use super::{convert, wasi_2023_10_18::convert_result};
+use crate::sockets::{SpinSockets, SpinSocketsView};
+use futures::{
+    Stream as _,
+    channel::{mpsc, oneshot},
+};
+use pin_project_lite::pin_project;
+use spin_factors::anyhow;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use wasmtime::component::{
+    Access, Accessor, Destination, FutureConsumer, FutureProducer, FutureReader, HasData, Lift,
+    Linker, Lower, Resource, Source, StreamConsumer, StreamProducer, StreamReader, StreamResult,
+};
+use wasmtime::error::Context as _;
+use wasmtime::{AsContextMut, StoreContextMut};
+use wasmtime_wasi::cli::{WasiCli, WasiCliCtxView};
+use wasmtime_wasi::clocks::{WasiClocks, WasiClocksCtxView};
+use wasmtime_wasi::filesystem::{WasiFilesystem, WasiFilesystemCtxView};
+use wasmtime_wasi::p3::bindings as latest;
+use wasmtime_wasi::random::{WasiRandom, WasiRandomCtx};
+use wasmtime_wasi::sockets::{WasiSockets, WasiSocketsCtxView};
+
+mod bindings {
+    use super::latest;
+
+    wasmtime::component::bindgen!({
+        path: "../../wit",
+        world: "wasi:cli/command@0.3.0-rc-2026-03-15",
+        imports: {
+            "wasi:cli/stdin": store | trappable,
+            "wasi:cli/stdout": store | trappable,
+            "wasi:cli/stderr": store | trappable,
+            "wasi:filesystem/types.[method]descriptor.read-via-stream": store | trappable,
+            "wasi:filesystem/types.[method]descriptor.write-via-stream": store | trappable,
+            "wasi:filesystem/types.[method]descriptor.append-via-stream": store | trappable,
+            "wasi:filesystem/types.[method]descriptor.read-directory": store | trappable,
+            "wasi:sockets/types.[method]tcp-socket.bind": async | trappable,
+            "wasi:sockets/types.[method]tcp-socket.listen": async | store | trappable,
+            "wasi:sockets/types.[method]tcp-socket.send": store | trappable,
+            "wasi:sockets/types.[method]tcp-socket.receive": store | trappable,
+            "wasi:sockets/types.[method]udp-socket.bind": async | trappable,
+            "wasi:sockets/types.[method]udp-socket.connect": async | trappable,
+            default: trappable,
+        },
+        exports: { default: async | store },
+        with: {
+            "wasi:cli/terminal-input.terminal-input": latest::cli::terminal_input::TerminalInput,
+            "wasi:cli/terminal-output.terminal-output": latest::cli::terminal_output::TerminalOutput,
+            "wasi:filesystem/types.descriptor": latest::filesystem::types::Descriptor,
+            "wasi:sockets/types.tcp-socket": latest::sockets::types::TcpSocket,
+            "wasi:sockets/types.udp-socket": latest::sockets::types::UdpSocket,
+        },
+    });
+}
+
+mod wasi {
+    pub use super::bindings::wasi::{
+        cli0_3_0_rc_2026_03_15 as cli, clocks0_3_0_rc_2026_03_15 as clocks,
+        filesystem0_3_0_rc_2026_03_15 as filesystem, random0_3_0_rc_2026_03_15 as random,
+        sockets0_3_0_rc_2026_03_15 as sockets,
+    };
+}
+
+pub fn add_to_linker<T>(
+    linker: &mut Linker<T>,
+    random_closure: fn(&mut T) -> &mut WasiRandomCtx,
+    clocks_closure: fn(&mut T) -> WasiClocksCtxView<'_>,
+    cli_closure: fn(&mut T) -> WasiCliCtxView<'_>,
+    filesystem_closure: fn(&mut T) -> WasiFilesystemCtxView<'_>,
+    sockets_closure: fn(&mut T) -> SpinSocketsView<'_, T>,
+    wasi_sockets_closure: fn(&mut T) -> WasiSocketsCtxView<'_>,
+) -> anyhow::Result<()>
+where
+    T: Send + 'static,
+{
+    wasi::clocks::monotonic_clock::add_to_linker::<_, WasiClocks>(linker, clocks_closure)?;
+    wasi::clocks::system_clock::add_to_linker::<_, WasiClocks>(linker, clocks_closure)?;
+    wasi::filesystem::types::add_to_linker::<_, WasiFilesystem>(linker, filesystem_closure)?;
+    wasi::filesystem::preopens::add_to_linker::<_, WasiFilesystem>(linker, filesystem_closure)?;
+    wasi::random::random::add_to_linker::<_, WasiRandom>(linker, random_closure)?;
+    wasi::random::insecure::add_to_linker::<_, WasiRandom>(linker, random_closure)?;
+    wasi::random::insecure_seed::add_to_linker::<_, WasiRandom>(linker, random_closure)?;
+    wasi::cli::exit::add_to_linker::<_, WasiCli>(
+        linker,
+        &wasi::cli::exit::LinkOptions::default(),
+        cli_closure,
+    )?;
+    wasi::cli::environment::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::stdin::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::stdout::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::stderr::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::terminal_input::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::terminal_output::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::terminal_stdin::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::terminal_stdout::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::cli::terminal_stderr::add_to_linker::<_, WasiCli>(linker, cli_closure)?;
+    wasi::sockets::types::add_to_linker::<_, SpinSockets<T>>(linker, sockets_closure)?;
+    wasi::sockets::ip_name_lookup::add_to_linker::<_, WasiSockets>(linker, wasi_sockets_closure)?;
+    Ok(())
+}
+
+impl wasi::clocks::types::Host for WasiClocksCtxView<'_> {}
+
+impl wasi::clocks::system_clock::Host for WasiClocksCtxView<'_> {
+    fn now(&mut self) -> wasmtime::Result<wasi::clocks::system_clock::Instant> {
+        latest::clocks::system_clock::Host::now(self).map(|v| v.into())
+    }
+
+    fn get_resolution(&mut self) -> wasmtime::Result<wasi::clocks::types::Duration> {
+        latest::clocks::system_clock::Host::get_resolution(self)
+    }
+}
+
+impl<T> wasi::clocks::monotonic_clock::HostWithStore<T> for WasiClocks {
+    async fn wait_until(
+        store: &Accessor<T, Self>,
+        when: wasi::clocks::monotonic_clock::Mark,
+    ) -> wasmtime::Result<()> {
+        latest::clocks::monotonic_clock::HostWithStore::wait_until(store, when).await
+    }
+
+    async fn wait_for(
+        store: &Accessor<T, Self>,
+        duration: wasi::clocks::types::Duration,
+    ) -> wasmtime::Result<()> {
+        latest::clocks::monotonic_clock::HostWithStore::wait_for(store, duration).await
+    }
+}
+
+impl wasi::clocks::monotonic_clock::Host for WasiClocksCtxView<'_> {
+    fn now(&mut self) -> wasmtime::Result<wasi::clocks::monotonic_clock::Mark> {
+        latest::clocks::monotonic_clock::Host::now(self)
+    }
+
+    fn get_resolution(&mut self) -> wasmtime::Result<wasi::clocks::types::Duration> {
+        latest::clocks::monotonic_clock::Host::get_resolution(self)
+    }
+}
+
+impl wasi::filesystem::types::Host for WasiFilesystemCtxView<'_> {}
+
+impl<T> wasi::filesystem::types::HostDescriptorWithStore<T> for WasiFilesystem {
+    fn read_via_stream(
+        mut store: Access<'_, T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        offset: wasi::filesystem::types::Filesize,
+    ) -> wasmtime::Result<(
+        StreamReader<u8>,
+        FutureReader<Result<(), wasi::filesystem::types::ErrorCode>>,
+    )> {
+        latest::filesystem::types::HostDescriptorWithStore::read_via_stream(
+            reborrow(&mut store),
+            fd,
+            offset,
+        )
+        .and_then(|(stream, future)| {
+            Ok((stream, future.try_map(store, |v| v.map_err(|v| v.into()))?))
+        })
+    }
+
+    fn write_via_stream(
+        mut store: Access<'_, T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        data: StreamReader<u8>,
+        offset: wasi::filesystem::types::Filesize,
+    ) -> wasmtime::Result<FutureReader<Result<(), wasi::filesystem::types::ErrorCode>>> {
+        latest::filesystem::types::HostDescriptorWithStore::write_via_stream(
+            reborrow(&mut store),
+            fd,
+            data,
+            offset,
+        )
+        .and_then(|v| v.try_map(store, |v| v.map_err(|v| v.into())))
+    }
+
+    fn append_via_stream(
+        mut store: Access<'_, T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        data: StreamReader<u8>,
+    ) -> wasmtime::Result<FutureReader<Result<(), wasi::filesystem::types::ErrorCode>>> {
+        latest::filesystem::types::HostDescriptorWithStore::append_via_stream(
+            reborrow(&mut store),
+            fd,
+            data,
+        )
+        .and_then(|v| v.try_map(store, |v| v.map_err(|v| v.into())))
+    }
+
+    async fn advise(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        offset: wasi::filesystem::types::Filesize,
+        length: wasi::filesystem::types::Filesize,
+        advice: wasi::filesystem::types::Advice,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::advise(
+                store,
+                fd,
+                offset,
+                length,
+                advice.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn sync_data(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::sync_data(store, fd).await,
+        )
+    }
+
+    async fn get_flags(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<
+        Result<wasi::filesystem::types::DescriptorFlags, wasi::filesystem::types::ErrorCode>,
+    > {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::get_flags(store, fd).await,
+        )
+    }
+
+    async fn get_type(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<
+        Result<wasi::filesystem::types::DescriptorType, wasi::filesystem::types::ErrorCode>,
+    > {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::get_type(store, fd).await,
+        )
+    }
+
+    async fn set_size(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        size: wasi::filesystem::types::Filesize,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::set_size(store, fd, size).await,
+        )
+    }
+
+    async fn set_times(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        data_access_timestamp: wasi::filesystem::types::NewTimestamp,
+        data_modification_timestamp: wasi::filesystem::types::NewTimestamp,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::set_times(
+                store,
+                fd,
+                data_access_timestamp.into(),
+                data_modification_timestamp.into(),
+            )
+            .await,
+        )
+    }
+
+    fn read_directory(
+        mut store: Access<'_, T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<(
+        StreamReader<wasi::filesystem::types::DirectoryEntry>,
+        FutureReader<Result<(), wasi::filesystem::types::ErrorCode>>,
+    )> {
+        latest::filesystem::types::HostDescriptorWithStore::read_directory(reborrow(&mut store), fd)
+            .and_then(|(stream, future)| {
+                Ok((
+                    stream.try_map(reborrow(&mut store), |v| v.into())?,
+                    future.try_map(store, |v| v.map_err(|v| v.into()))?,
+                ))
+            })
+    }
+
+    async fn sync(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(latest::filesystem::types::HostDescriptorWithStore::sync(store, fd).await)
+    }
+
+    async fn create_directory_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::create_directory_at(
+                store, fd, path,
+            )
+            .await,
+        )
+    }
+
+    async fn stat(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<
+        Result<wasi::filesystem::types::DescriptorStat, wasi::filesystem::types::ErrorCode>,
+    > {
+        convert_result(latest::filesystem::types::HostDescriptorWithStore::stat(store, fd).await)
+    }
+
+    async fn stat_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path_flags: wasi::filesystem::types::PathFlags,
+        path: String,
+    ) -> wasmtime::Result<
+        Result<wasi::filesystem::types::DescriptorStat, wasi::filesystem::types::ErrorCode>,
+    > {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::stat_at(
+                store,
+                fd,
+                path_flags.into(),
+                path,
+            )
+            .await,
+        )
+    }
+
+    async fn set_times_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path_flags: wasi::filesystem::types::PathFlags,
+        path: String,
+        data_access_timestamp: wasi::filesystem::types::NewTimestamp,
+        data_modification_timestamp: wasi::filesystem::types::NewTimestamp,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::set_times_at(
+                store,
+                fd,
+                path_flags.into(),
+                path,
+                data_access_timestamp.into(),
+                data_modification_timestamp.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn link_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        old_path_flags: wasi::filesystem::types::PathFlags,
+        old_path: String,
+        new_fd: Resource<wasi::filesystem::types::Descriptor>,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::link_at(
+                store,
+                fd,
+                old_path_flags.into(),
+                old_path,
+                new_fd,
+                new_path,
+            )
+            .await,
+        )
+    }
+
+    async fn open_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path_flags: wasi::filesystem::types::PathFlags,
+        path: String,
+        open_flags: wasi::filesystem::types::OpenFlags,
+        flags: wasi::filesystem::types::DescriptorFlags,
+    ) -> wasmtime::Result<
+        Result<Resource<wasi::filesystem::types::Descriptor>, wasi::filesystem::types::ErrorCode>,
+    > {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::open_at(
+                store,
+                fd,
+                path_flags.into(),
+                path,
+                open_flags.into(),
+                flags.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn readlink_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<String, wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::readlink_at(store, fd, path).await,
+        )
+    }
+
+    async fn remove_directory_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::remove_directory_at(
+                store, fd, path,
+            )
+            .await,
+        )
+    }
+
+    async fn rename_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        old_path: String,
+        new_fd: Resource<wasi::filesystem::types::Descriptor>,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::rename_at(
+                store, fd, old_path, new_fd, new_path,
+            )
+            .await,
+        )
+    }
+
+    async fn symlink_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        old_path: String,
+        new_path: String,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::symlink_at(
+                store, fd, old_path, new_path,
+            )
+            .await,
+        )
+    }
+
+    async fn unlink_file_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path: String,
+    ) -> wasmtime::Result<Result<(), wasi::filesystem::types::ErrorCode>> {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::unlink_file_at(store, fd, path)
+                .await,
+        )
+    }
+
+    async fn is_same_object(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        other: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<bool> {
+        latest::filesystem::types::HostDescriptorWithStore::is_same_object(store, fd, other).await
+    }
+
+    async fn metadata_hash(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+    ) -> wasmtime::Result<
+        Result<wasi::filesystem::types::MetadataHashValue, wasi::filesystem::types::ErrorCode>,
+    > {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::metadata_hash(store, fd).await,
+        )
+    }
+
+    async fn metadata_hash_at(
+        store: &Accessor<T, Self>,
+        fd: Resource<wasi::filesystem::types::Descriptor>,
+        path_flags: wasi::filesystem::types::PathFlags,
+        path: String,
+    ) -> wasmtime::Result<
+        Result<wasi::filesystem::types::MetadataHashValue, wasi::filesystem::types::ErrorCode>,
+    > {
+        convert_result(
+            latest::filesystem::types::HostDescriptorWithStore::metadata_hash_at(
+                store,
+                fd,
+                path_flags.into(),
+                path,
+            )
+            .await,
+        )
+    }
+}
+
+impl wasi::filesystem::types::HostDescriptor for WasiFilesystemCtxView<'_> {
+    fn drop(&mut self, fd: Resource<wasi::filesystem::types::Descriptor>) -> wasmtime::Result<()> {
+        latest::filesystem::types::HostDescriptor::drop(self, fd)
+    }
+}
+
+impl wasi::filesystem::preopens::Host for WasiFilesystemCtxView<'_> {
+    fn get_directories(
+        &mut self,
+    ) -> wasmtime::Result<Vec<(Resource<wasi::filesystem::types::Descriptor>, String)>> {
+        latest::filesystem::preopens::Host::get_directories(self)
+    }
+}
+
+impl wasi::random::random::Host for WasiRandomCtx {
+    fn get_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
+        latest::random::random::Host::get_random_bytes(self, len)
+    }
+
+    fn get_random_u64(&mut self) -> wasmtime::Result<u64> {
+        latest::random::random::Host::get_random_u64(self)
+    }
+}
+
+impl wasi::random::insecure::Host for WasiRandomCtx {
+    fn get_insecure_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
+        latest::random::insecure::Host::get_insecure_random_bytes(self, len)
+    }
+
+    fn get_insecure_random_u64(&mut self) -> wasmtime::Result<u64> {
+        latest::random::insecure::Host::get_insecure_random_u64(self)
+    }
+}
+
+impl wasi::random::insecure_seed::Host for WasiRandomCtx {
+    fn get_insecure_seed(&mut self) -> wasmtime::Result<(u64, u64)> {
+        latest::random::insecure_seed::Host::get_insecure_seed(self)
+    }
+}
+
+impl wasi::cli::terminal_input::Host for WasiCliCtxView<'_> {}
+impl wasi::cli::terminal_output::Host for WasiCliCtxView<'_> {}
+
+impl wasi::cli::terminal_input::HostTerminalInput for WasiCliCtxView<'_> {
+    fn drop(
+        &mut self,
+        rep: Resource<wasi::cli::terminal_input::TerminalInput>,
+    ) -> wasmtime::Result<()> {
+        latest::cli::terminal_input::HostTerminalInput::drop(self, rep)
+    }
+}
+
+impl wasi::cli::terminal_output::HostTerminalOutput for WasiCliCtxView<'_> {
+    fn drop(
+        &mut self,
+        rep: Resource<wasi::cli::terminal_output::TerminalOutput>,
+    ) -> wasmtime::Result<()> {
+        latest::cli::terminal_output::HostTerminalOutput::drop(self, rep)
+    }
+}
+
+impl wasi::cli::terminal_stdin::Host for WasiCliCtxView<'_> {
+    fn get_terminal_stdin(
+        &mut self,
+    ) -> wasmtime::Result<Option<Resource<wasi::cli::terminal_input::TerminalInput>>> {
+        latest::cli::terminal_stdin::Host::get_terminal_stdin(self)
+    }
+}
+
+impl wasi::cli::terminal_stdout::Host for WasiCliCtxView<'_> {
+    fn get_terminal_stdout(
+        &mut self,
+    ) -> wasmtime::Result<Option<Resource<wasi::cli::terminal_output::TerminalOutput>>> {
+        latest::cli::terminal_stdout::Host::get_terminal_stdout(self)
+    }
+}
+
+impl wasi::cli::terminal_stderr::Host for WasiCliCtxView<'_> {
+    fn get_terminal_stderr(
+        &mut self,
+    ) -> wasmtime::Result<Option<Resource<wasi::cli::terminal_output::TerminalOutput>>> {
+        latest::cli::terminal_stderr::Host::get_terminal_stderr(self)
+    }
+}
+
+impl<T> wasi::cli::stdin::HostWithStore<T> for WasiCli {
+    fn read_via_stream(
+        mut store: Access<T, Self>,
+    ) -> wasmtime::Result<(
+        StreamReader<u8>,
+        FutureReader<Result<(), wasi::cli::types::ErrorCode>>,
+    )> {
+        latest::cli::stdin::HostWithStore::read_via_stream(reborrow(&mut store)).and_then(
+            |(stream, future)| Ok((stream, future.try_map(store, |v| v.map_err(|v| v.into()))?)),
+        )
+    }
+}
+
+impl wasi::cli::stdin::Host for WasiCliCtxView<'_> {}
+
+impl<T> wasi::cli::stdout::HostWithStore<T> for WasiCli {
+    fn write_via_stream(
+        mut store: Access<'_, T, Self>,
+        data: StreamReader<u8>,
+    ) -> wasmtime::Result<FutureReader<Result<(), wasi::cli::types::ErrorCode>>> {
+        latest::cli::stdout::HostWithStore::write_via_stream(reborrow(&mut store), data)
+            .and_then(|v| v.try_map(store, |v| v.map_err(|v| v.into())))
+    }
+}
+
+impl wasi::cli::stdout::Host for WasiCliCtxView<'_> {}
+
+impl<T> wasi::cli::stderr::HostWithStore<T> for WasiCli {
+    fn write_via_stream(
+        mut store: Access<'_, T, Self>,
+        data: StreamReader<u8>,
+    ) -> wasmtime::Result<FutureReader<Result<(), wasi::cli::types::ErrorCode>>> {
+        latest::cli::stderr::HostWithStore::write_via_stream(reborrow(&mut store), data)
+            .and_then(|v| v.try_map(store, |v| v.map_err(|v| v.into())))
+    }
+}
+
+impl wasi::cli::stderr::Host for WasiCliCtxView<'_> {}
+
+impl wasi::cli::environment::Host for WasiCliCtxView<'_> {
+    fn get_environment(&mut self) -> wasmtime::Result<Vec<(String, String)>> {
+        latest::cli::environment::Host::get_environment(self)
+    }
+
+    fn get_arguments(&mut self) -> wasmtime::Result<Vec<String>> {
+        latest::cli::environment::Host::get_arguments(self)
+    }
+
+    fn get_initial_cwd(&mut self) -> wasmtime::Result<Option<String>> {
+        latest::cli::environment::Host::get_initial_cwd(self)
+    }
+}
+
+impl wasi::cli::exit::Host for WasiCliCtxView<'_> {
+    fn exit(&mut self, status: Result<(), ()>) -> wasmtime::Result<()> {
+        latest::cli::exit::Host::exit(self, status)
+    }
+
+    fn exit_with_code(&mut self, status_code: u8) -> wasmtime::Result<()> {
+        latest::cli::exit::Host::exit_with_code(self, status_code)
+    }
+}
+
+impl<T> wasi::sockets::types::Host for SpinSocketsView<'_, T> {}
+
+impl<T: 'static> wasi::sockets::types::HostUdpSocketWithStore<T> for SpinSockets<T> {
+    async fn send(
+        store: &Accessor<T, Self>,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+        data: Vec<u8>,
+        remote_address: Option<wasi::sockets::types::IpSocketAddress>,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostUdpSocketWithStore::send(
+                store,
+                socket,
+                data,
+                remote_address.map(|v| v.into()),
+            )
+            .await,
+        )
+    }
+
+    async fn receive(
+        store: &Accessor<T, Self>,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<
+        Result<(Vec<u8>, wasi::sockets::types::IpSocketAddress), wasi::sockets::types::ErrorCode>,
+    > {
+        convert_result(
+            latest::sockets::types::HostUdpSocketWithStore::receive(store, socket)
+                .await
+                .map(|(a, b)| (a, b.into())),
+        )
+    }
+}
+
+impl<T> wasi::sockets::types::HostUdpSocket for SpinSocketsView<'_, T> {
+    async fn bind(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+        local_address: wasi::sockets::types::IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostUdpSocket::bind(self, socket, local_address.into()).await,
+        )
+    }
+
+    async fn connect(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+        remote_address: wasi::sockets::types::IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostUdpSocket::connect(self, socket, remote_address.into())
+                .await,
+        )
+    }
+
+    fn create(
+        &mut self,
+        address_family: wasi::sockets::types::IpAddressFamily,
+    ) -> wasmtime::Result<
+        Result<Resource<wasi::sockets::types::UdpSocket>, wasi::sockets::types::ErrorCode>,
+    > {
+        convert_result(latest::sockets::types::HostUdpSocket::create(
+            self,
+            address_family.into(),
+        ))
+    }
+
+    fn disconnect(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostUdpSocket::disconnect(
+            self, socket,
+        ))
+    }
+
+    fn get_local_address(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<
+        Result<wasi::sockets::types::IpSocketAddress, wasi::sockets::types::ErrorCode>,
+    > {
+        convert_result(latest::sockets::types::HostUdpSocket::get_local_address(
+            self, socket,
+        ))
+    }
+
+    fn get_remote_address(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<
+        Result<wasi::sockets::types::IpSocketAddress, wasi::sockets::types::ErrorCode>,
+    > {
+        convert_result(latest::sockets::types::HostUdpSocket::get_remote_address(
+            self, socket,
+        ))
+    }
+
+    fn get_address_family(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<wasi::sockets::types::IpAddressFamily> {
+        latest::sockets::types::HostUdpSocket::get_address_family(self, socket).map(|v| v.into())
+    }
+
+    fn get_unicast_hop_limit(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<Result<u8, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostUdpSocket::get_unicast_hop_limit(self, socket))
+    }
+
+    fn set_unicast_hop_limit(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+        value: u8,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostUdpSocket::set_unicast_hop_limit(self, socket, value),
+        )
+    }
+
+    fn get_receive_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<Result<u64, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostUdpSocket::get_receive_buffer_size(self, socket))
+    }
+
+    fn set_receive_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostUdpSocket::set_receive_buffer_size(self, socket, value),
+        )
+    }
+
+    fn get_send_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+    ) -> wasmtime::Result<Result<u64, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostUdpSocket::get_send_buffer_size(
+            self, socket,
+        ))
+    }
+
+    fn set_send_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::UdpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostUdpSocket::set_send_buffer_size(
+            self, socket, value,
+        ))
+    }
+
+    fn drop(&mut self, sock: Resource<wasi::sockets::types::UdpSocket>) -> wasmtime::Result<()> {
+        latest::sockets::types::HostUdpSocket::drop(self, sock)
+    }
+}
+
+impl<T: Send + 'static> wasi::sockets::types::HostTcpSocketWithStore<T> for SpinSockets<T> {
+    async fn connect(
+        store: &Accessor<T, Self>,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        remote_address: wasi::sockets::types::IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostTcpSocketWithStore::connect(
+                store,
+                socket,
+                remote_address.into(),
+            )
+            .await,
+        )
+    }
+
+    async fn listen(
+        store: &Accessor<T, Self>,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<
+        Result<
+            StreamReader<Resource<wasi::sockets::types::TcpSocket>>,
+            wasi::sockets::types::ErrorCode,
+        >,
+    > {
+        store.with(|store| {
+            convert_result(latest::sockets::types::HostTcpSocketWithStore::listen(
+                store, socket,
+            ))
+        })
+    }
+
+    fn send(
+        mut store: Access<'_, T, Self>,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        data: StreamReader<u8>,
+    ) -> wasmtime::Result<FutureReader<Result<(), wasi::sockets::types::ErrorCode>>> {
+        latest::sockets::types::HostTcpSocketWithStore::send(reborrow(&mut store), socket, data)
+            .and_then(|v| v.try_map(store, |v| v.map_err(|v| v.into())))
+    }
+
+    fn receive(
+        mut store: Access<'_, T, Self>,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<(
+        StreamReader<u8>,
+        FutureReader<Result<(), wasi::sockets::types::ErrorCode>>,
+    )> {
+        latest::sockets::types::HostTcpSocketWithStore::receive(reborrow(&mut store), socket)
+            .and_then(|(stream, future)| {
+                Ok((stream, future.try_map(store, |v| v.map_err(|v| v.into()))?))
+            })
+    }
+}
+
+impl<T> wasi::sockets::types::HostTcpSocket for SpinSocketsView<'_, T> {
+    async fn bind(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        local_address: wasi::sockets::types::IpSocketAddress,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostTcpSocket::bind(self, socket, local_address.into()).await,
+        )
+    }
+
+    fn create(
+        &mut self,
+        address_family: wasi::sockets::types::IpAddressFamily,
+    ) -> wasmtime::Result<
+        Result<Resource<wasi::sockets::types::TcpSocket>, wasi::sockets::types::ErrorCode>,
+    > {
+        convert_result(latest::sockets::types::HostTcpSocket::create(
+            self,
+            address_family.into(),
+        ))
+    }
+
+    fn get_local_address(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<
+        Result<wasi::sockets::types::IpSocketAddress, wasi::sockets::types::ErrorCode>,
+    > {
+        convert_result(latest::sockets::types::HostTcpSocket::get_local_address(
+            self, socket,
+        ))
+    }
+
+    fn get_remote_address(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<
+        Result<wasi::sockets::types::IpSocketAddress, wasi::sockets::types::ErrorCode>,
+    > {
+        convert_result(latest::sockets::types::HostTcpSocket::get_remote_address(
+            self, socket,
+        ))
+    }
+
+    fn get_is_listening(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<bool> {
+        latest::sockets::types::HostTcpSocket::get_is_listening(self, socket)
+    }
+
+    fn get_address_family(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<wasi::sockets::types::IpAddressFamily> {
+        latest::sockets::types::HostTcpSocket::get_address_family(self, socket).map(|v| v.into())
+    }
+
+    fn set_listen_backlog_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostTcpSocket::set_listen_backlog_size(self, socket, value),
+        )
+    }
+
+    fn get_keep_alive_enabled(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<Result<bool, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::get_keep_alive_enabled(self, socket))
+    }
+
+    fn set_keep_alive_enabled(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: bool,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostTcpSocket::set_keep_alive_enabled(self, socket, value),
+        )
+    }
+
+    fn get_keep_alive_idle_time(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<Result<wasi::sockets::types::Duration, wasi::sockets::types::ErrorCode>>
+    {
+        convert_result(
+            latest::sockets::types::HostTcpSocket::get_keep_alive_idle_time(self, socket),
+        )
+    }
+
+    fn set_keep_alive_idle_time(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: wasi::sockets::types::Duration,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostTcpSocket::set_keep_alive_idle_time(self, socket, value),
+        )
+    }
+
+    fn get_keep_alive_interval(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<Result<wasi::sockets::types::Duration, wasi::sockets::types::ErrorCode>>
+    {
+        convert_result(latest::sockets::types::HostTcpSocket::get_keep_alive_interval(self, socket))
+    }
+
+    fn set_keep_alive_interval(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: wasi::sockets::types::Duration,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostTcpSocket::set_keep_alive_interval(self, socket, value),
+        )
+    }
+
+    fn get_keep_alive_count(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<Result<u32, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::get_keep_alive_count(
+            self, socket,
+        ))
+    }
+
+    fn set_keep_alive_count(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: u32,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::set_keep_alive_count(
+            self, socket, value,
+        ))
+    }
+
+    fn get_hop_limit(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<Result<u8, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::get_hop_limit(
+            self, socket,
+        ))
+    }
+
+    fn set_hop_limit(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: u8,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::set_hop_limit(
+            self, socket, value,
+        ))
+    }
+
+    fn get_receive_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<Result<u64, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::get_receive_buffer_size(self, socket))
+    }
+
+    fn set_receive_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(
+            latest::sockets::types::HostTcpSocket::set_receive_buffer_size(self, socket, value),
+        )
+    }
+
+    fn get_send_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+    ) -> wasmtime::Result<Result<u64, wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::get_send_buffer_size(
+            self, socket,
+        ))
+    }
+
+    fn set_send_buffer_size(
+        &mut self,
+        socket: Resource<wasi::sockets::types::TcpSocket>,
+        value: u64,
+    ) -> wasmtime::Result<Result<(), wasi::sockets::types::ErrorCode>> {
+        convert_result(latest::sockets::types::HostTcpSocket::set_send_buffer_size(
+            self, socket, value,
+        ))
+    }
+
+    fn drop(&mut self, sock: Resource<wasi::sockets::types::TcpSocket>) -> wasmtime::Result<()> {
+        latest::sockets::types::HostTcpSocket::drop(self, sock)
+    }
+}
+
+impl<T> wasi::sockets::ip_name_lookup::HostWithStore<T> for WasiSockets {
+    async fn resolve_addresses(
+        store: &Accessor<T, Self>,
+        name: String,
+    ) -> wasmtime::Result<
+        Result<Vec<wasi::sockets::types::IpAddress>, wasi::sockets::ip_name_lookup::ErrorCode>,
+    > {
+        latest::sockets::ip_name_lookup::HostWithStore::resolve_addresses(store, name)
+            .await
+            .map(|v| {
+                v.map(|v| v.into_iter().map(|v| v.into()).collect())
+                    .map_err(|e| e.into())
+            })
+    }
+}
+
+impl wasi::sockets::ip_name_lookup::Host for WasiSocketsCtxView<'_> {}
+
+convert! {
+    struct latest::clocks::system_clock::Instant [<=>] wasi::clocks::system_clock::Instant {
+        seconds,
+        nanoseconds,
+    }
+
+    enum latest::cli::types::ErrorCode => wasi::cli::types::ErrorCode {
+        Io,
+        IllegalByteSequence,
+        Pipe,
+    }
+
+    enum latest::filesystem::types::ErrorCode => wasi::filesystem::types::ErrorCode {
+        Access,
+        Already,
+        BadDescriptor,
+        Busy,
+        Deadlock,
+        Quota,
+        Exist,
+        FileTooLarge,
+        IllegalByteSequence,
+        InProgress,
+        Interrupted,
+        Invalid,
+        Io,
+        IsDirectory,
+        Loop,
+        TooManyLinks,
+        MessageSize,
+        NameTooLong,
+        NoDevice,
+        NoEntry,
+        NoLock,
+        InsufficientMemory,
+        InsufficientSpace,
+        NotDirectory,
+        NotEmpty,
+        NotRecoverable,
+        Unsupported,
+        NoTty,
+        NoSuchDevice,
+        Overflow,
+        NotPermitted,
+        Pipe,
+        ReadOnly,
+        InvalidSeek,
+        TextFileBusy,
+        CrossDevice,
+        Other(v),
+    }
+
+    enum wasi::filesystem::types::Advice => latest::filesystem::types::Advice {
+        Normal,
+        Sequential,
+        Random,
+        WillNeed,
+        DontNeed,
+        NoReuse,
+    }
+
+    flags wasi::filesystem::types::DescriptorFlags [<=>] latest::filesystem::types::DescriptorFlags {
+        READ,
+        WRITE,
+        FILE_INTEGRITY_SYNC,
+        DATA_INTEGRITY_SYNC,
+        REQUESTED_WRITE_SYNC,
+        MUTATE_DIRECTORY,
+    }
+
+    enum wasi::filesystem::types::DescriptorType [<=>] latest::filesystem::types::DescriptorType {
+        BlockDevice,
+        CharacterDevice,
+        Directory,
+        Fifo,
+        SymbolicLink,
+        RegularFile,
+        Socket,
+        Other(v),
+    }
+
+    enum wasi::filesystem::types::NewTimestamp => latest::filesystem::types::NewTimestamp {
+        NoChange,
+        Now,
+        Timestamp(e),
+    }
+
+    flags wasi::filesystem::types::PathFlags => latest::filesystem::types::PathFlags {
+        SYMLINK_FOLLOW,
+    }
+
+    flags wasi::filesystem::types::OpenFlags => latest::filesystem::types::OpenFlags {
+        CREATE,
+        DIRECTORY,
+        EXCLUSIVE,
+        TRUNCATE,
+    }
+
+    struct latest::filesystem::types::MetadataHashValue => wasi::filesystem::types::MetadataHashValue {
+        lower,
+        upper,
+    }
+
+    struct latest::filesystem::types::DirectoryEntry => wasi::filesystem::types::DirectoryEntry {
+        type_,
+        name,
+    }
+
+    enum latest::sockets::types::ErrorCode => wasi::sockets::types::ErrorCode {
+        AccessDenied,
+        NotSupported,
+        InvalidArgument,
+        OutOfMemory,
+        Timeout,
+        InvalidState,
+        AddressNotBindable,
+        AddressInUse,
+        RemoteUnreachable,
+        ConnectionRefused,
+        ConnectionBroken,
+        ConnectionReset,
+        ConnectionAborted,
+        DatagramTooLarge,
+        Other(v),
+    }
+
+    enum latest::sockets::types::IpAddress [<=>] wasi::sockets::types::IpAddress {
+        Ipv4(e),
+        Ipv6(e),
+    }
+
+    enum latest::sockets::types::IpSocketAddress [<=>] wasi::sockets::types::IpSocketAddress {
+        Ipv4(e),
+        Ipv6(e),
+    }
+
+    struct latest::sockets::types::Ipv4SocketAddress [<=>] wasi::sockets::types::Ipv4SocketAddress {
+        port,
+        address,
+    }
+
+    struct latest::sockets::types::Ipv6SocketAddress [<=>] wasi::sockets::types::Ipv6SocketAddress {
+        port,
+        flow_info,
+        scope_id,
+        address,
+    }
+
+    enum latest::sockets::types::IpAddressFamily [<=>] wasi::sockets::types::IpAddressFamily {
+        Ipv4,
+        Ipv6,
+    }
+
+    enum latest::sockets::ip_name_lookup::ErrorCode => wasi::sockets::ip_name_lookup::ErrorCode {
+        AccessDenied,
+        InvalidArgument,
+        NameUnresolvable,
+        TemporaryResolverFailure,
+        PermanentResolverFailure,
+        Other(v),
+    }
+}
+
+impl From<latest::filesystem::types::DescriptorStat> for wasi::filesystem::types::DescriptorStat {
+    fn from(
+        e: latest::filesystem::types::DescriptorStat,
+    ) -> wasi::filesystem::types::DescriptorStat {
+        wasi::filesystem::types::DescriptorStat {
+            type_: e.type_.into(),
+            link_count: e.link_count,
+            size: e.size,
+            data_access_timestamp: e.data_access_timestamp.map(|e| e.into()),
+            data_modification_timestamp: e.data_modification_timestamp.map(|e| e.into()),
+            status_change_timestamp: e.status_change_timestamp.map(|e| e.into()),
+        }
+    }
+}
+
+pub trait FutureReaderExt<T> {
+    fn try_map<U: Lower + Lift + 'static>(
+        self,
+        store: impl AsContextMut,
+        fun: impl FnOnce(T) -> U + Send + 'static,
+    ) -> wasmtime::Result<FutureReader<U>>;
+}
+
+impl<T: Lift + Send + 'static> FutureReaderExt<T> for FutureReader<T> {
+    fn try_map<U: Lower + Lift + 'static>(
+        self,
+        mut store: impl AsContextMut,
+        fun: impl FnOnce(T) -> U + Send + 'static,
+    ) -> wasmtime::Result<FutureReader<U>> {
+        pin_project! {
+            struct Producer<T, F> {
+                #[pin]
+                rx: oneshot::Receiver<T>,
+                fun: Option<F>,
+            }
+        }
+
+        impl<D, T: Send + 'static, U, F: FnOnce(T) -> U + Send + 'static> FutureProducer<D>
+            for Producer<T, F>
+        {
+            type Item = U;
+
+            fn poll_produce(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                _store: StoreContextMut<D>,
+                finish: bool,
+            ) -> Poll<wasmtime::Result<Option<Self::Item>>> {
+                let me = self.project();
+
+                match me.rx.poll(cx) {
+                    Poll::Pending if finish => Poll::Ready(Ok(None)),
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(result) => {
+                        Poll::Ready(result.map_err(wasmtime::Error::from).and_then(|value| {
+                            Ok(Some((me
+                                .fun
+                                .take()
+                                .context("oneshot channel yielded more than one value")?)(
+                                value,
+                            )))
+                        }))
+                    }
+                }
+            }
+        }
+
+        struct Consumer<T> {
+            tx: Option<oneshot::Sender<T>>,
+        }
+
+        impl<D, T: Lift + Send + 'static> FutureConsumer<D> for Consumer<T> {
+            type Item = T;
+
+            fn poll_consume(
+                mut self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                store: StoreContextMut<D>,
+                mut source: Source<'_, Self::Item>,
+                _finish: bool,
+            ) -> Poll<wasmtime::Result<()>> {
+                let mut result = None;
+                source
+                    .read(store, &mut result)
+                    .context("failed to read result")?;
+                let result = result.context("result value missing")?;
+                let tx = self.tx.take().context("polled after returning `Ready`")?;
+                _ = tx.send(result);
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        let (tx, rx) = oneshot::channel();
+        let mapped = FutureReader::new(store.as_context_mut(), Producer { rx, fun: Some(fun) })?;
+        self.pipe(store, Consumer { tx: Some(tx) })?;
+        Ok(mapped)
+    }
+}
+
+pub trait StreamReaderExt<T> {
+    fn try_map<U: Lower + Lift + Send + Sync + 'static>(
+        self,
+        store: impl AsContextMut,
+        fun: impl Fn(T) -> U + Send + 'static,
+    ) -> wasmtime::Result<StreamReader<U>>;
+}
+
+impl<T: Lift + Send + 'static> StreamReaderExt<T> for StreamReader<T> {
+    fn try_map<U: Lower + Lift + Send + Sync + 'static>(
+        self,
+        mut store: impl AsContextMut,
+        fun: impl Fn(T) -> U + Send + 'static,
+    ) -> wasmtime::Result<StreamReader<U>> {
+        pin_project! {
+            struct Producer<T, F> {
+                #[pin]
+                rx: mpsc::Receiver<T>,
+                fun: F,
+            }
+        }
+
+        impl<D, T: Send + 'static, U: Send + Sync + 'static, F: Fn(T) -> U + Send + 'static>
+            StreamProducer<D> for Producer<T, F>
+        {
+            type Item = U;
+            type Buffer = Option<U>;
+
+            fn poll_produce<'a>(
+                self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                _store: StoreContextMut<'a, D>,
+                mut destination: Destination<'a, Self::Item, Self::Buffer>,
+                finish: bool,
+            ) -> Poll<wasmtime::Result<StreamResult>> {
+                let me = self.project();
+
+                match me.rx.poll_next(cx) {
+                    Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(Some(result)) => {
+                        destination.set_buffer(Some((me.fun)(result)));
+                        Poll::Ready(Ok(StreamResult::Completed))
+                    }
+                    Poll::Ready(None) => Poll::Ready(Ok(StreamResult::Dropped)),
+                }
+            }
+        }
+
+        struct Consumer<T> {
+            tx: mpsc::Sender<T>,
+        }
+
+        impl<D, T: Lift + Send + 'static> StreamConsumer<D> for Consumer<T> {
+            type Item = T;
+
+            fn poll_consume(
+                mut self: Pin<&mut Self>,
+                cx: &mut Context<'_>,
+                store: StoreContextMut<D>,
+                mut source: Source<'_, Self::Item>,
+                finish: bool,
+            ) -> Poll<wasmtime::Result<StreamResult>> {
+                match self.tx.poll_ready(cx) {
+                    Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
+                    Poll::Pending => Poll::Pending,
+                    Poll::Ready(Ok(())) => {
+                        let mut result = None;
+                        source
+                            .read(store, &mut result)
+                            .context("failed to read result")?;
+                        let result = result.context("result value missing")?;
+                        self.tx.start_send(result)?;
+                        Poll::Ready(Ok(StreamResult::Completed))
+                    }
+                    Poll::Ready(Err(error)) if error.is_disconnected() => {
+                        Poll::Ready(Ok(StreamResult::Dropped))
+                    }
+                    Poll::Ready(Err(error)) => Poll::Ready(Err(error.into())),
+                }
+            }
+        }
+
+        let (tx, rx) = mpsc::channel(1);
+        let mapped = StreamReader::new(store.as_context_mut(), Producer { rx, fun })?;
+        self.pipe(store, Consumer { tx })?;
+        Ok(mapped)
+    }
+}
+
+pub fn reborrow<'a, T: 'static, D: HasData + ?Sized>(
+    access: &'a mut Access<'_, T, D>,
+) -> Access<'a, T, D> {
+    let getter = access.getter();
+    Access::new(access.as_context_mut(), getter)
+}

--- a/crates/factors/src/factor.rs
+++ b/crates/factors/src/factor.rs
@@ -28,7 +28,7 @@ pub trait Factor: Any + Sized {
     /// This will be called at most once, before any call to
     /// [`Factor::prepare`]. `InitContext` provides access to a wasmtime
     /// `Linker`, so this is where any bindgen `add_to_linker` calls go.
-    fn init(&mut self, ctx: &mut impl InitContext<Self>) -> anyhow::Result<()> {
+    fn init<T: InitContext<Self>>(&mut self, ctx: &mut T) -> anyhow::Result<()> {
         let _ = ctx;
         Ok(())
     }

--- a/crates/http/src/trigger.rs
+++ b/crates/http/src/trigger.rs
@@ -3,9 +3,9 @@ use spin_factor_outbound_http::wasi_2023_10_18::ProxyIndices as ProxyIndices2023
 use spin_factor_outbound_http::wasi_2023_11_10::ProxyIndices as ProxyIndices2023_11_10;
 use wasmtime::component::InstancePre;
 use wasmtime_wasi::p2::bindings::CommandIndices;
-use wasmtime_wasi_http::handler::{HandlerState, ProxyHandler, ProxyPre};
+use wasmtime_wasi_http::handler::{HandlerState, ProxyHandler};
 use wasmtime_wasi_http::p2::bindings::ProxyIndices;
-use wasmtime_wasi_http::p3::bindings::{ServiceIndices, ServicePre};
+use wasmtime_wasi_http::p3::bindings::ServicePre;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -24,9 +24,22 @@ pub enum HandlerType<S: HandlerState> {
     Spin,
     Wagi(CommandIndices),
     Wasi0_2(ProxyIndices),
-    Wasi0_3(ServiceIndices, ProxyHandler<S>),
+    Wasi0_3(ProxyHandler<S>),
     Wasi2023_11_10(ProxyIndices2023_11_10),
     Wasi2023_10_18(ProxyIndices2023_10_18),
+}
+
+impl<S: HandlerState> Clone for HandlerType<S> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Spin => Self::Spin,
+            Self::Wagi(indices) => Self::Wagi(indices.clone()),
+            Self::Wasi0_2(indices) => Self::Wasi0_2(indices.clone()),
+            Self::Wasi2023_11_10(indices) => Self::Wasi2023_11_10(indices.clone()),
+            Self::Wasi2023_10_18(indices) => Self::Wasi2023_10_18(indices.clone()),
+            Self::Wasi0_3(handler) => Self::Wasi0_3(handler.clone()),
+        }
+    }
 }
 
 /// The `incoming-handler` export for `wasi:http` version rc-2023-10-18
@@ -47,14 +60,8 @@ impl<T, S: HandlerState<StoreData = T>> HandlerType<S> {
         if let Ok(indices) = ProxyIndices::new(pre) {
             candidates.push(HandlerType::Wasi0_2(indices));
         }
-        if let Ok(pre) = ServicePre::new(pre.clone()) {
-            candidates.push(HandlerType::Wasi0_3(
-                // We `.unwrap()` here because the `Ok(_)` result from
-                // `ServicePre::new` above proves that `pre` implements
-                // `wasi:http/handler@0.3.0-rc-2026-03-15`, so this can't fail.
-                ServiceIndices::new(pre.instance_pre()).unwrap(),
-                ProxyHandler::new(handler_state, ProxyPre::P3(pre)),
-            ));
+        if ServicePre::new(pre.clone()).is_ok() {
+            candidates.push(HandlerType::Wasi0_3(ProxyHandler::new(handler_state)));
         }
         if let Ok(indices) = ProxyIndices2023_10_18::new(pre) {
             candidates.push(HandlerType::Wasi2023_10_18(indices));

--- a/crates/http/src/trigger.rs
+++ b/crates/http/src/trigger.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use spin_factor_outbound_http::wasi_2023_10_18::ProxyIndices as ProxyIndices2023_10_18;
 use spin_factor_outbound_http::wasi_2023_11_10::ProxyIndices as ProxyIndices2023_11_10;
+use spin_factor_outbound_http::wasi_2026_03_15::ServiceIndices as ServiceIndices2026_03_15;
 use wasmtime::component::InstancePre;
 use wasmtime_wasi::p2::bindings::CommandIndices;
 use wasmtime_wasi_http::handler::{HandlerState, ProxyHandler};
@@ -27,6 +28,7 @@ pub enum HandlerType<S: HandlerState> {
     Wasi0_3(ProxyHandler<S>),
     Wasi2023_11_10(ProxyIndices2023_11_10),
     Wasi2023_10_18(ProxyIndices2023_10_18),
+    Wasi2026_03_15(ServiceIndices2026_03_15),
 }
 
 impl<S: HandlerState> Clone for HandlerType<S> {
@@ -37,19 +39,22 @@ impl<S: HandlerState> Clone for HandlerType<S> {
             Self::Wasi0_2(indices) => Self::Wasi0_2(indices.clone()),
             Self::Wasi2023_11_10(indices) => Self::Wasi2023_11_10(indices.clone()),
             Self::Wasi2023_10_18(indices) => Self::Wasi2023_10_18(indices.clone()),
+            Self::Wasi2026_03_15(indices) => Self::Wasi2026_03_15(indices.clone()),
             Self::Wasi0_3(handler) => Self::Wasi0_3(handler.clone()),
         }
     }
 }
 
-/// The `incoming-handler` export for `wasi:http` version rc-2023-10-18
+/// The `incoming-handler` export for `wasi:http` version 0.2.0-rc-2023-10-18
 const WASI_HTTP_EXPORT_2023_10_18: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-10-18";
-/// The `incoming-handler` export for `wasi:http` version rc-2023-11-10
+/// The `incoming-handler` export for `wasi:http` version 0.2.0-rc-2023-11-10
 const WASI_HTTP_EXPORT_2023_11_10: &str = "wasi:http/incoming-handler@0.2.0-rc-2023-11-10";
 /// The `incoming-handler` export prefix for all `wasi:http` 0.2 versions
 const WASI_HTTP_EXPORT_0_2_PREFIX: &str = "wasi:http/incoming-handler@0.2";
 /// The `handler` export `wasi:http` version 0.3.0-rc-2025-08-15
 const WASI_HTTP_EXPORT_0_3_0_RC_03_15: &str = "wasi:http/handler@0.3.0-rc-2026-03-15";
+/// The `handler` export prefix for all `wasi:http` 0.3 versions
+const WASI_HTTP_EXPORT_0_3_PREFIX: &str = "wasi:http/handler@0.3";
 /// The `inbound-http` export for `fermyon:spin`
 const SPIN_HTTP_EXPORT: &str = "fermyon:spin/inbound-http";
 
@@ -69,6 +74,9 @@ impl<T, S: HandlerState<StoreData = T>> HandlerType<S> {
         if let Ok(indices) = ProxyIndices2023_11_10::new(pre) {
             candidates.push(HandlerType::Wasi2023_11_10(indices));
         }
+        if let Ok(indices) = ServiceIndices2026_03_15::new(pre) {
+            candidates.push(HandlerType::Wasi2026_03_15(indices));
+        }
         if pre
             .component()
             .get_export_index(None, SPIN_HTTP_EXPORT)
@@ -85,6 +93,7 @@ impl<T, S: HandlerState<StoreData = T>> HandlerType<S> {
                     `{WASI_HTTP_EXPORT_2023_11_10}`, \
                     `{WASI_HTTP_EXPORT_0_2_PREFIX}.*`, \
                     `{WASI_HTTP_EXPORT_0_3_0_RC_03_15}`, \
+                    `{WASI_HTTP_EXPORT_0_3_PREFIX}.*`, \
                      or `{SPIN_HTTP_EXPORT}` but it exported none of those. \
                      This may mean the component handles a different trigger, or that its `wasi:http` export is newer then those supported by Spin. \
                      If you're sure this is an HTTP module, check if a Spin upgrade is available: this may handle the newer version."

--- a/crates/llm-local/src/llama.rs
+++ b/crates/llm-local/src/llama.rs
@@ -6,7 +6,7 @@ use candle_transformers::{
     generation::{LogitsProcessor, Sampling},
     models::llama::{self, Cache, Config, Llama, LlamaConfig},
 };
-use rand::{RngCore, SeedableRng};
+use rand::{SeedableRng, rand_core::Rng};
 use spin_core::async_trait;
 use spin_world::v2::llm::{self as wasi_llm, InferencingUsage};
 use std::{collections::HashMap, fs, path::Path, sync::Arc};
@@ -100,7 +100,7 @@ impl InferencingModel for LlamaModels {
             .map_err(|e| anyhow!(e.to_string()))?
             .get_ids()
             .to_vec();
-        let mut rng = rand::rngs::StdRng::from_os_rng();
+        let mut rng = rand::rngs::StdRng::try_from_rng(&mut rand::rngs::SysRng).unwrap();
 
         let mut logits_processor = {
             let temperature = params.temperature;

--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -24,8 +24,8 @@ use std::{
 use anyhow::{Context, bail};
 use clap::Args;
 use rand::{
-    RngCore,
     distr::uniform::{SampleRange, SampleUniform},
+    rand_core::Rng,
 };
 use serde::Deserialize;
 use spin_app::App;
@@ -168,10 +168,7 @@ impl<T> Range<T> {
 }
 
 impl<T: SampleUniform + PartialOrd> SampleRange<T> for Range<T> {
-    fn sample_single<R: RngCore + ?Sized>(
-        self,
-        rng: &mut R,
-    ) -> Result<T, rand::distr::uniform::Error> {
+    fn sample_single<R: Rng + ?Sized>(self, rng: &mut R) -> Result<T, rand::distr::uniform::Error> {
         match self {
             Self::Value(v) => Ok(v),
             Self::Bounds(a, b) => (a..b).sample_single(rng),

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -434,7 +434,8 @@ impl<F: RuntimeFactors> HttpServer<F> {
                 }
                 HandlerType::Wasi0_2(_)
                 | HandlerType::Wasi2023_11_10(_)
-                | HandlerType::Wasi2023_10_18(_) => {
+                | HandlerType::Wasi2023_10_18(_)
+                | HandlerType::Wasi2026_03_15(_) => {
                     WasiHttpExecutor { handler_type }
                         .execute(instance_builder, &route_match, req, client_addr)
                         .await

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -2,12 +2,15 @@ use std::{
     collections::HashMap,
     future::Future,
     io::{ErrorKind, IsTerminal},
+    marker::PhantomData,
     net::SocketAddr,
+    pin::Pin,
     sync::{Arc, OnceLock},
-    time::Duration,
+    task::{Context, Poll},
+    time::{Duration, Instant},
 };
 
-use anyhow::{Context, bail};
+use anyhow::{Context as _, bail};
 use http::{
     Request, Response, StatusCode, Uri,
     uri::{Authority, Scheme},
@@ -21,7 +24,8 @@ use hyper_util::{
     rt::{TokioExecutor, TokioIo},
     server::conn::auto::Builder,
 };
-use rand::Rng;
+use pin_project_lite::pin_project;
+use rand::RngExt;
 use spin_app::{APP_DESCRIPTION_KEY, APP_NAME_KEY};
 use spin_factor_outbound_http::{OutboundHttpFactor, SelfRequestOrigin};
 use spin_factors::RuntimeFactors;
@@ -39,10 +43,14 @@ use tokio::{
     task,
 };
 use tracing::Instrument;
-use wasmtime::ToWasmtimeResult;
+use wasmtime::{Store, StoreContextMut, ToWasmtimeResult, component::GuestTaskId};
 use wasmtime_wasi::p2::bindings::CommandIndices;
-use wasmtime_wasi_http::handler::{HandlerState, StoreBundle};
+use wasmtime_wasi_http::handler::{
+    HandlerState, Instance, Proxy, ShouldAccept, ViewFn, WorkerExpiration, WorkerState,
+    WorkerStatus,
+};
 use wasmtime_wasi_http::p2::body::HyperOutgoingBody;
+use wasmtime_wasi_http::p3::bindings::Service;
 
 use crate::{
     Body, InstanceReuseConfig, NotFoundRouteKind, OutputFormat, TlsConfig, TriggerApp,
@@ -419,7 +427,7 @@ impl<F: RuntimeFactors> HttpServer<F> {
                         .execute(instance_builder, &route_match, req, client_addr)
                         .await
                 }
-                HandlerType::Wasi0_3(_, handler) => {
+                HandlerType::Wasi0_3(handler) => {
                     Wasip3HttpExecutor(handler)
                         .execute(&route_match, req, client_addr)
                         .await
@@ -699,6 +707,83 @@ pub(crate) trait HttpExecutor {
     ) -> impl Future<Output = anyhow::Result<Response<Body>>>;
 }
 
+pin_project! {
+    pub(crate) struct HttpWorkerExpiration {
+        idle_timeout: Duration,
+        request_timeout: Duration,
+        #[pin]
+        sleep: tokio::time::Sleep,
+    }
+}
+
+impl WorkerExpiration for HttpWorkerExpiration {
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        status: WorkerStatus,
+        start: Instant,
+    ) -> Poll<()> {
+        let mut me = self.project();
+
+        let timeout = match status {
+            WorkerStatus::Idle => *me.idle_timeout,
+            // TODO: add a dedicated `post_return_timeout` config setting
+            // instead of reusing `request_timeout` for
+            // `WorkerStatus::PostReturn` here
+            WorkerStatus::Requests | WorkerStatus::PostReturn => *me.request_timeout,
+        };
+
+        if let Some(deadline) = start.checked_add(timeout) {
+            let deadline = deadline.into();
+            if deadline != me.sleep.deadline() {
+                me.sleep.as_mut().reset(deadline);
+            }
+            me.sleep.poll(cx)
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+pub(crate) struct HttpWorkerState<F: RuntimeFactors> {
+    request_timeout: Duration,
+    max_instance_reuse_count: usize,
+    max_instance_concurrent_reuse_count: usize,
+    _phantom: PhantomData<F>,
+}
+
+impl<F: RuntimeFactors> WorkerState for HttpWorkerState<F> {
+    type StoreData = InstanceState<F::InstanceState, ()>;
+    type RequestId = ();
+
+    fn should_accept_request(&self, concurrent_count: usize, total_count: usize) -> ShouldAccept {
+        if total_count >= self.max_instance_reuse_count {
+            ShouldAccept::Never
+        } else if concurrent_count >= self.max_instance_concurrent_reuse_count {
+            ShouldAccept::No
+        } else {
+            ShouldAccept::Yes
+        }
+    }
+
+    fn on_request_start(
+        &self,
+        _: StoreContextMut<'_, Self::StoreData>,
+        _: Self::RequestId,
+        _: GuestTaskId,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send + Sync + 'static>> {
+        Box::pin(tokio::time::sleep(self.request_timeout))
+    }
+
+    fn drop(&self, store: Store<Self::StoreData>, result: Result<(), wasmtime::Error>) {
+        if let Err(error) = result {
+            eprintln!("worker failed: {error:?}");
+        }
+
+        drop(store);
+    }
+}
+
 pub(crate) struct HttpHandlerState<F: RuntimeFactors> {
     trigger_app: Arc<TriggerApp<F>>,
     component_id: String,
@@ -707,40 +792,53 @@ pub(crate) struct HttpHandlerState<F: RuntimeFactors> {
 
 impl<F: RuntimeFactors> HandlerState for HttpHandlerState<F> {
     type StoreData = InstanceState<F::InstanceState, ()>;
+    type WorkerExpiration = HttpWorkerExpiration;
+    type WorkerState = HttpWorkerState<F>;
 
-    fn new_store(&self, _req_id: Option<u64>) -> wasmtime::Result<StoreBundle<Self::StoreData>> {
-        Ok(StoreBundle {
-            store: self
-                .trigger_app
-                .prepare(&self.component_id)
-                .to_wasmtime_result()?
-                .instantiate_store(())
-                .to_wasmtime_result()?
-                .into_inner(),
-            write_profile: Box::new(|_| ()),
-        })
-    }
+    async fn instantiate(
+        &self,
+    ) -> wasmtime::Result<Instance<Self::StoreData, Self::WorkerExpiration, Self::WorkerState>>
+    {
+        let (instance, store) = self
+            .trigger_app
+            .prepare(&self.component_id)
+            .to_wasmtime_result()?
+            .instantiate(())
+            .await
+            .to_wasmtime_result()?;
 
-    fn request_timeout(&self) -> Duration {
-        self.reuse_config
+        let mut store = store.into_inner();
+
+        let proxy = Proxy::P3(Service::new(&mut store, &instance).unwrap());
+
+        let request_timeout = self
+            .reuse_config
             .request_timeout
             .map(|range| rand::rng().random_range(range))
-            .unwrap_or(Duration::MAX)
-    }
+            .unwrap_or(Duration::MAX);
 
-    fn idle_instance_timeout(&self) -> Duration {
-        rand::rng().random_range(self.reuse_config.idle_instance_timeout)
-    }
-
-    fn max_instance_reuse_count(&self) -> usize {
-        rand::rng().random_range(self.reuse_config.max_instance_reuse_count)
-    }
-
-    fn max_instance_concurrent_reuse_count(&self) -> usize {
-        rand::rng().random_range(self.reuse_config.max_instance_concurrent_reuse_count)
-    }
-
-    fn handle_worker_error(&self, error: wasmtime::Error) {
-        tracing::warn!("worker error: {error:?}")
+        Ok(Instance {
+            store,
+            proxy,
+            view: ViewFn::P3(|data| {
+                spin_factor_outbound_http::OutboundHttpFactor::get_wasi_p3_http_impl(
+                    data.factors_instance_state_mut(),
+                )
+                .unwrap()
+            }),
+            expiration: HttpWorkerExpiration {
+                idle_timeout: rand::rng().random_range(self.reuse_config.idle_instance_timeout),
+                request_timeout,
+                sleep: tokio::time::sleep(Duration::MAX),
+            },
+            state: HttpWorkerState {
+                request_timeout,
+                max_instance_reuse_count: rand::rng()
+                    .random_range(self.reuse_config.max_instance_reuse_count),
+                max_instance_concurrent_reuse_count: rand::rng()
+                    .random_range(self.reuse_config.max_instance_concurrent_reuse_count),
+                _phantom: PhantomData,
+            },
+        })
     }
 }

--- a/crates/trigger-http/src/wasi.rs
+++ b/crates/trigger-http/src/wasi.rs
@@ -90,7 +90,7 @@ impl<S: HandlerState> HttpExecutor for WasiHttpExecutor<'_, S> {
                 Handler::Handler2023_11_10(guest)
             }
             HandlerType::Wasi0_2(indices) => Handler::Latest(indices.load(&mut store, &instance)?),
-            HandlerType::Wasi0_3(_, _) => unreachable!("should have used Wasip3HttpExecutor"),
+            HandlerType::Wasi0_3(_) => unreachable!("should have used Wasip3HttpExecutor"),
             HandlerType::Spin => unreachable!("should have used SpinHttpExecutor"),
             HandlerType::Wagi(_) => unreachable!("should have used WagiExecutor instead"),
         };

--- a/crates/trigger-http/src/wasi.rs
+++ b/crates/trigger-http/src/wasi.rs
@@ -1,20 +1,27 @@
+use std::future;
 use std::io::IsTerminal;
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result, anyhow};
 use futures::TryFutureExt;
 use http::{HeaderName, HeaderValue};
+use http_body_util::BodyExt;
 use hyper::{Request, Response};
+use spin_core::Store;
 use spin_factor_outbound_http::wasi_2023_10_18::Proxy as Proxy2023_10_18;
 use spin_factor_outbound_http::wasi_2023_11_10::Proxy as Proxy2023_11_10;
-use spin_factors::RuntimeFactors;
+use spin_factor_outbound_http::wasi_2026_03_15::Service as Service2026_03_15;
+use spin_factors::{RuntimeFactors, RuntimeFactorsInstanceState};
+use spin_factors_executor::InstanceState;
 use spin_http::routes::RouteMatch;
 use spin_http::trigger::HandlerType;
 use tokio::{sync::oneshot, task};
 use tracing::{Instrument, Level, instrument};
+use wasmtime::AsContextMut;
 use wasmtime_wasi_http::handler::HandlerState;
 use wasmtime_wasi_http::p2::bindings::http::types::Scheme;
 use wasmtime_wasi_http::p2::{bindings::Proxy, body::HyperIncomingBody as Body};
+use wasmtime_wasi_http::p3;
 
 use crate::{TriggerInstanceBuilder, headers::prepare_request_headers, server::HttpExecutor};
 
@@ -64,16 +71,6 @@ impl<S: HandlerState> HttpExecutor for WasiHttpExecutor<'_, S> {
 
         let (instance, mut store) = instance_builder.instantiate(()).await?;
 
-        let mut wasi_http = spin_factor_outbound_http::OutboundHttpFactor::get_wasi_http_impl(
-            store.data_mut().factors_instance_state_mut(),
-        )
-        .context("missing OutboundHttpFactor")?;
-
-        let request = wasi_http.new_incoming_request(Scheme::Http, req)?;
-
-        let (response_tx, response_rx) = oneshot::channel();
-        let response = wasi_http.new_response_outparam(response_tx)?;
-
         enum Handler {
             Latest(Proxy),
             Handler2023_11_10(Proxy2023_11_10),
@@ -89,11 +86,25 @@ impl<S: HandlerState> HttpExecutor for WasiHttpExecutor<'_, S> {
                 let guest = indices.load(&mut store, &instance)?;
                 Handler::Handler2023_11_10(guest)
             }
+            HandlerType::Wasi2026_03_15(indices) => {
+                let guest = indices.load(&mut store, &instance)?;
+                return handle_2026_03_15(store, guest, req).await;
+            }
             HandlerType::Wasi0_2(indices) => Handler::Latest(indices.load(&mut store, &instance)?),
             HandlerType::Wasi0_3(_) => unreachable!("should have used Wasip3HttpExecutor"),
             HandlerType::Spin => unreachable!("should have used SpinHttpExecutor"),
             HandlerType::Wagi(_) => unreachable!("should have used WagiExecutor instead"),
         };
+
+        let mut wasi_http = spin_factor_outbound_http::OutboundHttpFactor::get_wasi_http_impl(
+            store.data_mut().factors_instance_state_mut(),
+        )
+        .context("missing OutboundHttpFactor")?;
+
+        let request = wasi_http.new_incoming_request(Scheme::Http, req)?;
+
+        let (response_tx, response_rx) = oneshot::channel();
+        let response = wasi_http.new_response_outparam(response_tx)?;
 
         let handle = task::spawn(
             async move {
@@ -168,4 +179,63 @@ impl<S: HandlerState> HttpExecutor for WasiHttpExecutor<'_, S> {
             }
         }
     }
+}
+
+async fn handle_2026_03_15<T: RuntimeFactorsInstanceState, U: Send>(
+    mut store: Store<InstanceState<T, U>>,
+    guest: Service2026_03_15,
+    req: Request<Body>,
+) -> Result<Response<Body>> {
+    let (request, request_io_result) = p3::Request::from_http(req);
+    let view: fn(&mut InstanceState<_, _>) -> p3::WasiHttpCtxView =
+        |data: &mut InstanceState<_, _>| {
+            spin_factor_outbound_http::OutboundHttpFactor::get_wasi_p3_http_impl(
+                data.factors_instance_state_mut(),
+            )
+            .unwrap()
+        };
+    let request = view(store.data_mut()).table.push(request)?;
+
+    let (tx, rx) = oneshot::channel();
+    task::spawn(
+        async move {
+            store
+                .as_context_mut()
+                .run_concurrent(async |accessor| {
+                    let response = guest
+                        .wasi_http0_3_0_rc_2026_03_15_handler()
+                        .call_handle(accessor, request)
+                        .await??;
+
+                    let response = accessor.with(|mut store| {
+                        view(store.get())
+                            .table
+                            .delete(response)?
+                            .into_http_with_getter(&mut store, request_io_result, view)
+                    })?;
+
+                    _ = tx.send(response);
+
+                    future::poll_fn(|cx| accessor.poll_no_interesting_tasks(cx)).await;
+
+                    Ok(())
+                })
+                .await?
+        }
+        .map_err(|e: anyhow::Error| {
+            if std::io::stderr().is_terminal() {
+                tracing::error!(
+                    "Component error while handling request. \
+                                 The response may not be fully sent: {e:?}"
+                );
+            } else {
+                terminal::warn!("Component error while handling request: {e:?}");
+            }
+        })
+        .in_current_span(),
+    );
+
+    Ok(rx
+        .await?
+        .map(|body| body.map_err(|e| e.into()).boxed_unsync()))
 }

--- a/crates/trigger-http/src/wasip3.rs
+++ b/crates/trigger-http/src/wasip3.rs
@@ -1,18 +1,14 @@
 use crate::server::HttpHandlerState;
-use anyhow::{Context as _, Result};
-use futures::{FutureExt, channel::oneshot};
+use anyhow::Result;
 use http_body_util::BodyExt;
-use spin_factor_outbound_http::{NotifyOnDropBody, p3_to_p2_error_code};
 use spin_factors::RuntimeFactors;
-use spin_factors_executor::InstanceState;
 use spin_http::routes::RouteMatch;
 use std::net::SocketAddr;
-use tracing::{Instrument, Level, instrument};
-use wasmtime::component::Accessor;
+use tracing::{Level, instrument};
 use wasmtime_wasi_http::{
-    handler::{Proxy, ProxyHandler},
-    p2::body::HyperIncomingBody as Body,
-    p3::{WasiHttpCtxView, bindings::http::types},
+    handler::{ErrorCode, ProxyHandler},
+    p2::{bindings::http::types as p2_types, body::HyperIncomingBody as Body},
+    p3::bindings::http::types as p3_types,
 };
 
 /// An [`HttpExecutor`] that uses the `wasi:http@0.3.*/handler` interface.
@@ -30,79 +26,19 @@ impl<F: RuntimeFactors> Wasip3HttpExecutor<'_, F> {
     ) -> Result<http::Response<Body>> {
         super::wasi::prepare_request(route_match, &mut req, client_addr)?;
 
-        let getter = (|data| wasi_http::<F>(data).unwrap())
-            as fn(&mut InstanceState<F::InstanceState, ()>) -> WasiHttpCtxView<'_>;
-
-        let (request, body) = req.into_parts();
-        let body = body.map_err(spin_factor_outbound_http::p2_to_p3_error_code);
-        let request = http::Request::from_parts(request, body);
-        let (request, request_io_result) = types::Request::from_http(request);
-
-        let (tx, rx) = oneshot::channel();
-        self.0.spawn(
-            None,
-            Box::new(move |store: &Accessor<_>, guest: &Proxy| {
-                Box::pin(
-                    async move {
-                        let Proxy::P3(guest) = guest else {
-                            unreachable!();
-                        };
-
-                        let request = store.with(|mut store| {
-                            anyhow::Ok(wasi_http::<F>(store.data_mut())?.table.push(request)?)
-                        })?;
-
-                        let response = guest
-                            .wasi_http_handler()
-                            .call_handle(store, request)
-                            .await?;
-                        let response = store.with(|mut store| {
-                            anyhow::Ok(wasi_http::<F>(store.get())?.table.delete(response?)?)
-                        })?;
-                        let response = store.with(|mut store| {
-                            response.into_http_with_getter(&mut store, request_io_result, getter)
-                        })?;
-
-                        // Wrap the response body in a `NotifyOnDropBody` so we can
-                        // be notified when Hyper has finished reading it.
-                        let (response_body_tx, response_body_rx) = oneshot::channel();
-                        let response = response.map(|body| {
-                            NotifyOnDropBody::new(
-                                body.map_err(p3_to_p2_error_code),
-                                response_body_tx,
-                            )
-                            .boxed_unsync()
-                        });
-
-                        if tx.send(response).is_ok() {
-                            // We must not exit the store's event loop until
-                            // Hyper has finished reading the response body;
-                            // otherwise, the guest will not have a chance
-                            // to finish writing it.
-                            _ = response_body_rx.await;
-                        }
-
-                        anyhow::Ok(())
-                    }
-                    .in_current_span()
-                    .map(|result| {
-                        if let Err(error) = result {
-                            tracing::error!("Component error handling request: {error:?}");
-                        }
-                    }),
-                )
-            }),
-        );
-
-        Ok(rx.await?)
+        Ok(self
+            .0
+            .handle(
+                (),
+                req.map(|body| body.map_err(ErrorCode::from).boxed_unsync()),
+            )
+            .await?
+            .map(|body| {
+                body.map_err(|e| match e.downcast::<p3_types::ErrorCode>() {
+                    Ok(e) => e.into(),
+                    Err(e) => p2_types::ErrorCode::InternalError(Some(e.to_string())),
+                })
+                .boxed_unsync()
+            }))
     }
-}
-
-fn wasi_http<F: RuntimeFactors>(
-    data: &mut InstanceState<F::InstanceState, ()>,
-) -> Result<WasiHttpCtxView<'_>> {
-    spin_factor_outbound_http::OutboundHttpFactor::get_wasi_p3_http_impl(
-        data.factors_instance_state_mut(),
-    )
-    .context("missing OutboundHttpFactor")
 }

--- a/examples/spin-timer/Cargo.lock
+++ b/examples/spin-timer/Cargo.lock
@@ -634,53 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.2",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "azure_core"
 version = "0.20.0"
 source = "git+https://github.com/azure/azure-sdk-for-rust?rev=8c4caa251c3903d5eae848b41bb1d02a4d65231c#8c4caa251c3903d5eae848b41bb1d02a4d65231c"
@@ -993,7 +946,7 @@ checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "smallvec",
 ]
 
@@ -1009,20 +962,10 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "rustix-linux-procfs",
  "windows-sys 0.59.0",
  "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -1034,7 +977,7 @@ dependencies = [
  "cap-primitives",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -1047,7 +990,7 @@ dependencies = [
  "cap-primitives",
  "iana-time-zone",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "winx",
 ]
 
@@ -1080,6 +1023,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "chrono"
@@ -1235,28 +1189,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-assembler-x64"
-version = "0.131.0"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6edb5bdd1af46714e3224a017fabbbd57f70df4e840eb5ad6a7429dc456119d6"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.133.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06aeba2c965fc446d13c56a6ccb2631b78445d7544543dd9a25289977630914"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a819599186e1b1a1f88d464e06045696afc7aa3e0cc018aa0b2999cb63d1d088"
+checksum = "ee2d2dde4ec1352715595b5cfa6fe2e5b8ebb9da3457b3ee8db0aa2808c069aa"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36e2c152d488e03c87b913bc2ed3414416eb1e0d66d61b49af60bf456a9665c7"
+checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -1264,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6559d4fbc253d1396e1f6beeae57fa88a244f02aaf0cde2a735afd3492d9b2e"
+checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1275,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d9315d98d6e0a64454d4c83be2ee0e8055c3f80c3b2d7bcad7079f281a06ff"
+checksum = "b7780677247ad3577e3a6a3ebf43f39b325a11d6393db72b2c9968a910d4d13d"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1289,13 +1252,16 @@ dependencies = [
  "cranelift-entity",
  "cranelift-isle",
  "gimli",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
+ "serde_derive",
+ "sha2",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -1303,9 +1269,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89c00a88081c55e3087c45bebc77e0cc973de2d7b44ef6a943c7122647b89f5"
+checksum = "ac9645250416cbf92454fe61160e17e026e0ce405906a54500b114f923ddffc9"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1316,24 +1282,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f77c497a1eb6273482aa1ac3b23cb8563ff04edb39ed5dfcfd28c8deff8f5"
+checksum = "20ee8d222ff0fd3681791979afbf88586ac9f49010d3db96b3cbe4c96759aee3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "498dc1f17a6910c88316d49c7176d8fa97cf10c30859c32a266040449317f963"
+checksum = "591abe6f5312bd2c4220f1b3bead56c2ad00257c52668015ba013b85dcf2a17a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2acba797f6a46042ce82aaf7680d0c3567fe2001e238db9df649fd104a2727f"
+checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1343,11 +1309,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dca3df1d107d98d88f159ad1d5eaa2d5cdb678b3d5bcfadc6fc83d8ebb448ea"
+checksum = "da4adbf760207fdbbe130f1191cce01cdef66831a9f648b1f39ff2800d126d45"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.0",
  "log",
  "smallvec",
  "target-lexicon",
@@ -1355,15 +1322,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62dd18116d88bed649871feceda79dad7b59cc685ea8998c2b3e64d0e689602"
+checksum = "8315b21ff018226a42a60a4702c2dd75f6447cac26e9bca622e14c22088c2ff5"
 
 [[package]]
 name = "cranelift-native"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f843b80360d7fdf61a6124642af7597f6d55724cf521210c34af8a1c66daca6e"
+checksum = "d506ef23a60715bde451b06620b14402166ded3b648454fccbf04f3e46a4aa70"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1372,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.131.0"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090ee5de58c6f17eb5e3a5ae8cf1695c7efea04ec4dd0ecba6a5b996c9bad7dc"
+checksum = "48ed47e602652e3410f9387fc0db70fefadcee4d78a78881421aabcab4e26b89"
 
 [[package]]
 name = "crc32fast"
@@ -1760,17 +1727,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.1.2",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,7 +1814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
 dependencies = [
  "io-lifetimes",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2056,9 +2012,23 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -2100,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2144,8 +2114,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2315,22 +2283,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.8",
+ "h2 0.4.14",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2378,7 +2345,7 @@ checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http 1.3.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-native-certs 0.8.3",
@@ -2395,7 +2362,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2410,7 +2377,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2429,7 +2396,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "libc",
  "pin-project-lite",
  "socket2 0.5.9",
@@ -2837,9 +2804,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2932,9 +2899,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2982,12 +2949,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "matchers"
@@ -2997,12 +2961,6 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "maybe-owned"
@@ -3032,7 +2990,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -3052,13 +3010,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3328,9 +3286,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.28.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3342,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.28.1"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c513c7af3bec30113f3d4620134ff923295f1e9c580fda2b8abe0831f925ddc0"
+checksum = "e716f864eb23007bdd9dc4aec381e188a1cee28eecf22066772b5fd822b9727d"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -3354,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3368,11 +3326,10 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
 dependencies = [
- "async-trait",
  "futures-core",
  "http 1.3.1",
  "opentelemetry",
@@ -3388,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3400,24 +3357,23 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb3a2f78c2d55362cd6c313b8abedfbc0142ab3c2676822068fd2ab7d51f9b7"
+checksum = "84b29a9f89f1a954936d5aa92f19b2feec3c8f3971d3e96206640db7f9706ae3"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.9.4",
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
@@ -3697,6 +3653,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3782,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df866b7fd522992ccc6682e58b2741cc7972b163b661db24c4328f4c914cb09d"
+checksum = "38b92604caae1a1899b6a5b54967289dd538177c626004c91accf9d0ec7e4a12"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -3794,9 +3760,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7dfa8354acc622b3857e1bb1a4e4315d3bc1a44ad31d5653c3e87c0da9306d7"
+checksum = "5a7ac85c0bb3fb351f10d531230aaa5e366b46d7c4e5328e5f02801d6dac1165"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3873,6 +3839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,6 +3882,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3970,6 +3953,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4018,7 +4007,7 @@ dependencies = [
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -4078,15 +4067,16 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -4162,11 +4152,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.14",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-rustls 0.27.5",
  "hyper-tls",
  "hyper-util",
@@ -4368,14 +4358,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -4386,7 +4376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
 dependencies = [
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -4812,7 +4802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4829,7 +4819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4899,12 +4889,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4965,9 +4955,9 @@ dependencies = [
  "anyhow",
  "tracing",
  "wasm-encoder 0.247.0",
- "wasm-metadata",
+ "wasm-metadata 0.247.0",
  "wasmparser 0.247.0",
- "wit-component",
+ "wit-component 0.247.0",
  "wit-parser 0.247.0",
 ]
 
@@ -4987,6 +4977,16 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "wac-graph",
+]
+
+[[package]]
+name = "spin-connection-semaphore"
+version = "4.1.0-pre0"
+dependencies = [
+ "anyhow",
+ "spin-telemetry",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -5077,7 +5077,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-util",
  "opentelemetry-semantic-conventions",
  "pin-project-lite",
@@ -5086,9 +5086,11 @@ dependencies = [
  "serde",
  "spin-factor-otel",
  "spin-factor-outbound-networking",
+ "spin-factor-wasi",
  "spin-factors",
  "spin-telemetry",
  "spin-world",
+ "terminal",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -5105,6 +5107,7 @@ version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
  "rumqttc",
+ "serde",
  "spin-core",
  "spin-factor-otel",
  "spin-factor-outbound-networking",
@@ -5122,6 +5125,8 @@ dependencies = [
  "anyhow",
  "futures",
  "mysql_async",
+ "opentelemetry-semantic-conventions",
+ "serde",
  "spin-core",
  "spin-factor-otel",
  "spin-factor-outbound-networking",
@@ -5148,6 +5153,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
+ "spin-connection-semaphore",
  "spin-factor-variables",
  "spin-factor-wasi",
  "spin-factors",
@@ -5155,6 +5161,7 @@ dependencies = [
  "spin-manifest",
  "spin-outbound-networking-config",
  "spin-serde",
+ "tokio",
  "tracing",
  "url",
  "webpki-root-certs",
@@ -5171,9 +5178,11 @@ dependencies = [
  "futures",
  "moka",
  "native-tls",
+ "opentelemetry-semantic-conventions",
  "postgres-native-tls",
  "postgres_range",
  "rust_decimal",
+ "serde",
  "serde_json",
  "spin-common",
  "spin-core",
@@ -5198,7 +5207,9 @@ name = "spin-factor-outbound-redis"
 version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
+ "opentelemetry-semantic-conventions",
  "redis",
+ "serde",
  "spin-core",
  "spin-factor-otel",
  "spin-factor-outbound-networking",
@@ -5214,6 +5225,7 @@ name = "spin-factor-sqlite"
 version = "4.1.0-pre0"
 dependencies = [
  "async-trait",
+ "opentelemetry-semantic-conventions",
  "spin-core",
  "spin-factor-otel",
  "spin-factors",
@@ -5244,9 +5256,13 @@ version = "4.1.0-pre0"
 dependencies = [
  "async-trait",
  "bytes",
+ "futures",
+ "pin-project-lite",
  "spin-common",
+ "spin-connection-semaphore",
  "spin-factors",
  "tokio",
+ "tracing",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -5529,12 +5545,20 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "reqwest",
  "terminal",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "spin-tls"
+version = "4.1.0-pre0"
+dependencies = [
+ "rustls 0.23.37",
 ]
 
 [[package]]
@@ -5560,6 +5584,7 @@ dependencies = [
  "spin-factors",
  "spin-factors-executor",
  "spin-telemetry",
+ "spin-tls",
  "spin-world",
  "tokio",
  "tracing",
@@ -5759,22 +5784,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.44",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5788,20 +5797,20 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.2",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5827,7 +5836,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5942,9 +5951,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5952,16 +5961,16 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6149,22 +6158,18 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.8",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
- "socket2 0.5.9",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -6272,9 +6277,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
 dependencies = [
  "js-sys",
  "once_cell",
@@ -6518,7 +6523,7 @@ dependencies = [
  "thiserror 1.0.69",
  "wac-types",
  "wasm-encoder 0.247.0",
- "wasm-metadata",
+ "wasm-metadata 0.247.0",
  "wasmparser 0.247.0",
 ]
 
@@ -6580,6 +6585,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -6649,9 +6672,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.246.2"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
+checksum = "b089037d7eb453ed57b560fe7833de0707411c8b9fdc429745ced77e2a1bacb9"
 dependencies = [
  "anyhow",
  "heck",
@@ -6659,19 +6682,19 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-encoder"
-version = "0.246.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -6682,6 +6705,28 @@ checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.251.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -6735,15 +6780,14 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.246.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
- "hashbrown 0.16.1",
+ "hashbrown 0.15.2",
  "indexmap 2.14.0",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -6760,21 +6804,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.246.2"
+name = "wasmparser"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8798c1a699bd25648b6708eefe94d97c6f9891febb94b42cca1f7a4b086ea64e"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca3f777dfb4db45915f95eeb25cac7f2eeb268797a27e5eb78b072618135c7f"
+checksum = "c4213d2f019a5e44aa8a61d8826dd33a505bff79f749b14a8bafd67321cb9351"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -6797,7 +6854,7 @@ dependencies = [
  "postcard",
  "pulley-interpreter",
  "rayon",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "semver",
  "serde",
  "serde_derive",
@@ -6806,8 +6863,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -6819,16 +6876,16 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c5ca1af838cec374931242d07af5d354aedf63f297f95b3625ac863e516ef67"
+checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -6836,7 +6893,7 @@ dependencies = [
  "cranelift-bitset",
  "cranelift-entity",
  "gimli",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "log",
  "object",
@@ -6848,8 +6905,8 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.246.2",
- "wasmparser 0.246.2",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -6857,15 +6914,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2004f7c86ebeb116550655377cdf16dbf7b03ae5aa6b4b1c1458cfa23aaa306"
+checksum = "438bc7dc45fb75297d75f79a9a0ce852345d13ebc6a6863f6f688f013836a9dd"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
  "log",
  "postcard",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "serde",
  "serde_derive",
  "sha2",
@@ -6877,9 +6934,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58b31927f7b613d8fe019609744e226f6458d8aa5e6289e92fbbc60e521cd026"
+checksum = "f1e48f8d4966d62a10b6d70722bc432c1e163890be2801d3b5784589ad36ffc3"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -6887,32 +6944,32 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc29e3478928b93979831ba02a997ce7f707c673ce47180d643091cf4fa4f561"
+checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816a61a75275c6be435131fc625a4f5956daf24d9f9f59443e81cbef228929b3"
+checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "libm",
  "serde",
 ]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ceb5e079877e7e4565c1e2d86d9db889175d55f7ca0001315576d08c71e634"
+checksum = "a433efc6e35112a5457e1dc8bc4d8d39820ac7722267e89bc04e5df641f32124"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6928,7 +6985,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.246.2",
+ "wasmparser 0.251.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -6937,14 +6994,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e18f8bb05d25e0d4cca7278147c9f9e2f26f66886ef754b562bf729128f1e537"
+checksum = "18a1d3a39d0d210f6b8574ee96a4315e0a14c67f3a1fc3cd5372cb10d2fb4422"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "wasmtime-environ",
  "wasmtime-internal-versioned-export-macros",
  "windows-sys 0.61.2",
@@ -6952,21 +7009,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357f1070b31154ee463937b477ca0b2962bf450b40fc59799bef2f656b15da73"
+checksum = "9f667288cb4dfa68a4639ffac4d5628535dda64ebdc2b990526efb12b30ba803"
 dependencies = [
  "cc",
  "object",
- "rustix 1.1.2",
+ "rustix 1.1.4",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd683a94490bf755d016a09697b0955602c50106b1ded97d16983ab2ded9fed"
+checksum = "eba651d44ab0faad4c58106b3adb45068189fb65ef50f0c404b6d9e3bf81a357"
 dependencies = [
  "cfg-if",
  "libc",
@@ -6976,9 +7033,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471746ce113c3c1862ce2c0674acb35399a4b3ed3ef4531dc087f333c74f064"
+checksum = "2ecc52563b0558af2a7487eb710de07cc4532564b55528876129238e83118cb1"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -6989,9 +7046,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6af582ec18b674bf7a17775d6fbfbddfcc143f0edbd89c9c1778239c8aa92ed"
+checksum = "e747f4a074699ba1b4e4d841fb263f9b7df5bd1555181c4752bf5990d21ba676"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6999,55 +7056,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31be8916bb60ea756d2f0ae1f634d9258442aa71e773c893e2f4cead30501b5"
-dependencies = [
- "cranelift-codegen",
- "gimli",
- "log",
- "object",
- "target-lexicon",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2150e63d502ab2d64754e5abe8eb737ae674b7dd4ad53144fd16bbeceaf4a19"
+checksum = "80009f46991622814196d96fac6fc0a938f46b5cba737a8f4e21e24e5a03856f"
 dependencies = [
  "anyhow",
  "bitflags",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.246.2",
+ "wit-parser 0.251.0",
 ]
 
 [[package]]
 name = "wasmtime-wasi"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83f5109b4fd619b9796b9c9901de59d83e3575cd1226c1a36d1901371f43db28"
+checksum = "e9f65ef30a2c5478873cdb619085a7a649d3ce41cc3eaf298a7ce3dee96a8e11"
 dependencies = [
  "async-trait",
  "bitflags",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
- "cap-rand",
  "cap-std",
  "cap-time-ext",
- "fs-set-times",
+ "cfg-if",
  "futures",
  "io-extras",
  "io-lifetimes",
- "rustix 1.1.2",
- "system-interface",
+ "rand 0.10.1",
+ "rustix 1.1.4",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -7060,9 +7099,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5798e6e48005406983ba6a7b27f3832f1571e53f1401ef2d60111c96eab534b4"
+checksum = "cb65eeb8116615c2a22f51b19672c0d5b652ca7b051086da5c7c0a9eb39f4af7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7070,7 +7109,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.10.1",
  "rustls 0.23.37",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -7084,9 +7123,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ebe14c586e98d2fdc32c76ca0005ef28348e98ed737e776d378b3b0cc2afd0"
+checksum = "cee57d5fef4976b1ab542615f4cef2c43278eb549d8078939668ea0f13d5c696"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7106,24 +7145,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "247.0.0"
+version = "251.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579d2d47eb33b0cdf9b14723cb115f1e1b7d6e77aac6f0816e5b7c7aeaa418ff"
+checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.247.0",
+ "wasm-encoder 0.251.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.247.0"
+version = "1.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f4091c56437e86f2b57fa2fac72c4f528957a605b3f44f7c0b3b19a17ac5ee"
+checksum = "81b1086c9e85b95bd6a229a928bc6c6d0662e42af0250c88d067b418831ea4d4"
 dependencies = [
- "wast 247.0.0",
+ "wast 251.0.0",
 ]
 
 [[package]]
@@ -7177,9 +7216,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cff414ef7dce0cc1cf8a033ff80d3f38e3987c37e3efeec7926ecb5ffaaae6"
+checksum = "e03df88bf1a6068b02851aa3ef9427d285118f5c1c153b068a8995c69dd9562a"
 dependencies = [
  "bitflags",
  "thiserror 2.0.17",
@@ -7191,9 +7230,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf9dc7272b151a9616a2699e7f94ea1d4ae253b47b63a79fbc8f38e2cca5fa6"
+checksum = "e014aec8661b613154377e4b49dbbb0dfc4f424efcee749782054576c00537d9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -7205,9 +7244,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "44.0.0"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa7c29fcf738630cba4e35f1805da5e42dde20ee9809ee9202b0648ae671602f"
+checksum = "f67310a8ae5190b7f3dcacf8697f2890701a3a8427b3e77ed91d3632dcedaceb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7245,25 +7284,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "44.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9339858ad222412200fd8b1af9e270712201aaec440c7618991443af3446481f"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.17",
- "wasmparser 0.246.2",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "windows"
@@ -7633,12 +7653,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.244.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core",
+ "wit-component 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.244.0",
+ "wasm-metadata 0.244.0",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -7655,19 +7751,18 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.247.0",
- "wasm-metadata",
+ "wasm-metadata 0.247.0",
  "wasmparser 0.247.0",
  "wit-parser 0.247.0",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.246.2"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
- "hashbrown 0.16.1",
  "id-arena",
  "indexmap 2.14.0",
  "log",
@@ -7676,7 +7771,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.246.2",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -7696,6 +7791,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.251.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.251.0",
 ]
 
 [[package]]

--- a/examples/spin-timer/Cargo.toml
+++ b/examples/spin-timer/Cargo.toml
@@ -13,6 +13,6 @@ spin-runtime-factors = { path = "../../crates/runtime-factors" }
 spin-trigger = { path = "../../crates/trigger" }
 tokio = { version = "1", features = ["full"] }
 tokio-scoped = "0.2.0"
-wasmtime = { version = "44.0.0", features = ["component-model-async"] }
+wasmtime = { version = "46.0.1", features = ["component-model-async"] }
 
 [workspace]


### PR DESCRIPTION
The first commit just updates Wasmtime; the second commit adds shims to support 0.3.0-rc-2026-03-15.

~This is a draft for now, while I investigate an odd regression in `test_max_memory_size_violated`.~ EDIT: this seems to be due to how my local version of Rust compiles the guest code rather than anything that changed in Spin or Wasmtime.