### PR TITLE
Fix wasmtime bump regexes

### DIFF
--- a/.github/workflows/bump-wasmtime.yml
+++ b/.github/workflows/bump-wasmtime.yml
@@ -25,8 +25,11 @@ jobs:
       - name: Bump Spin to latest Wasmtime release
         run: |
           sed -i -E "s/wasmtime = \{ version = \"[0-9]+[0-9.]*\"/wasmtime = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\"/g" Cargo.toml
+          sed -i -E "s/wasmtime = \"[0-9]+[0-9.]*\"/wasmtime = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\" }/g" Cargo.toml
           sed -i -E "s/wasmtime-wasi = \{ version = \"[0-9]+[0-9.]*\"/wasmtime-wasi = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\"/g" Cargo.toml
+          sed -i -E "s/wasmtime-wasi = \"[0-9]+[0-9.]*\"/wasmtime-wasi = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\" }/g" Cargo.toml
           sed -i -E "s/wasmtime-wasi-http = \{ version = \"[0-9]+[0-9.]*\"/wasmtime-wasi-http = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\"/g" Cargo.toml
+          sed -i -E "s/wasmtime-wasi-http = \"[0-9]+[0-9.]*\"/wasmtime-wasi = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\" }/g" Cargo.toml
           cargo update
 
       # Import GPG key for signing commits


### PR DESCRIPTION
Fixes the bug laid horribly bare by https://github.com/spinframework/spin/pull/3605.

I couldn't test properly in my fork because of tokens and keys and whatnot but I made it cat the munged Cargo.toml and it looked uh not obviously wrong.  Well not obviously wrong _to me_ anyway.

https://github.com/itowlson/spin/actions/runs/28987200598/job/86018887021#step:4:849
