### PR TITLE
Miscellaneous improvements and cleanup (batch 2)

### DIFF
--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -1,6 +1,7 @@
 //! Resolves a file path to a manifest file
 
 use anyhow::{Context, Result, anyhow};
+use std::env::current_dir;
 use std::path::{Path, PathBuf};
 
 use crate::ui::quoted_path;
@@ -71,8 +72,8 @@ pub fn search_upwards_for_manifest() -> Option<(PathBuf, usize)> {
         return Some((candidate, 0));
     }
 
-    for distance in 1..20 {
-        let inferred_dir = PathBuf::from("../".repeat(distance));
+    let current_dir = current_dir().ok()?;
+    for (distance, inferred_dir) in current_dir.ancestors().enumerate() {
         if !inferred_dir.is_dir() {
             return None;
         }
@@ -82,7 +83,7 @@ pub fn search_upwards_for_manifest() -> Option<(PathBuf, usize)> {
             return Some((candidate, distance));
         }
 
-        if is_git_root(&inferred_dir) {
+        if is_git_root(inferred_dir) {
             return None;
         }
     }

--- a/crates/common/src/paths.rs
+++ b/crates/common/src/paths.rs
@@ -1,7 +1,6 @@
 //! Resolves a file path to a manifest file
 
 use anyhow::{Context, Result, anyhow};
-use std::env::current_dir;
 use std::path::{Path, PathBuf};
 
 use crate::ui::quoted_path;
@@ -72,8 +71,8 @@ pub fn search_upwards_for_manifest() -> Option<(PathBuf, usize)> {
         return Some((candidate, 0));
     }
 
-    let current_dir = current_dir().ok()?;
-    for (distance, inferred_dir) in current_dir.ancestors().enumerate() {
+    for distance in 1..20 {
+        let inferred_dir = PathBuf::from("../".repeat(distance));
         if !inferred_dir.is_dir() {
             return None;
         }
@@ -83,7 +82,7 @@ pub fn search_upwards_for_manifest() -> Option<(PathBuf, usize)> {
             return Some((candidate, distance));
         }
 
-        if is_git_root(inferred_dir) {
+        if is_git_root(&inferred_dir) {
             return None;
         }
     }

--- a/crates/oci/src/auth.rs
+++ b/crates/oci/src/auth.rs
@@ -67,18 +67,14 @@ impl AuthConfig {
 
         let bytes = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoded)?;
         let decoded = std::str::from_utf8(&bytes)?;
-        let parts: Vec<&str> = decoded.splitn(2, ':').collect();
+        let (username, secret) = decoded
+            .split_once(':')
+            .context("expected secret as second element of the decoded auth")?;
 
         tracing::trace!("Decoded registry credentials from the Spin configuration.");
         Ok(RegistryAuth::Basic(
-            parts
-                .first()
-                .context("expected username as first element of the decoded auth")?
-                .to_string(),
-            parts
-                .get(1)
-                .context("expected secret as second element of the decoded auth")?
-                .to_string(),
+            username.to_string(),
+            secret.to_string(),
         ))
     }
 

--- a/crates/templates/src/filters.rs
+++ b/crates/templates/src/filters.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::box_default)]
 
 use heck::{ToKebabCase, ToSnakeCase, ToUpperCamelCase};
+use itertools::Itertools;
 use liquid_core::{Filter, ParseFilter, Runtime, ValueView};
 use liquid_derive::FilterReflection;
 
@@ -155,11 +156,7 @@ impl Filter for DottedPascalCaseFilter {
 
         let input = input.into_string().to_string();
 
-        let result = input
-            .split('.')
-            .map(|s| s.to_upper_camel_case())
-            .collect::<Vec<_>>()
-            .join(".");
+        let result = input.split('.').map(|s| s.to_upper_camel_case()).join(".");
 
         Ok(result.to_value())
     }

--- a/crates/templates/src/source.rs
+++ b/crates/templates/src/source.rs
@@ -258,7 +258,6 @@ fn bypass_gh_added_root(unpack_dir: PathBuf) -> PathBuf {
         return unpack_dir;
     };
 
-    // If we get here, there is a single directory (dirs has a single element). Look in it to see if it's a plausible repo root.
     let candidate_repo_root = dir.path();
     let Ok(mut candidate_repo_dirs) = candidate_repo_root.read_dir() else {
         // Again, if it all goes awry, propose the base unpack directory.

--- a/crates/templates/src/source.rs
+++ b/crates/templates/src/source.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, anyhow};
+use itertools::Itertools;
 use tempfile::{TempDir, tempdir};
 use tokio::process::Command;
 use url::Url;
@@ -253,13 +254,12 @@ fn bypass_gh_added_root(unpack_dir: PathBuf) -> PathBuf {
     // Is there a single directory at the root?  If not, we can't be in the GitHub situation:
     // return the root of the unpacking. (The take(2) here is because we don't need to traverse
     // the full list - we only care whether there is more than one.)
-    let dirs = dirs.filter_map(|de| de.ok()).take(2).collect::<Vec<_>>();
-    if dirs.len() != 1 {
+    let Ok(dir) = dirs.filter_map(Result::ok).exactly_one() else {
         return unpack_dir;
-    }
+    };
 
     // If we get here, there is a single directory (dirs has a single element). Look in it to see if it's a plausible repo root.
-    let candidate_repo_root = dirs[0].path();
+    let candidate_repo_root = dir.path();
     let Ok(mut candidate_repo_dirs) = candidate_repo_root.read_dir() else {
         // Again, if it all goes awry, propose the base unpack directory.
         return unpack_dir;

--- a/crates/world/src/wasi_otel/common_conversions.rs
+++ b/crates/world/src/wasi_otel/common_conversions.rs
@@ -16,14 +16,6 @@ impl From<wasi::otel::types::KeyValue> for opentelemetry::KeyValue {
     }
 }
 
-impl From<&wasi::otel::types::KeyValue> for opentelemetry::KeyValue {
-    fn from(kv: &wasi::otel::types::KeyValue) -> Self {
-        let owned: OwnedValue = from_json(&kv.value);
-        let value: opentelemetry::Value = owned.into();
-        opentelemetry::KeyValue::new(kv.key.to_owned(), value)
-    }
-}
-
 impl From<OwnedValue> for opentelemetry::Value {
     fn from(value: OwnedValue) -> Self {
         match value {
@@ -36,8 +28,8 @@ impl From<OwnedValue> for opentelemetry::Value {
                 OwnedArray::F64(v) => opentelemetry::Array::F64(v),
                 OwnedArray::I64(v) => opentelemetry::Array::I64(v),
                 OwnedArray::String(v) => opentelemetry::Array::String(
-                    v.iter()
-                        .map(|e| opentelemetry::StringValue::from(e.to_owned()))
+                    v.into_iter()
+                        .map(opentelemetry::StringValue::from)
                         .collect(),
                 ),
             }),

--- a/crates/world/src/wasi_otel/log_conversions.rs
+++ b/crates/world/src/wasi_otel/log_conversions.rs
@@ -63,7 +63,7 @@ pub fn parse_wasi_log_record(
     let otel_scope = if let Some(wasi_scope) = wasi_log_record.instrumentation_scope {
         let attrs: Vec<opentelemetry::KeyValue> = wasi_scope
             .attributes
-            .iter()
+            .into_iter()
             .map(|e| {
                 let kv: opentelemetry::KeyValue = e.into();
                 kv
@@ -122,7 +122,6 @@ fn severity_from_u8(n: u8) -> opentelemetry::logs::Severity {
     }
 }
 
-#[derive(Clone)]
 enum OwnedAnyValue {
     Int(i64),
     Double(f64),
@@ -138,17 +137,15 @@ impl From<OwnedAnyValue> for opentelemetry::logs::AnyValue {
         use opentelemetry::logs::AnyValue;
         match value {
             OwnedAnyValue::Boolean(v) => AnyValue::Boolean(v),
-            OwnedAnyValue::Bytes(v) => AnyValue::Bytes(Box::new(v.to_vec())),
+            OwnedAnyValue::Bytes(v) => AnyValue::Bytes(Box::new(v)),
             OwnedAnyValue::Double(v) => AnyValue::Double(v),
             OwnedAnyValue::Int(v) => AnyValue::Int(v),
-            OwnedAnyValue::String(v) => AnyValue::String(v.clone().into()),
+            OwnedAnyValue::String(v) => AnyValue::String(v.into()),
             OwnedAnyValue::ListAny(v) => {
-                AnyValue::ListAny(Box::new(v.iter().map(|e| e.clone().into()).collect()))
+                AnyValue::ListAny(Box::new(v.into_iter().map(|e| e.into()).collect()))
             }
             OwnedAnyValue::Map(v) => AnyValue::Map(Box::new(
-                v.iter()
-                    .map(|(k, v)| (k.clone().into(), v.clone().into()))
-                    .collect(),
+                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
             )),
         }
     }

--- a/crates/world/src/wasi_otel/metric_conversions.rs
+++ b/crates/world/src/wasi_otel/metric_conversions.rs
@@ -55,7 +55,7 @@ macro_rules! exemplars_to_otel {
             $exemplar_type:ty
         ) => {
         $wasi_exemplar_list
-            .iter()
+            .into_iter()
             .map(|e| {
                 let span_id: [u8; 8] = e
                     .span_id
@@ -70,7 +70,6 @@ macro_rules! exemplars_to_otel {
                 opentelemetry_sdk::metrics::data::Exemplar::<$exemplar_type> {
                     filtered_attributes: e
                         .filtered_attributes
-                        .to_owned()
                         .into_iter()
                         .map(Into::into)
                         .collect(),
@@ -90,9 +89,9 @@ macro_rules! wasi_gauge_to_otel {
         Box::new(opentelemetry_sdk::metrics::data::Gauge {
             data_points: $gauge
                 .data_points
-                .iter()
+                .into_iter()
                 .map(|dp| opentelemetry_sdk::metrics::data::GaugeDataPoint {
-                    attributes: dp.attributes.iter().map(Into::into).collect(),
+                    attributes: dp.attributes.into_iter().map(Into::into).collect(),
                     value: dp.value.into(),
                     exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
                 })
@@ -112,9 +111,9 @@ macro_rules! wasi_sum_to_otel {
         Box::new(opentelemetry_sdk::metrics::data::Sum {
             data_points: $sum
                 .data_points
-                .iter()
+                .into_iter()
                 .map(|dp| opentelemetry_sdk::metrics::data::SumDataPoint {
-                    attributes: dp.attributes.iter().map(Into::into).collect(),
+                    attributes: dp.attributes.into_iter().map(Into::into).collect(),
                     exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
                     value: dp.value.into(),
                 })
@@ -133,11 +132,11 @@ macro_rules! wasi_histogram_to_otel {
         Box::new(opentelemetry_sdk::metrics::data::Histogram {
             data_points: $histogram
                 .data_points
-                .iter()
+                .into_iter()
                 .map(|dp| opentelemetry_sdk::metrics::data::HistogramDataPoint {
-                    attributes: dp.attributes.iter().map(Into::into).collect(),
-                    bounds: dp.bounds.to_owned(),
-                    bucket_counts: dp.bucket_counts.to_owned(),
+                    attributes: dp.attributes.into_iter().map(Into::into).collect(),
+                    bounds: dp.bounds,
+                    bucket_counts: dp.bucket_counts,
                     exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
                     count: dp.count,
                     max: match dp.max {
@@ -164,10 +163,10 @@ macro_rules! wasi_exponential_histogram_to_otel {
         Box::new(opentelemetry_sdk::metrics::data::ExponentialHistogram {
             data_points: $histogram
                 .data_points
-                .iter()
+                .into_iter()
                 .map(
                     |dp| opentelemetry_sdk::metrics::data::ExponentialHistogramDataPoint {
-                        attributes: dp.attributes.iter().map(Into::into).collect(),
+                        attributes: dp.attributes.into_iter().map(Into::into).collect(),
                         exemplars: exemplars_to_otel!(dp.exemplars, $number_type),
                         count: dp.count as usize,
                         max: match dp.max {
@@ -181,8 +180,8 @@ macro_rules! wasi_exponential_histogram_to_otel {
                         sum: dp.sum.into(),
                         scale: dp.scale,
                         zero_count: dp.zero_count,
-                        positive_bucket: dp.positive_bucket.to_owned().into(),
-                        negative_bucket: dp.negative_bucket.to_owned().into(),
+                        positive_bucket: dp.positive_bucket.into(),
+                        negative_bucket: dp.negative_bucket.into(),
                         zero_threshold: dp.zero_threshold,
                     },
                 )

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -673,11 +673,10 @@ impl WorkingDirectory {
 
 // Parse the environment variables passed in `key=value` pairs.
 fn parse_env_var(s: &str) -> Result<(String, String)> {
-    let parts: Vec<_> = s.splitn(2, '=').collect();
-    if parts.len() != 2 {
+    let Some((key, value)) = s.split_once('=') else {
         bail!("Environment variable must be of the form `key=value`");
-    }
-    Ok((parts[0].to_owned(), parts[1].to_owned()))
+    };
+    Ok((key.to_owned(), value.to_owned()))
 }
 
 fn resolve_trigger_plugin(trigger_type: &str) -> Result<String> {


### PR DESCRIPTION
- Use `split_once` for first-delimiter parsing in environment variables and OCI basic authentication
- Use `Itertools::join` in the dotted PascalCase template filter. These changes remove temporary collections without changing behavior.
- ~~Search for `spin.toml` with `Path::ancestors` to remove the depth limit~~
- Use `exactly_one` to detect a single GitHub tarball root directory
- Move owned WASI OpenTelemetry data into OTel types instead of cloning it.