### PR TITLE
Add a hard request deadline config for embedded HTTP servers

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -239,6 +239,7 @@ pub struct InstanceReuseConfig {
     max_instance_reuse_count: Range<usize>,
     max_instance_concurrent_reuse_count: Range<usize>,
     request_timeout: Option<Range<Duration>>,
+    request_deadline: Option<Duration>,
     idle_instance_timeout: Range<Duration>,
 }
 
@@ -250,6 +251,26 @@ impl Default for InstanceReuseConfig {
                 DEFAULT_WASIP3_MAX_INSTANCE_CONCURRENT_REUSE_COUNT,
             ),
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            request_deadline: None,
+            idle_instance_timeout: DEFAULT_IDLE_INSTANCE_TIMEOUT,
+        }
+    }
+}
+
+impl InstanceReuseConfig {
+    /// Creates a single-use instance reuse configuration with a Wasmtime request deadline.
+    ///
+    /// The deadline is enforced by the Wasmtime epoch interruption mechanism in the
+    /// underlying Spin store. It is a rough deadline: the guest may run somewhat longer
+    /// depending on the engine epoch tick interval, host thread scheduling, and how often
+    /// the compiled guest code checks the epoch. Instance reuse is disabled so every request
+    /// receives a fresh store with a request-specific deadline.
+    pub fn single_use_with_request_deadline(timeout: Duration) -> Self {
+        Self {
+            max_instance_reuse_count: Range::Value(1),
+            max_instance_concurrent_reuse_count: Range::Value(1),
+            request_timeout: Some(Range::Value(timeout)),
+            request_deadline: Some(timeout),
             idle_instance_timeout: DEFAULT_IDLE_INSTANCE_TIMEOUT,
         }
     }
@@ -289,6 +310,7 @@ impl<F: RuntimeFactors> Trigger<F> for HttpTrigger {
                     DEFAULT_WASIP3_MAX_INSTANCE_CONCURRENT_REUSE_COUNT,
                 )),
             request_timeout: cli_args.request_timeout,
+            request_deadline: None,
             idle_instance_timeout: cli_args.idle_instance_timeout,
         };
 
@@ -444,5 +466,19 @@ mod tests {
         let addr = parse_listen_addr("localhost:12345").unwrap();
         assert_eq!(addr.ip(), Ipv4Addr::LOCALHOST);
         assert_eq!(addr.port(), 12345);
+    }
+
+    #[test]
+    fn request_deadline_config_is_single_use() {
+        let timeout = Duration::from_millis(500);
+        let config = InstanceReuseConfig::single_use_with_request_deadline(timeout);
+
+        assert!(matches!(config.max_instance_reuse_count, Range::Value(1)));
+        assert!(matches!(
+            config.max_instance_concurrent_reuse_count,
+            Range::Value(1)
+        ));
+        assert!(matches!(config.request_timeout, Some(Range::Value(value)) if value == timeout));
+        assert_eq!(config.request_deadline, Some(timeout));
     }
 }

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -66,6 +66,15 @@ use crate::{
 
 pub const MAX_RETRIES: u16 = 10;
 
+pub(crate) fn set_request_deadline<T>(
+    store: &mut spin_core::Store<T>,
+    request_deadline: Option<Duration>,
+) {
+    if let Some(timeout) = request_deadline {
+        store.set_deadline(Instant::now() + timeout);
+    }
+}
+
 /// An HTTP server which runs Spin apps.
 pub struct HttpServer<F: RuntimeFactors> {
     /// The address the server was configured to listen on (the `--listen` value).
@@ -84,6 +93,8 @@ pub struct HttpServer<F: RuntimeFactors> {
     find_free_port: bool,
     /// The output format for the server's startup information.
     output_format: OutputFormat,
+    /// Hard Wasmtime request deadline for direct HTTP executor paths.
+    request_deadline: Option<Duration>,
     /// Request router.
     router: Router,
     /// The app being triggered.
@@ -174,6 +185,7 @@ impl<F: RuntimeFactors> HttpServer<F> {
             component_trigger_configs,
             component_handler_types,
             output_format,
+            request_deadline: reuse_config.request_deadline,
         })
     }
 
@@ -424,7 +436,13 @@ impl<F: RuntimeFactors> HttpServer<F> {
             HttpExecutorType::Http => match handler_type {
                 HandlerType::Spin => {
                     SpinHttpExecutor
-                        .execute(instance_builder, &route_match, req, client_addr)
+                        .execute(
+                            instance_builder,
+                            &route_match,
+                            req,
+                            client_addr,
+                            self.request_deadline,
+                        )
                         .await
                 }
                 HandlerType::Wasi0_3(handler) => {
@@ -437,7 +455,13 @@ impl<F: RuntimeFactors> HttpServer<F> {
                 | HandlerType::Wasi2023_10_18(_)
                 | HandlerType::Wasi2026_03_15(_) => {
                     WasiHttpExecutor { handler_type }
-                        .execute(instance_builder, &route_match, req, client_addr)
+                        .execute(
+                            instance_builder,
+                            &route_match,
+                            req,
+                            client_addr,
+                            self.request_deadline,
+                        )
                         .await
                 }
                 HandlerType::Wagi(_) => unreachable!(),
@@ -452,7 +476,13 @@ impl<F: RuntimeFactors> HttpServer<F> {
                     indices,
                 };
                 executor
-                    .execute(instance_builder, &route_match, req, client_addr)
+                    .execute(
+                        instance_builder,
+                        &route_match,
+                        req,
+                        client_addr,
+                        self.request_deadline,
+                    )
                     .await
             }
         };
@@ -705,6 +735,7 @@ pub(crate) trait HttpExecutor {
         route_match: &RouteMatch<'_, '_>,
         req: Request<Body>,
         client_addr: SocketAddr,
+        request_deadline: Option<Duration>,
     ) -> impl Future<Output = anyhow::Result<Response<Body>>>;
 }
 
@@ -800,13 +831,14 @@ impl<F: RuntimeFactors> HandlerState for HttpHandlerState<F> {
         &self,
     ) -> wasmtime::Result<Instance<Self::StoreData, Self::WorkerExpiration, Self::WorkerState>>
     {
-        let (instance, store) = self
+        let (instance, mut store) = self
             .trigger_app
             .prepare(&self.component_id)
             .to_wasmtime_result()?
             .instantiate(())
             .await
             .to_wasmtime_result()?;
+        set_request_deadline(&mut store, self.reuse_config.request_deadline);
 
         let mut store = store.into_inner();
 

--- a/crates/trigger-http/src/spin.rs
+++ b/crates/trigger-http/src/spin.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use anyhow::Result;
 use http_body_util::BodyExt;
@@ -12,7 +12,7 @@ use tracing::{Level, instrument};
 use crate::{
     Body, TriggerInstanceBuilder,
     headers::{append_headers, prepare_request_headers},
-    server::HttpExecutor,
+    server::{HttpExecutor, set_request_deadline},
 };
 
 /// An [`HttpExecutor`] that uses the `fermyon:spin/inbound-http` interface.
@@ -27,6 +27,7 @@ impl HttpExecutor for SpinHttpExecutor {
         route_match: &RouteMatch<'_, '_>,
         req: Request<Body>,
         client_addr: SocketAddr,
+        request_deadline: Option<Duration>,
     ) -> Result<Response<Body>> {
         let spin_http::routes::TriggerLookupKey::Component(component_id) = route_match.lookup_key()
         else {
@@ -36,6 +37,7 @@ impl HttpExecutor for SpinHttpExecutor {
         tracing::trace!("Executing request using the Spin executor for component {component_id}");
 
         let (instance, mut store) = instance_builder.instantiate(()).await?;
+        set_request_deadline(&mut store, request_deadline);
 
         let headers = prepare_request_headers(&req, route_match, client_addr)?;
         // Expects here are safe since we have already checked that this

--- a/crates/trigger-http/src/wagi.rs
+++ b/crates/trigger-http/src/wagi.rs
@@ -1,4 +1,4 @@
-use std::{io::Cursor, net::SocketAddr};
+use std::{io::Cursor, net::SocketAddr, time::Duration};
 
 use anyhow::{Context, Result, ensure};
 use http_body_util::BodyExt;
@@ -11,7 +11,11 @@ use wasmtime_wasi::p2::bindings::CommandIndices;
 use wasmtime_wasi::p2::pipe::MemoryOutputPipe;
 use wasmtime_wasi_http::p2::body::HyperIncomingBody as Body;
 
-use crate::{TriggerInstanceBuilder, headers::compute_default_headers, server::HttpExecutor};
+use crate::{
+    TriggerInstanceBuilder,
+    headers::compute_default_headers,
+    server::{HttpExecutor, set_request_deadline},
+};
 
 pub struct WagiHttpExecutor<'a> {
     pub wagi_config: &'a WagiTriggerConfig,
@@ -26,6 +30,7 @@ impl HttpExecutor for WagiHttpExecutor<'_> {
         route_match: &RouteMatch<'_, '_>,
         req: Request<Body>,
         client_addr: SocketAddr,
+        request_deadline: Option<Duration>,
     ) -> Result<Response<Body>> {
         let spin_http::routes::TriggerLookupKey::Component(component) = route_match.lookup_key()
         else {
@@ -90,6 +95,7 @@ impl HttpExecutor for WagiHttpExecutor<'_> {
         wasi_builder.stdout(stdout.clone());
 
         let (instance, mut store) = instance_builder.instantiate(()).await?;
+        set_request_deadline(&mut store, request_deadline);
 
         let command = self.indices.load(&mut store, &instance)?;
 

--- a/crates/trigger-http/src/wasi.rs
+++ b/crates/trigger-http/src/wasi.rs
@@ -1,6 +1,6 @@
 use std::future;
 use std::io::IsTerminal;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, time::Duration};
 
 use anyhow::{Context, Result, anyhow};
 use futures::TryFutureExt;
@@ -23,7 +23,11 @@ use wasmtime_wasi_http::p2::bindings::http::types::Scheme;
 use wasmtime_wasi_http::p2::{bindings::Proxy, body::HyperIncomingBody as Body};
 use wasmtime_wasi_http::p3;
 
-use crate::{TriggerInstanceBuilder, headers::prepare_request_headers, server::HttpExecutor};
+use crate::{
+    TriggerInstanceBuilder,
+    headers::prepare_request_headers,
+    server::{HttpExecutor, set_request_deadline},
+};
 
 pub(super) fn prepare_request(
     route_match: &RouteMatch<'_, '_>,
@@ -66,10 +70,12 @@ impl<S: HandlerState> HttpExecutor for WasiHttpExecutor<'_, S> {
         route_match: &RouteMatch<'_, '_>,
         mut req: Request<Body>,
         client_addr: SocketAddr,
+        request_deadline: Option<Duration>,
     ) -> Result<Response<Body>> {
         prepare_request(route_match, &mut req, client_addr)?;
 
         let (instance, mut store) = instance_builder.instantiate(()).await?;
+        set_request_deadline(&mut store, request_deadline);
 
         enum Handler {
             Latest(Proxy),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,8 +11,36 @@ mod integration_tests {
     use testing_framework::runtimes::{SpinAppType, spin_cli::SpinConfig};
 
     pub use super::testcases::{
-        assert_spin_request, bootstap_env, http_smoke_test_template, run_test, spin_binary,
+        assert_spin_request, bootstap_env, http_smoke_test_template, preboot, run_test, spin_binary,
     };
+
+    #[test]
+    fn http_request_deadline_interrupts_wasip2_loop() -> anyhow::Result<()> {
+        use spin_trigger_http::InstanceReuseConfig;
+        use std::time::{Duration, Instant};
+        use test_environment::{TestEnvironment, services::ServicesConfig};
+        use testing_framework::runtimes::in_process_spin::InProcessSpin;
+
+        let config = InProcessSpin::config_with_reuse_config(
+            ServicesConfig::none(),
+            InstanceReuseConfig::single_use_with_request_deadline(Duration::from_millis(100)),
+            |env| preboot("http-infinite-loop", env),
+        );
+        let mut env = TestEnvironment::up(config, |_| Ok(()))?;
+        let started = Instant::now();
+        let response =
+            env.runtime_mut()
+                .make_http_request(test_environment::http::Request::full(
+                    test_environment::http::Method::Get,
+                    "/",
+                    &[("Host", "localhost")],
+                    None,
+                ))?;
+
+        assert_eq!(response.status(), 500);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        Ok(())
+    }
 
     #[cfg(feature = "extern-dependencies-tests")]
     /// Helper macro to assert that a condition is true eventually

--- a/tests/test-components/components/Cargo.lock
+++ b/tests/test-components/components/Cargo.lock
@@ -423,6 +423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-infinite-loop"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "http 0.2.11",
+ "spin-sdk 2.2.0",
+]
+
+[[package]]
 name = "http-routing"
 version = "0.1.0"
 dependencies = [

--- a/tests/test-components/components/http-infinite-loop/Cargo.toml
+++ b/tests/test-components/components/http-infinite-loop/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "http-infinite-loop"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1"
+http = "0.2"
+spin-sdk = "2.2.0"

--- a/tests/test-components/components/http-infinite-loop/src/lib.rs
+++ b/tests/test-components/components/http-infinite-loop/src/lib.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+use spin_sdk::http_component;
+
+#[http_component]
+fn loop_forever(_request: http::Request<()>) -> Result<http::Response<String>> {
+    loop {
+        std::hint::spin_loop();
+    }
+}

--- a/tests/testcases/http-infinite-loop/spin.toml
+++ b/tests/testcases/http-infinite-loop/spin.toml
@@ -1,0 +1,12 @@
+spin_manifest_version = 2
+
+[application]
+name = "http-infinite-loop"
+version = "0.1.0"
+
+[[trigger.http]]
+route = "/..."
+component = "loop"
+
+[component.loop]
+source = "%{source=http-infinite-loop}"

--- a/tests/testcases/mod.rs
+++ b/tests/testcases/mod.rs
@@ -114,10 +114,7 @@ impl<T: std::fmt::Display> std::fmt::Display for TruncatedSlice<'_, T> {
 }
 
 /// Get the test environment ready to run a test
-fn preboot(
-    test: &str,
-    env: &mut TestEnvironment<testing_framework::runtimes::spin_cli::SpinCli>,
-) -> anyhow::Result<()> {
+pub fn preboot<R>(test: &str, env: &mut TestEnvironment<R>) -> anyhow::Result<()> {
     let test_path = format!("tests/testcases/{test}");
     for file in std::fs::read_dir(test_path)? {
         let file = file?;

--- a/tests/testing-framework/src/runtimes/in_process_spin.rs
+++ b/tests/testing-framework/src/runtimes/in_process_spin.rs
@@ -25,13 +25,22 @@ impl InProcessSpin {
         services_config: ServicesConfig,
         preboot: impl FnOnce(&mut TestEnvironment<InProcessSpin>) -> anyhow::Result<()> + 'static,
     ) -> TestEnvironmentConfig<Self> {
+        Self::config_with_reuse_config(services_config, InstanceReuseConfig::default(), preboot)
+    }
+
+    /// Configure a new in-process Spin instance with an explicit HTTP instance reuse policy.
+    pub fn config_with_reuse_config(
+        services_config: ServicesConfig,
+        reuse_config: InstanceReuseConfig,
+        preboot: impl FnOnce(&mut TestEnvironment<InProcessSpin>) -> anyhow::Result<()> + 'static,
+    ) -> TestEnvironmentConfig<Self> {
         TestEnvironmentConfig {
             services_config,
-            create_runtime: Box::new(|env| {
+            create_runtime: Box::new(move |env| {
                 preboot(env)?;
                 tokio::runtime::Runtime::new()
                     .context("failed to start tokio runtime")?
-                    .block_on(async { initialize_trigger(env).await })
+                    .block_on(async { initialize_trigger(env, reuse_config).await })
             }),
         }
     }
@@ -95,6 +104,7 @@ impl Runtime for InProcessSpin {
 /// Initialize the trigger for the Spin instance inside the environment
 async fn initialize_trigger(
     env: &mut TestEnvironment<InProcessSpin>,
+    reuse_config: InstanceReuseConfig,
 ) -> anyhow::Result<InProcessSpin> {
     let locked_app = spin_loader::from_file(
         env.path().join("spin.toml"),
@@ -111,7 +121,7 @@ async fn initialize_trigger(
         None,
         false,
         None,
-        InstanceReuseConfig::default(),
+        reuse_config,
         OutputFormat::default(),
     )?;
     let mut builder = TriggerAppBuilder::<_, FactorsBuilder>::new(trigger);


### PR DESCRIPTION
This adds an opt-in request deadline mode for embedders of `spin-trigger-http`.

The new API is:

```rust
let reuse_config =
    InstanceReuseConfig::single_use_with_request_deadline(timeout);
```

That config keeps the existing HTTP request timeout behavior, and also applies a hard deadline to the underlying Spin `Store` before guest HTTP code runs. This matters for CPU-bound guest code: an outer async timeout can stop waiting for a response, but it does not necessarily interrupt a tight Wasm loop. A store deadline does.

For this first version, the deadline config intentionally uses single-use instances. That keeps the API small and avoids subtle deadline-reset behavior for reused workers. Embedders that need hard per-request limits get correctness first, while the default config and CLI-created config remain unchanged.

The deadline is wired through the legacy Spin HTTP executor, WASI HTTP executor, Wagi executor, and the WASIp3 handler-state path.

Related issue: #3609

Validation:

```sh
cargo check -p spin-trigger-http
cargo test -p spin-trigger-http request_deadline_config_is_single_use
```
