### PR TITLE
Miscellaneous Cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9486,6 +9486,7 @@ dependencies = [
  "anyhow",
  "glob",
  "indexmap 2.14.0",
+ "itertools 0.14.0",
  "schemars",
  "semver",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4793,6 +4793,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8741,7 +8750,7 @@ dependencies = [
  "hyper 1.8.1",
  "hyper-util",
  "indicatif",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy_static 1.5.0",
  "levenshtein",
  "nix 0.29.0",
@@ -9472,7 +9481,7 @@ version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
  "async-trait",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "serde",
  "serde_json",
  "spin-serde",
@@ -9486,7 +9495,7 @@ dependencies = [
  "anyhow",
  "glob",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "schemars",
  "semver",
  "serde",
@@ -9513,7 +9522,7 @@ dependencies = [
  "docker_credential",
  "flate2",
  "futures-util",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "oci-client 0.17.0",
  "reqwest 0.12.9",
  "reqwest 0.13.4",
@@ -9726,7 +9735,7 @@ dependencies = [
  "fs_extra",
  "heck 0.5.0",
  "indexmap 2.14.0",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "lazy_static 1.5.0",
  "liquid",
  "liquid-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ http-body-util = "0.1"
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
 indexmap = "2"
-itertools = "0.14"
+itertools = "0.15"
 lazy_static = "1.5"
 opentelemetry = "0.29"
 # The default `reqwest-blocking-client` causes a runtime panic

--- a/crates/factor-outbound-pg/src/types/interval.rs
+++ b/crates/factor-outbound-pg/src/types/interval.rs
@@ -36,7 +36,7 @@ impl ToSql for Interval {
 impl FromSql<'_> for Interval {
     fn from_sql(
         _ty: &Type,
-        raw: &'_ [u8],
+        mut raw: &'_ [u8],
     ) -> std::result::Result<Self, Box<dyn std::error::Error + Sync + Send>> {
         const EXPECTED_LEN: usize = size_of::<i64>() + size_of::<i32>() + size_of::<i32>();
 
@@ -44,12 +44,11 @@ impl FromSql<'_> for Interval {
             return Err(Box::new(IntervalLengthError));
         }
 
-        let (micro_bytes, rest) = raw.split_at(size_of::<i64>());
-        let (day_bytes, rest) = rest.split_at(size_of::<i32>());
-        let month_bytes = rest;
-        let months = i32::from_be_bytes(month_bytes.try_into().unwrap());
-        let days = i32::from_be_bytes(day_bytes.try_into().unwrap());
-        let micros = i64::from_be_bytes(micro_bytes.try_into().unwrap());
+        use bytes::Buf;
+
+        let micros = raw.get_i64();
+        let days = raw.get_i32();
+        let months = raw.get_i32();
 
         Ok(Self(v4::Interval {
             micros,

--- a/crates/manifest/Cargo.toml
+++ b/crates/manifest/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
+itertools = { workspace = true }
 schemars = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true }

--- a/crates/manifest/src/compat/allowed_http_hosts.rs
+++ b/crates/manifest/src/compat/allowed_http_hosts.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, anyhow};
+use itertools::Itertools;
 use url::Url;
 
 const ALLOW_ALL_HOSTS: &str = "insecure:allow-all";
@@ -40,11 +41,10 @@ pub fn parse_allowed_http_hosts(list: &[impl AsRef<str>]) -> Result<AllowedHttpH
     if list.iter().any(|domain| domain.as_ref() == ALLOW_ALL_HOSTS) {
         Ok(AllowedHttpHosts::AllowAll)
     } else {
-        let parse_results = list
+        let (hosts, errors): (Vec<_>, Vec<_>) = list
             .iter()
             .map(|h| parse_allowed_http_host(h.as_ref()))
-            .collect::<Vec<_>>();
-        let (hosts, errors) = partition_results(parse_results);
+            .partition_result();
 
         if errors.is_empty() {
             Ok(AllowedHttpHosts::AllowSpecific(hosts))
@@ -101,21 +101,6 @@ fn parse_allowed_http_host_from_http_url(url: &Url, text: &str) -> Result<Allowe
     }
 
     Ok(AllowedHttpHost::new(host, url.port()))
-}
-
-fn partition_results<T, E>(results: Vec<Result<T, E>>) -> (Vec<T>, Vec<E>) {
-    // We are going to to be OPTIMISTIC do you hear me
-    let mut oks = Vec::with_capacity(results.len());
-    let mut errs = vec![];
-
-    for result in results {
-        match result {
-            Ok(t) => oks.push(t),
-            Err(e) => errs.push(e),
-        }
-    }
-
-    (oks, errs)
 }
 
 #[cfg(test)]

--- a/crates/oci/src/client.rs
+++ b/crates/oci/src/client.rs
@@ -1083,6 +1083,12 @@ mod test {
         };
     }
 
+    fn file_url(path: impl AsRef<Path>) -> String {
+        Url::from_file_path(path)
+            .expect("should convert test path to file URL")
+            .to_string()
+    }
+
     #[tokio::test]
     async fn can_assemble_layers() {
         use spin_locked_app::locked::LockedComponent;
@@ -1184,14 +1190,14 @@ mod test {
                     "id": "component1",
                     "source": {
                         "content_type": "application/wasm",
-                        "source": format!("file://{}", working_dir.path().join("component1.wasm").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1.wasm")),
                         "digest": "digest",
                 }},
                 {
                     "id": "component2",
                     "source": {
                         "content_type": "application/wasm",
-                        "source": format!("file://{}", working_dir.path().join("component2.wasm").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component2.wasm")),
                         "digest": "digest",
                 }}]),
                 expected_layer_count: 2,
@@ -1200,21 +1206,23 @@ mod test {
             },
             TestCase {
                 name: "One component layer and two file layers",
-                opts: Some(ClientOpts{content_ref_inline_max_size: 0}),
+                opts: Some(ClientOpts {
+                    content_ref_inline_max_size: 0,
+                }),
                 locked_components: from_json!([{
                 "id": "component1",
                 "source": {
                     "content_type": "application/wasm",
-                    "source": format!("file://{}", working_dir.path().join("component1.wasm").to_str().unwrap()),
+                    "source": file_url(working_dir.path().join("component1.wasm")),
                     "digest": "digest",
                 },
                 "files": [
                     {
-                        "source": format!("file://{}", working_dir.path().join("component1").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1")),
                         "path": working_dir.path().join("component1").join("bar").to_str().unwrap()
                     },
                     {
-                        "source": format!("file://{}", working_dir.path().join("component1").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1")),
                         "path": working_dir.path().join("component1").join("baz").to_str().unwrap()
                     }
                 ]
@@ -1230,12 +1238,12 @@ mod test {
                 "id": "component1",
                 "source": {
                     "content_type": "application/wasm",
-                    "source": format!("file://{}", working_dir.path().join("component1.wasm").to_str().unwrap()),
+                    "source": file_url(working_dir.path().join("component1.wasm")),
                     "digest": "digest",
                 },
                 "files": [
                     {
-                        "source": format!("file://{}", working_dir.path().join("component1").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1")),
                         "path": working_dir.path().join("component1").join("bar").to_str().unwrap()
                     }
                 ]
@@ -1246,19 +1254,21 @@ mod test {
             },
             TestCase {
                 name: "One component layer and one dependency component layer skipping composition",
-                opts: Some(ClientOpts{content_ref_inline_max_size: 0}),
+                opts: Some(ClientOpts {
+                    content_ref_inline_max_size: 0,
+                }),
                 locked_components: from_json!([{
                 "id": "component1",
                 "source": {
                     "content_type": "application/wasm",
-                    "source": format!("file://{}", working_dir.path().join("component1.wasm").to_str().unwrap()),
+                    "source": file_url(working_dir.path().join("component1.wasm")),
                     "digest": "digest",
                 },
                 "dependencies": {
                     "test:comp2": {
                         "source": {
                             "content_type": "application/wasm",
-                            "source": format!("file://{}", working_dir.path().join("component2.wasm").to_str().unwrap()),
+                            "source": file_url(working_dir.path().join("component2.wasm")),
                             "digest": "digest",
                         },
                         "export": null,
@@ -1291,14 +1301,14 @@ mod test {
                     "id": "component1",
                     "source": {
                         "content_type": "application/wasm",
-                        "source": format!("file://{}", working_dir.path().join("component1.wasm").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1.wasm")),
                         "digest": "digest",
                 }},
                 {
                     "id": "component2",
                     "source": {
                         "content_type": "application/wasm",
-                        "source": format!("file://{}", working_dir.path().join("component1.wasm").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1.wasm")),
                         "digest": "digest",
                 }}]),
                 expected_layer_count: 1,
@@ -1307,21 +1317,23 @@ mod test {
             },
             TestCase {
                 name: "Duplicate file paths",
-                opts: Some(ClientOpts{content_ref_inline_max_size: 0}),
+                opts: Some(ClientOpts {
+                    content_ref_inline_max_size: 0,
+                }),
                 locked_components: from_json!([{
                 "id": "component1",
                 "source": {
                     "content_type": "application/wasm",
-                    "source": format!("file://{}", working_dir.path().join("component1.wasm").to_str().unwrap()),
+                    "source": file_url(working_dir.path().join("component1.wasm")),
                     "digest": "digest",
                 },
                 "files": [
                     {
-                        "source": format!("file://{}", working_dir.path().join("component1").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1")),
                         "path": working_dir.path().join("component1").join("bar").to_str().unwrap()
                     },
                     {
-                        "source": format!("file://{}", working_dir.path().join("component1").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component1")),
                         "path": working_dir.path().join("component1").join("baz").to_str().unwrap()
                     }
                 ]},
@@ -1329,12 +1341,12 @@ mod test {
                     "id": "component2",
                     "source": {
                         "content_type": "application/wasm",
-                        "source": format!("file://{}", working_dir.path().join("component2.wasm").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component2.wasm")),
                         "digest": "digest",
                 },
                 "files": [
                     {
-                        "source": format!("file://{}", working_dir.path().join("component2").to_str().unwrap()),
+                        "source": file_url(working_dir.path().join("component2")),
                         "path": working_dir.path().join("component2").join("baz").to_str().unwrap()
                     }
                 ]
@@ -1345,19 +1357,21 @@ mod test {
             },
             TestCase {
                 name: "One component layer and one dependency component layer with composition",
-                opts: Some(ClientOpts{content_ref_inline_max_size: 0}),
+                opts: Some(ClientOpts {
+                    content_ref_inline_max_size: 0,
+                }),
                 locked_components: from_json!([{
                 "id": "component-with-deps",
                 "source": {
                     "content_type": "application/wasm",
-                    "source": format!("file://{}", working_dir.path().join("root.wasm").to_str().unwrap()),
+                    "source": file_url(working_dir.path().join("root.wasm")),
                     "digest": "digest",
                 },
                 "dependencies": {
                     "test:test/a": {
                         "source": {
                             "content_type": "application/wasm",
-                            "source": format!("file://{}", working_dir.path().join("dep_a.wasm").to_str().unwrap()),
+                            "source": file_url(working_dir.path().join("dep_a.wasm")),
                             "digest": "digest",
                         },
                         "export": null,

--- a/crates/oci/src/validate.rs
+++ b/crates/oci/src/validate.rs
@@ -59,6 +59,12 @@ mod test {
     use spin_locked_app::locked::LockedComponent;
     use tokio::io::AsyncWriteExt;
 
+    fn file_url(path: impl AsRef<std::path::Path>) -> String {
+        reqwest::Url::from_file_path(path)
+            .expect("should convert test path to file URL")
+            .to_string()
+    }
+
     #[tokio::test]
     async fn ensures_valid_wasm_binaries() {
         let working_dir = tempfile::tempdir().unwrap();
@@ -69,7 +75,7 @@ mod test {
                     "id": "jiggs",
                     "source": {
                         "content_type": "application/wasm",
-                        "source": format!("file://{}", working_dir.path().join($source).to_str().unwrap()),
+                        "source": file_url(working_dir.path().join($source)),
                         "digest": "digest",
                     },
                     "dependencies": {
@@ -77,7 +83,7 @@ mod test {
                             $dep_name: {
                                 "source": {
                                     "content_type": "application/wasm",
-                                    "source": format!("file://{}", working_dir.path().join($dep_path).to_str().unwrap()),
+                                    "source": file_url(working_dir.path().join($dep_path)),
                                     "digest": "digest",
                                 },
                             }

--- a/src/commands/external.rs
+++ b/src/commands/external.rs
@@ -365,7 +365,7 @@ mod test {
         );
 
         let cmd_with_args = "example arg1 arg2"
-            .split(' ')
+            .split_whitespace()
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
         assert_eq!(
@@ -378,7 +378,7 @@ mod test {
         );
 
         let cmd_with_args_override = format!("example arg1 arg2 {override_flag}")
-            .split(' ')
+            .split_whitespace()
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
         assert_eq!(
@@ -391,7 +391,7 @@ mod test {
         );
 
         let cmd_with_args_override = format!("example {override_flag} arg1 arg2")
-            .split(' ')
+            .split_whitespace()
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
         assert_eq!(
@@ -404,7 +404,7 @@ mod test {
         );
 
         let cmd_with_args_override = format!("{override_flag} example arg1 arg2")
-            .split(' ')
+            .split_whitespace()
             .map(|s| s.to_string())
             .collect::<Vec<String>>();
         assert_eq!(


### PR DESCRIPTION
Some small cleanups

- Replace manually implemented `partition_results` with [`partition_result` from `itertools`](https://docs.rs/itertools/latest/itertools/trait.Itertools.html#method.partition_result).
  - Upgrade itertools to 0.15
- Replace manually implemented bytes parsing with [bytes::Buf](https://docs.rs/bytes/latest/bytes/buf/trait.Buf.html).
- Using the file URL parsing from reqwest in tests (I can remove this if it seems to be too annoying for tests)