### PR TITLE
add http middleware template

### DIFF
--- a/crates/templates/src/manager.rs
+++ b/crates/templates/src/manager.rs
@@ -615,7 +615,7 @@ mod tests {
         }
     }
 
-    const TPLS_IN_THIS: usize = 12;
+    const TPLS_IN_THIS: usize = 13;
 
     #[tokio::test]
     async fn can_install_into_new_directory() {

--- a/templates/http-middleware/content/.gitignore
+++ b/templates/http-middleware/content/.gitignore
@@ -1,0 +1,2 @@
+target/
+.spin/

--- a/templates/http-middleware/content/Cargo.toml.tmpl
+++ b/templates/http-middleware/content/Cargo.toml.tmpl
@@ -1,0 +1,15 @@
+[package]
+name = "{{project-name | kebab_case}}"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+version = "0.1.0"
+rust-version = "1.93"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = "1"
+spin-sdk = { git = "https://github.com/spinframework/spin-rust-sdk", branch = "main", features = ["http-middleware"] }
+[workspace]

--- a/templates/http-middleware/content/spin.toml
+++ b/templates/http-middleware/content/spin.toml
@@ -1,0 +1,14 @@
+spin_manifest_version = 2
+
+[application]
+name = "{{project-name | kebab_case}}"
+version = "0.1.0"
+authors = ["{{authors}}"]
+description = "{{project-description}}"
+
+[component.{{project-name | kebab_case}}]
+source = "target/wasm32-wasip2/release/{{project-name | snake_case}}.wasm"
+allowed_outbound_hosts = []
+[component.{{project-name | kebab_case}}.build]
+command = "cargo build --target wasm32-wasip2 --release"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/http-middleware/content/src/lib.rs
+++ b/templates/http-middleware/content/src/lib.rs
@@ -1,0 +1,38 @@
+use spin_sdk::http::{self, Request, Response};
+use spin_sdk::http_service;
+
+/// Headers that WASI HTTP manages itself and forbids setting on an outgoing
+/// request. They must be stripped from the incoming request before it is
+/// forwarded, otherwise the runtime rejects it with `HeaderError::Forbidden`.
+const FORBIDDEN_HEADERS: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-connection",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+    "content-length",
+];
+
+#[http_service]
+async fn handle(mut req: Request) -> http::Result<Response> {
+    // Request runs on the way in, before the next handler.
+    eprintln!("[middleware] --> {} {}", req.method(), req.uri().path());
+
+    // Strip runtime-managed headers so forwarding doesn't hit `Forbidden`.
+    let headers = req.headers_mut();
+    for name in FORBIDDEN_HEADERS {
+        headers.remove(*name);
+    }
+
+    // MIDDLEWARE LOGIC GOES HERE
+    
+    // Forward the (modified) request to the next handler in the chain and wait
+    // for its response.
+    let resp = http::next(req).await?;
+
+    // Response runs on the way out, after the next handler
+    eprintln!("[middleware] <-- {}", resp.status());
+
+    Ok(resp)
+}

--- a/templates/http-middleware/metadata/snippets/component.txt
+++ b/templates/http-middleware/metadata/snippets/component.txt
@@ -1,0 +1,7 @@
+[component.{{project-name | kebab_case}}]
+source = "{{ output-path }}/target/wasm32-wasip2/release/{{project-name | snake_case}}.wasm"
+allowed_outbound_hosts = []
+[component.{{project-name | kebab_case}}.build]
+command = "cargo build --target wasm32-wasip2 --release"
+workdir = "{{ output-path }}"
+watch = ["src/**/*.rs", "Cargo.toml"]

--- a/templates/http-middleware/metadata/spin-template.toml
+++ b/templates/http-middleware/metadata/spin-template.toml
@@ -1,0 +1,17 @@
+manifest_version = "1"
+id = "http-middleware"
+description = "http middleware rust template"
+tags = []
+
+[new_application]
+supported = false
+
+[add_component]
+skip_files = ["spin.toml"]
+[add_component.snippets]
+component = "component.txt"
+
+[parameters]
+# These are placehodlers for the template parameters
+# You can add more parameters here, or remove them if you don't need them.
+project-description = { type = "string", prompt = "Description", default = "" }


### PR DESCRIPTION
Opened up this draft PR as an additional resource to visualize https://github.com/spinframework/spin/issues/3618. 
This is an attempt to add an http middleware template for both the `spin new` and `spin add` experience. I ran into a few issues. 