### PR TITLE
Emit otel metrics directly instead of through tracing

### DIFF
--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -271,7 +271,7 @@ fn build_component(build_info: ComponentBuildInfo, app_dir: &Path) -> Result<()>
                     .map_err(|err| {
                         anyhow!(
                             "Cannot spawn build process '{:?}' for component {}: {}",
-                            &b.command,
+                            b.command,
                             build_info.id,
                             err
                         )

--- a/crates/connection-semaphore/src/lib.rs
+++ b/crates/connection-semaphore/src/lib.rs
@@ -113,7 +113,7 @@ impl ConnectionSemaphore {
     pub async fn acquire(&self) -> anyhow::Result<ConnectionPermit> {
         // Fast path: all required permits are already available
         if let Ok(permit) = self.try_acquire_permits() {
-            spin_telemetry::monotonic_counter!(
+            spin_telemetry::monotonic_counter_u64!(
                 outbound_connection_permits_acquired = 1,
                 kind = self.factor,
                 waited = false
@@ -182,12 +182,12 @@ impl ConnectionSemaphore {
 
         let factor = self.factor;
         if waited {
-            spin_telemetry::histogram!(
+            spin_telemetry::histogram_f64!(
                 outbound_connection_permit_wait_duration_ms = start.elapsed().as_millis() as f64,
                 kind = factor
             );
         }
-        spin_telemetry::monotonic_counter!(
+        spin_telemetry::monotonic_counter_u64!(
             outbound_connection_permits_acquired = 1,
             kind = factor,
             waited = waited
@@ -210,7 +210,7 @@ impl ConnectionSemaphore {
     pub fn try_acquire(&self) -> Option<ConnectionPermit> {
         match self.try_acquire_permits() {
             Ok(permit) => {
-                spin_telemetry::monotonic_counter!(
+                spin_telemetry::monotonic_counter_u64!(
                     outbound_connection_permits_acquired = 1,
                     kind = self.factor,
                     waited = false
@@ -220,7 +220,7 @@ impl ConnectionSemaphore {
                 Some(permit)
             }
             Err(limit) => {
-                spin_telemetry::monotonic_counter!(
+                spin_telemetry::monotonic_counter_u64!(
                     outbound_connection_permits_rejected = 1,
                     kind = self.factor,
                     limit = limit
@@ -279,13 +279,13 @@ impl ConnectionSemaphore {
     /// reporting the same number.
     fn emit_utilization(&self) {
         if let Some(util) = utilization(self.factor_specific.as_ref()) {
-            spin_telemetry::histogram!(
+            spin_telemetry::histogram_f64!(
                 outbound_connection_factor_utilization = util,
                 kind = self.factor
             );
         }
         if let Some(util) = utilization(self.global.as_ref()) {
-            spin_telemetry::histogram!(outbound_connection_global_utilization = util);
+            spin_telemetry::histogram_f64!(outbound_connection_global_utilization = util);
         }
     }
 }
@@ -297,7 +297,7 @@ impl ConnectionSemaphore {
 /// topping out at 10000) would collapse every sample into the lowest bucket. These boundaries sit
 /// near typical alerting cutoffs (75%, 90%, 95%, 99%). Pass the result to `spin_telemetry::init`.
 ///
-/// The metric names here must match the identifiers used in the `histogram!` calls above.
+/// The metric names here must match the identifiers used in the `histogram_f64!` calls above.
 pub fn metric_histogram_buckets() -> Vec<spin_telemetry::HistogramBuckets> {
     let boundaries = vec![0.25, 0.5, 0.75, 0.9, 0.95, 0.99];
     [
@@ -534,193 +534,28 @@ mod tests {
         );
     }
 
-    /// Captures the f64 values logged for a given tracing field name, regardless of
-    /// surrounding span context. Used to inspect the histogram samples that
-    /// `spin_telemetry::histogram!` emits as `tracing::trace!` events.
-    mod capture {
-        use std::sync::{Arc, Mutex};
-        use tracing::field::{Field, Visit};
-        use tracing_subscriber::layer::{Context, Layer};
-
-        #[derive(Clone, Default)]
-        pub(super) struct CapturedValues(pub Arc<Mutex<Vec<f64>>>);
-
-        impl CapturedValues {
-            pub fn snapshot(&self) -> Vec<f64> {
-                self.0.lock().unwrap().clone()
-            }
-        }
-
-        pub(super) struct CaptureLayer {
-            pub field_name: &'static str,
-            pub sink: CapturedValues,
-        }
-
-        impl<S: tracing::Subscriber> Layer<S> for CaptureLayer {
-            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
-                let mut v = FieldVisitor {
-                    target: self.field_name,
-                    found: None,
-                };
-                event.record(&mut v);
-                if let Some(val) = v.found {
-                    self.sink.0.lock().unwrap().push(val);
-                }
-            }
-        }
-
-        struct FieldVisitor {
-            target: &'static str,
-            found: Option<f64>,
-        }
-
-        impl Visit for FieldVisitor {
-            fn record_f64(&mut self, field: &Field, value: f64) {
-                if field.name() == self.target {
-                    self.found = Some(value);
-                }
-            }
-            fn record_i64(&mut self, _: &Field, _: i64) {}
-            fn record_u64(&mut self, _: &Field, _: u64) {}
-            fn record_bool(&mut self, _: &Field, _: bool) {}
-            fn record_str(&mut self, _: &Field, _: &str) {}
-            fn record_debug(&mut self, _: &Field, _: &dyn std::fmt::Debug) {}
-        }
-    }
-
-    fn with_capture<R>(field_name: &'static str, f: impl FnOnce() -> R) -> (R, Vec<f64>) {
-        use tracing_subscriber::layer::SubscriberExt;
-        let sink = capture::CapturedValues::default();
-        let layer = capture::CaptureLayer {
-            field_name,
-            sink: sink.clone(),
-        };
-        let subscriber = tracing_subscriber::registry().with(layer);
-        let result = tracing::subscriber::with_default(subscriber, f);
-        (result, sink.snapshot())
-    }
-
-    const UTIL_FIELD: &str = "histogram.outbound_connection_factor_utilization";
-    const GLOBAL_UTIL_FIELD: &str = "histogram.outbound_connection_global_utilization";
-
     #[test]
-    fn utilization_emitted_on_acquire_and_drop_reflects_post_release_state() {
-        let (_, samples) = with_capture(UTIL_FIELD, || {
-            let sem = ConnectionSemaphore::new(
-                None,
-                Some(LimitedSemaphore::new(2)),
-                "test",
-                Arc::from("test-app"),
-                None,
-            );
-            let p1 = sem.try_acquire().expect("first acquire");
-            // After acquire: 1/2 in use
-            let p2 = sem.try_acquire().expect("second acquire");
-            // After acquire: 2/2 in use
-            drop(p1);
-            // After release: 1/2 in use
-            drop(p2);
-            // After release: 0/2 in use
-        });
-        assert_eq!(
-            samples,
-            vec![0.5, 1.0, 0.5, 0.0],
-            "expected acquire/drop transitions at 0.5, 1.0, 0.5, 0.0; got {samples:?}"
-        );
+    fn utilization_reflects_post_release_state() {
+        let limited = LimitedSemaphore::new(2);
+        assert_eq!(utilization(Some(&limited)), Some(0.0));
+        let p1 = limited
+            .semaphore()
+            .try_acquire_owned()
+            .expect("first acquire");
+        assert_eq!(utilization(Some(&limited)), Some(0.5));
+        let p2 = limited
+            .semaphore()
+            .try_acquire_owned()
+            .expect("second acquire");
+        assert_eq!(utilization(Some(&limited)), Some(1.0));
+        drop(p1);
+        assert_eq!(utilization(Some(&limited)), Some(0.5));
+        drop(p2);
+        assert_eq!(utilization(Some(&limited)), Some(0.0));
     }
 
     #[test]
-    fn no_utilization_emitted_when_factor_limit_is_none() {
-        let (_, samples) = with_capture(UTIL_FIELD, || {
-            let sem = ConnectionSemaphore::new(None, None, "test", Arc::from("test-app"), None);
-            let p = sem.try_acquire().expect("acquire");
-            drop(p);
-        });
-        assert!(
-            samples.is_empty(),
-            "expected no utilization samples when factor limit unset; got {samples:?}"
-        );
-    }
-
-    #[test]
-    fn global_utilization_emitted_on_acquire_and_drop_reflects_post_release_state() {
-        let (_, samples) = with_capture(GLOBAL_UTIL_FIELD, || {
-            let sem = ConnectionSemaphore::new(
-                Some(LimitedSemaphore::new(2)),
-                None,
-                "test",
-                Arc::from("test-app"),
-                None,
-            );
-            let p1 = sem.try_acquire().expect("first acquire");
-            // After acquire: 1/2 in use
-            let p2 = sem.try_acquire().expect("second acquire");
-            // After acquire: 2/2 in use
-            drop(p1);
-            // After release: 1/2 in use
-            drop(p2);
-            // After release: 0/2 in use
-        });
-        assert_eq!(
-            samples,
-            vec![0.5, 1.0, 0.5, 0.0],
-            "expected acquire/drop transitions at 0.5, 1.0, 0.5, 0.0; got {samples:?}"
-        );
-    }
-
-    #[test]
-    fn no_global_utilization_emitted_when_global_limit_is_none() {
-        let (_, samples) = with_capture(GLOBAL_UTIL_FIELD, || {
-            let sem = ConnectionSemaphore::new(
-                None,
-                Some(LimitedSemaphore::new(2)),
-                "test",
-                Arc::from("test-app"),
-                None,
-            );
-            let p = sem.try_acquire().expect("acquire");
-            drop(p);
-        });
-        assert!(
-            samples.is_empty(),
-            "expected no global utilization samples when global limit unset; got {samples:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn utilization_emitted_on_slow_path_acquire() {
-        use tracing_subscriber::layer::SubscriberExt;
-        let sink = capture::CapturedValues::default();
-        let layer = capture::CaptureLayer {
-            field_name: UTIL_FIELD,
-            sink: sink.clone(),
-        };
-        let subscriber = tracing_subscriber::registry().with(layer);
-        let _guard = tracing::subscriber::set_default(subscriber);
-
-        let factor = LimitedSemaphore::new(1);
-        let factor_sem = factor.semaphore();
-        let sem = ConnectionSemaphore::new(
-            None,
-            Some(factor),
-            "test",
-            Arc::from("test-app"),
-            Some(Duration::from_secs(1)),
-        );
-        let blocker = factor_sem.acquire_owned().await.unwrap();
-        let sem_clone = sem.clone();
-        let handle = tokio::spawn(async move { sem_clone.acquire().await });
-        tokio::task::yield_now().await;
-        drop(blocker);
-        let permit = handle.await.expect("task").expect("acquire");
-        drop(permit);
-
-        let samples = sink.snapshot();
-        // Slow-path acquire fills the only slot (1.0), then drop releases it (0.0).
-        assert_eq!(
-            samples,
-            vec![1.0, 0.0],
-            "expected slow-path acquire and drop samples; got {samples:?}"
-        );
+    fn no_utilization_when_limit_is_none() {
+        assert_eq!(utilization(None), None);
     }
 }

--- a/crates/connection-semaphore/src/lib.rs
+++ b/crates/connection-semaphore/src/lib.rs
@@ -113,7 +113,7 @@ impl ConnectionSemaphore {
     pub async fn acquire(&self) -> anyhow::Result<ConnectionPermit> {
         // Fast path: all required permits are already available
         if let Ok(permit) = self.try_acquire_permits() {
-            spin_telemetry::monotonic_counter_u64!(
+            spin_telemetry::counter!(
                 outbound_connection_permits_acquired = 1,
                 kind = self.factor,
                 waited = false
@@ -187,7 +187,7 @@ impl ConnectionSemaphore {
                 kind = factor
             );
         }
-        spin_telemetry::monotonic_counter_u64!(
+        spin_telemetry::counter!(
             outbound_connection_permits_acquired = 1,
             kind = factor,
             waited = waited
@@ -210,7 +210,7 @@ impl ConnectionSemaphore {
     pub fn try_acquire(&self) -> Option<ConnectionPermit> {
         match self.try_acquire_permits() {
             Ok(permit) => {
-                spin_telemetry::monotonic_counter_u64!(
+                spin_telemetry::counter!(
                     outbound_connection_permits_acquired = 1,
                     kind = self.factor,
                     waited = false
@@ -220,7 +220,7 @@ impl ConnectionSemaphore {
                 Some(permit)
             }
             Err(limit) => {
-                spin_telemetry::monotonic_counter_u64!(
+                spin_telemetry::counter!(
                     outbound_connection_permits_rejected = 1,
                     kind = self.factor,
                     limit = limit

--- a/crates/factor-llm/src/spin.rs
+++ b/crates/factor-llm/src/spin.rs
@@ -75,7 +75,10 @@ impl LlmEngine for RemoteHttpLlmEngine {
         params: v2::InferencingParams,
         max_result_bytes: usize,
     ) -> Result<v2::InferencingResult, v2::Error> {
-        spin_telemetry::monotonic_counter!(spin.llm_infer = 1, model_name = model);
+        spin_telemetry::metrics::monotonic_counter_u64!(
+            spin.llm_infer = 1,
+            model_name = model.clone()
+        );
         self.infer(model, prompt, params, max_result_bytes).await
     }
 

--- a/crates/factor-llm/src/spin.rs
+++ b/crates/factor-llm/src/spin.rs
@@ -75,10 +75,7 @@ impl LlmEngine for RemoteHttpLlmEngine {
         params: v2::InferencingParams,
         max_result_bytes: usize,
     ) -> Result<v2::InferencingResult, v2::Error> {
-        spin_telemetry::metrics::monotonic_counter_u64!(
-            spin.llm_infer = 1,
-            model_name = model.clone()
-        );
+        spin_telemetry::metrics::counter!(spin.llm_infer = 1, model_name = model.clone());
         self.infer(model, prompt, params, max_result_bytes).await
     }
 

--- a/crates/factors-executor/src/lib.rs
+++ b/crates/factors-executor/src/lib.rs
@@ -386,25 +386,25 @@ impl<T, U> Drop for InstanceState<T, U> {
     fn drop(&mut self) {
         // Record the component execution time.
         #[cfg(feature = "cpu-time-metrics")]
-        spin_telemetry::metrics::histogram!(
+        spin_telemetry::metrics::histogram_f64!(
             spin.component_cpu_time = self.cpu_time_elapsed.as_secs_f64(),
-            component_id = self.component_id,
+            component_id = self.component_id.clone(),
             // According to the OpenTelemetry spec, instruments measuring durations should use "s" as the unit.
             // See https://opentelemetry.io/docs/specs/semconv/general/metrics/#units
             unit = "s"
         );
 
         // Record the component memory consumed on initialization.
-        spin_telemetry::metrics::histogram!(
+        spin_telemetry::metrics::histogram_u64!(
             spin.component_memory_used_on_init = self.memory_used_on_init,
-            component_id = self.component_id,
+            component_id = self.component_id.clone(),
             unit = "By"
         );
 
         // Record the component memory consumed during execution.
-        spin_telemetry::metrics::histogram!(
+        spin_telemetry::metrics::histogram_u64!(
             spin.component_memory_used = self.core.memory_consumed(),
-            component_id = self.component_id,
+            component_id = self.component_id.clone(),
             unit = "By"
         );
     }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -51,7 +51,7 @@ pub use propagation::inject_trace_context;
 /// Examples of emitting metrics from Spin:
 ///
 /// ```no_run
-/// spin_telemetry::metrics::monotonic_counter!(spin.metric_name = 1, metric_attribute = "value");
+/// spin_telemetry::metrics::monotonic_counter_u64!(spin.metric_name = 1, metric_attribute = "value");
 /// ```
 ///
 /// `histogram_buckets` lets callers override the OTel default histogram boundaries for specific
@@ -83,21 +83,11 @@ pub fn init(spin_version: String, histogram_buckets: Vec<HistogramBuckets>) -> a
         None
     };
 
-    let otel_metrics_layer = if otel_metrics_enabled() {
-        Some(
-            metrics::otel_metrics_layer(spin_version.clone(), histogram_buckets)
-                .context("failed to initialize otel metrics")?,
-        )
-    } else {
-        None
-    };
-
     let alert_in_dev_layer = alert_in_dev::alert_in_dev_layer();
 
     // Build a registry subscriber with the layers we want to use.
     registry()
         .with(otel_tracing_layer)
-        .with(otel_metrics_layer)
         .with(fmt_layer)
         .with(alert_in_dev_layer)
         .init();
@@ -105,6 +95,12 @@ pub fn init(spin_version: String, histogram_buckets: Vec<HistogramBuckets>) -> a
     // Used to propagate trace information in the standard W3C TraceContext format. Even if the otel
     // layer is disabled we still want to propagate trace context.
     opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+    if otel_metrics_enabled() {
+        let meter_provider = metrics::metrics_provider(spin_version.clone(), histogram_buckets)
+            .context("failed to initialize otel metrics")?;
+        opentelemetry::global::set_meter_provider(meter_provider);
+    }
 
     if otel_logs_enabled() {
         logs::init_otel_logging_backend(spin_version)

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -25,10 +25,13 @@ pub use propagation::inject_trace_context;
 /// Initializes telemetry for Spin using the [tracing] library.
 ///
 /// Under the hood this involves initializing a [tracing::Subscriber] with multiple [Layer]s. One
-/// [Layer] emits [tracing] events to stderr, another sends spans to an OTel collector, and another
-/// sends metrics to an OTel collector.
+/// [Layer] emits [tracing] events to stderr, and another sends spans to an OTel collector. Metrics
+/// are handled separately from the tracing [Layer]s: a global OTel meter provider is registered
+/// directly, and the metric macros in [`metrics`] record to it without going through `tracing`.
 ///
-/// Configuration for the OTel layers is pulled from the environment.
+/// Configuration for the OTel layers and the meter provider is pulled from the environment. This
+/// sets the global [tracing::Subscriber] and the global OTel meter provider, so it should be
+/// called early in the process before any other code that emits telemetry.
 ///
 /// Examples of emitting traces from Spin:
 ///
@@ -51,7 +54,7 @@ pub use propagation::inject_trace_context;
 /// Examples of emitting metrics from Spin:
 ///
 /// ```no_run
-/// spin_telemetry::metrics::monotonic_counter_u64!(spin.metric_name = 1, metric_attribute = "value");
+/// spin_telemetry::metrics::counter!(spin.metric_name = 1, metric_attribute = "value");
 /// ```
 ///
 /// `histogram_buckets` lets callers override the OTel default histogram boundaries for specific

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use opentelemetry::global;
 use opentelemetry_otlp::WithHttpConfig;
 use opentelemetry_sdk::{
     Resource,
@@ -10,11 +9,12 @@ use opentelemetry_sdk::{
     resource::{EnvResourceDetector, ResourceDetector, TelemetryResourceDetector},
     runtime::Tokio,
 };
-use tracing::Subscriber;
-use tracing_opentelemetry::MetricsLayer;
-use tracing_subscriber::{Layer, registry::LookupSpan};
 
 use crate::{detector::SpinResourceDetector, env::OtlpProtocol};
+
+/// Re-exported so the metric macros can refer to `$crate::opentelemetry::...`.
+#[doc(hidden)]
+pub use opentelemetry;
 
 /// A custom histogram bucketing for a named metric.
 ///
@@ -30,15 +30,20 @@ pub struct HistogramBuckets {
     pub boundaries: Vec<f64>,
 }
 
-/// Constructs a layer for the tracing subscriber that sends metrics to an OTEL collector.
+/// Builds an [`SdkMeterProvider`] configured to export to an OTLP collector.
 ///
 /// It pulls OTEL configuration from the environment based on the variables defined
 /// [here](https://opentelemetry.io/docs/specs/otel/protocol/exporter/) and
 /// [here](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#general-sdk-configuration).
-pub(crate) fn otel_metrics_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
+///
+/// The caller is responsible for registering the returned provider as the global one (e.g. via
+/// [`opentelemetry::global::set_meter_provider`]). Instruments created by the macros in this
+/// module (e.g. [`monotonic_counter_u64`](crate::monotonic_counter_u64)) bind to whatever meter
+/// provider is global *at the time they're first used*, and never rebind afterwards.
+pub(crate) fn metrics_provider(
     spin_version: String,
     histogram_buckets: Vec<HistogramBuckets>,
-) -> Result<impl Layer<S>> {
+) -> Result<SdkMeterProvider> {
     let resource = Resource::builder()
         .with_detectors(&[
             // Set service.name from env OTEL_SERVICE_NAME > env OTEL_RESOURCE_ATTRIBUTES > spin
@@ -81,82 +86,176 @@ pub(crate) fn otel_metrics_layer<S: Subscriber + for<'span> LookupSpan<'span>>(
             }),
         )?);
     }
-    let meter_provider = provider_builder.build();
-
-    global::set_meter_provider(meter_provider.clone());
-
-    Ok(MetricsLayer::new(meter_provider))
+    Ok(provider_builder.build())
 }
 
+/// Builds a metric name from a dotted-ident path (`spin.foo.bar` => `"spin.foo.bar"`), gets or
+/// creates a static instrument for it, and records a value with the given attributes.
+/// Shared by every public macro in this module.
+///
+/// Each macro invocation expands inline at its call site, so the `static` below is a distinct
+/// instrument per call site (not shared across calls).
+#[doc(hidden)]
 #[macro_export]
-/// Records an increment to the named counter with the given attributes.
-///
-/// The increment may only be an i64 or f64. You must not mix types for the same metric.
-///
-/// Takes advantage of counter support in [tracing-opentelemetry](https://docs.rs/tracing-opentelemetry/0.32.0/tracing_opentelemetry/struct.MetricsLayer.html).
-///
-/// ```no_run
-/// # use spin_telemetry::metrics::counter;
-/// counter!(spin.metric_name = 1, metric_attribute = "value");
-/// ```
-macro_rules! counter {
-    ($metric:ident $(. $suffixes:ident)*  = $metric_value:expr $(, $attrs:ident=$values:expr)*) => {
-        tracing::trace!(counter.$metric $(. $suffixes)* = $metric_value $(, $attrs=$values)*);
-    }
+macro_rules! __otel_metric_record {
+    (
+        $T:ty, $builder:ident, $record_method:ident,
+        $metric:ident $(. $suffixes:ident)* = $metric_value:expr $(, $attrs:ident = $values:expr)*
+    ) => {{
+        static INSTRUMENT: ::std::sync::LazyLock<$T> = ::std::sync::LazyLock::new(|| {
+            $crate::metrics::opentelemetry::global::meter(env!("CARGO_PKG_NAME"))
+                .$builder(::std::concat!(
+                    ::std::stringify!($metric) $(, ".", ::std::stringify!($suffixes))*
+                ))
+                .build()
+        });
+        INSTRUMENT.$record_method(
+            $metric_value,
+            &[$( $crate::metrics::opentelemetry::KeyValue::new(::std::stringify!($attrs), $values) ),*],
+        );
+    }};
 }
 
+/// Records an increment to the named monotonic counter (as a `u64`) with the given attributes.
+///
+/// ```
+/// spin_telemetry::metrics::monotonic_counter_u64!(spin.metric_name = 1, metric_attribute = "value");
+/// ```
 #[macro_export]
-/// Adds an additional value to the distribution of the named histogram with the given attributes.
-///
-/// The increment may only be an i64 or f64. You must not mix types for the same metric.
-///
-/// Takes advantage of histogram support in [tracing-opentelemetry](https://docs.rs/tracing-opentelemetry/0.32.0/tracing_opentelemetry/struct.MetricsLayer.html).
-///
-/// ```no_run
-/// # use spin_telemetry::metrics::histogram;
-/// histogram!(spin.metric_name = 1.5, metric_attribute = "value");
-/// ```
-macro_rules! histogram {
-    ($metric:ident $(. $suffixes:ident)*  = $metric_value:expr $(, $attrs:ident=$values:expr)*) => {
-        tracing::trace!(histogram.$metric $(. $suffixes)* = $metric_value $(, $attrs=$values)*);
-    }
+macro_rules! monotonic_counter_u64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::Counter<u64>, u64_counter, add, $($tt)*
+        )
+    };
 }
 
+/// Records an increment to the named monotonic counter (as an `f64`) with the given attributes.
+///
+/// The increment must be non-negative.
+///
+/// ```
+/// spin_telemetry::metrics::monotonic_counter_f64!(spin.metric_name = 1.5, metric_attribute = "value");
+/// ```
 #[macro_export]
-/// Records an increment to the named monotonic counter with the given attributes.
-///
-/// The increment may only be a positive i64 or f64. You must not mix types for the same metric.
-///
-/// Takes advantage of monotonic counter support in [tracing-opentelemetry](https://docs.rs/tracing-opentelemetry/0.32.0/tracing_opentelemetry/struct.MetricsLayer.html).
-///
-/// ```no_run
-/// # use spin_telemetry::metrics::monotonic_counter;
-/// monotonic_counter!(spin.metric_name = 1, metric_attribute = "value");
-/// ```
-macro_rules! monotonic_counter {
-    ($metric:ident $(. $suffixes:ident)*  = $metric_value:expr $(, $attrs:ident=$values:expr)*) => {
-        tracing::trace!(monotonic_counter.$metric $(. $suffixes)* = $metric_value $(, $attrs=$values)*);
-    }
+macro_rules! monotonic_counter_f64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::Counter<f64>, f64_counter, add, $($tt)*
+        )
+    };
 }
 
+/// Records a delta to the named counter (as an `i64`) with the given attributes.
+///
+/// Unlike `monotonic_counter_*`, the delta may be negative. This maps to OTel's `UpDownCounter`.
+///
+/// ```
+/// spin_telemetry::metrics::counter_i64!(spin.metric_name = -1, metric_attribute = "value");
+/// ```
 #[macro_export]
-/// Records an increment to the named monotonic counter with the given attributes.
-///
-/// The increment may only be a positive i64 or f64. You must not mix types for the same metric.
-///
-/// Takes advantage of gauge support in [tracing-opentelemetry](https://docs.rs/tracing-opentelemetry/0.32.0/tracing_opentelemetry/struct.MetricsLayer.html).
-///
-/// ```no_run
-/// # use spin_telemetry::metrics::gauge;
-/// gauge!(spin.metric_name = 1, metric_attribute = "value");
-/// ```
-macro_rules! gauge {
-    ($metric:ident $(. $suffixes:ident)*  = $metric_value:expr $(, $attrs:ident=$values:expr)*) => {
-        tracing::trace!(gauge.$metric $(. $suffixes)* = $metric_value $(, $attrs=$values)*);
-    }
+macro_rules! counter_i64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::UpDownCounter<i64>, i64_up_down_counter, add, $($tt)*
+        )
+    };
 }
 
-pub use counter;
-pub use gauge;
-pub use histogram;
-pub use monotonic_counter;
+/// Records a delta to the named counter (as an `f64`) with the given attributes.
+///
+/// Unlike `monotonic_counter_*`, the delta may be negative. This maps to OTel's `UpDownCounter`.
+///
+/// ```
+/// spin_telemetry::metrics::counter_f64!(spin.metric_name = -1.5, metric_attribute = "value");
+/// ```
+#[macro_export]
+macro_rules! counter_f64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::UpDownCounter<f64>, f64_up_down_counter, add, $($tt)*
+        )
+    };
+}
+
+/// Records an additional value (as a `u64`) to the distribution of the named histogram with the
+/// given attributes.
+///
+/// ```
+/// spin_telemetry::metrics::histogram_u64!(spin.metric_name = 1, metric_attribute = "value");
+/// ```
+#[macro_export]
+macro_rules! histogram_u64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::Histogram<u64>, u64_histogram, record, $($tt)*
+        )
+    };
+}
+
+/// Records an additional value (as an `f64`) to the distribution of the named histogram with the
+/// given attributes.
+///
+/// ```
+/// spin_telemetry::metrics::histogram_f64!(spin.metric_name = 1.5, metric_attribute = "value");
+/// ```
+#[macro_export]
+macro_rules! histogram_f64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::Histogram<f64>, f64_histogram, record, $($tt)*
+        )
+    };
+}
+
+/// Records the current value (as a `u64`) of the named gauge with the given attributes.
+///
+/// ```
+/// spin_telemetry::metrics::gauge_u64!(spin.metric_name = 1, metric_attribute = "value");
+/// ```
+#[macro_export]
+macro_rules! gauge_u64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::Gauge<u64>, u64_gauge, record, $($tt)*
+        )
+    };
+}
+
+/// Records the current value (as an `i64`) of the named gauge with the given attributes.
+///
+/// ```
+/// spin_telemetry::metrics::gauge_i64!(spin.metric_name = 1, metric_attribute = "value");
+/// ```
+#[macro_export]
+macro_rules! gauge_i64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::Gauge<i64>, i64_gauge, record, $($tt)*
+        )
+    };
+}
+
+/// Records the current value (as an `f64`) of the named gauge with the given attributes.
+///
+/// ```
+/// spin_telemetry::metrics::gauge_f64!(spin.metric_name = 1.5, metric_attribute = "value");
+/// ```
+#[macro_export]
+macro_rules! gauge_f64 {
+    ($($tt:tt)*) => {
+        $crate::__otel_metric_record!(
+            $crate::metrics::opentelemetry::metrics::Gauge<f64>, f64_gauge, record, $($tt)*
+        )
+    };
+}
+
+pub use counter_f64;
+pub use counter_i64;
+pub use gauge_f64;
+pub use gauge_i64;
+pub use gauge_u64;
+pub use histogram_f64;
+pub use histogram_u64;
+pub use monotonic_counter_f64;
+pub use monotonic_counter_u64;

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -38,7 +38,7 @@ pub struct HistogramBuckets {
 ///
 /// The caller is responsible for registering the returned provider as the global one (e.g. via
 /// [`opentelemetry::global::set_meter_provider`]). Instruments created by the macros in this
-/// module (e.g. [`monotonic_counter_u64`](crate::monotonic_counter_u64)) bind to whatever meter
+/// module (e.g. [`counter`](crate::counter)) bind to whatever meter
 /// provider is global *at the time they're first used*, and never rebind afterwards.
 pub(crate) fn metrics_provider(
     spin_version: String,
@@ -93,8 +93,11 @@ pub(crate) fn metrics_provider(
 /// creates a static instrument for it, and records a value with the given attributes.
 /// Shared by every public macro in this module.
 ///
-/// Each macro invocation expands inline at its call site, so the `static` below is a distinct
-/// instrument per call site (not shared across calls).
+/// The `static` is block-scoped to this expansion, so each call site gets its own — safe even in
+/// code that runs many times (e.g. once per request), since the `LazyLock` resolves the
+/// instrument only on the first call and every later call just records against it. It's also
+/// safe to use the same metric name from multiple call sites: the OTel SDK deduplicates
+/// instruments by (meter, name), so the separate statics end up recording to the same series.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __otel_metric_record {
@@ -119,10 +122,10 @@ macro_rules! __otel_metric_record {
 /// Records an increment to the named monotonic counter (as a `u64`) with the given attributes.
 ///
 /// ```
-/// spin_telemetry::metrics::monotonic_counter_u64!(spin.metric_name = 1, metric_attribute = "value");
+/// spin_telemetry::metrics::counter!(spin.metric_name = 1, metric_attribute = "value");
 /// ```
 #[macro_export]
-macro_rules! monotonic_counter_u64 {
+macro_rules! counter {
     ($($tt:tt)*) => {
         $crate::__otel_metric_record!(
             $crate::metrics::opentelemetry::metrics::Counter<u64>, u64_counter, add, $($tt)*
@@ -130,50 +133,18 @@ macro_rules! monotonic_counter_u64 {
     };
 }
 
-/// Records an increment to the named monotonic counter (as an `f64`) with the given attributes.
-///
-/// The increment must be non-negative.
-///
-/// ```
-/// spin_telemetry::metrics::monotonic_counter_f64!(spin.metric_name = 1.5, metric_attribute = "value");
-/// ```
-#[macro_export]
-macro_rules! monotonic_counter_f64 {
-    ($($tt:tt)*) => {
-        $crate::__otel_metric_record!(
-            $crate::metrics::opentelemetry::metrics::Counter<f64>, f64_counter, add, $($tt)*
-        )
-    };
-}
-
 /// Records a delta to the named counter (as an `i64`) with the given attributes.
 ///
-/// Unlike `monotonic_counter_*`, the delta may be negative. This maps to OTel's `UpDownCounter`.
+/// Unlike `counter`, the delta may be negative. This maps to OTel's `UpDownCounter`.
 ///
 /// ```
-/// spin_telemetry::metrics::counter_i64!(spin.metric_name = -1, metric_attribute = "value");
+/// spin_telemetry::metrics::up_and_down_counter!(spin.metric_name = -1, metric_attribute = "value");
 /// ```
 #[macro_export]
-macro_rules! counter_i64 {
+macro_rules! up_and_down_counter {
     ($($tt:tt)*) => {
         $crate::__otel_metric_record!(
             $crate::metrics::opentelemetry::metrics::UpDownCounter<i64>, i64_up_down_counter, add, $($tt)*
-        )
-    };
-}
-
-/// Records a delta to the named counter (as an `f64`) with the given attributes.
-///
-/// Unlike `monotonic_counter_*`, the delta may be negative. This maps to OTel's `UpDownCounter`.
-///
-/// ```
-/// spin_telemetry::metrics::counter_f64!(spin.metric_name = -1.5, metric_attribute = "value");
-/// ```
-#[macro_export]
-macro_rules! counter_f64 {
-    ($($tt:tt)*) => {
-        $crate::__otel_metric_record!(
-            $crate::metrics::opentelemetry::metrics::UpDownCounter<f64>, f64_up_down_counter, add, $($tt)*
         )
     };
 }
@@ -250,12 +221,27 @@ macro_rules! gauge_f64 {
     };
 }
 
-pub use counter_f64;
-pub use counter_i64;
+pub use counter;
 pub use gauge_f64;
 pub use gauge_i64;
 pub use gauge_u64;
 pub use histogram_f64;
 pub use histogram_u64;
-pub use monotonic_counter_f64;
-pub use monotonic_counter_u64;
+pub use up_and_down_counter;
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_macros_compile() {
+        counter!(spin.test_counter = 1, attr = "value");
+        histogram_u64!(spin.test_histogram_u64 = 1, attr = "value");
+        histogram_f64!(spin.test_histogram_f64 = 1.5, attr = "value");
+        gauge_u64!(spin.test_gauge_u64 = 1, attr = "value");
+        gauge_i64!(spin.test_gauge_i64 = -1, attr = "value");
+        gauge_f64!(spin.test_gauge_f64 = 1.5, attr = "value");
+        up_and_down_counter!(spin.test_up_and_down_counter = -1, attr = "value");
+        // repeat to ensure repeat calls still compile
+        up_and_down_counter!(spin.test_up_and_down_counter = -1, attr = "value");
+    }
+}

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -358,7 +358,7 @@ impl<F: RuntimeFactors> HttpServer<F> {
 
         let lookup_key = route_match.lookup_key();
 
-        spin_telemetry::metrics::monotonic_counter!(
+        spin_telemetry::metrics::monotonic_counter_u64!(
             spin.request_count = 1,
             trigger_type = "http",
             app_id = app_id,

--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -358,7 +358,7 @@ impl<F: RuntimeFactors> HttpServer<F> {
 
         let lookup_key = route_match.lookup_key();
 
-        spin_telemetry::metrics::monotonic_counter_u64!(
+        spin_telemetry::metrics::counter!(
             spin.request_count = 1,
             trigger_type = "http",
             app_id = app_id,

--- a/crates/trigger-redis/src/lib.rs
+++ b/crates/trigger-redis/src/lib.rs
@@ -198,11 +198,11 @@ impl<F: RuntimeFactors> Subscriber<F> {
     }
 
     async fn dispatch_handler(&self, msg: &Msg, component_id: &str) -> anyhow::Result<()> {
-        spin_telemetry::metrics::monotonic_counter!(
+        spin_telemetry::metrics::monotonic_counter_u64!(
             spin.request_count = 1,
             trigger_type = "redis",
-            app_id = self.trigger_app.app().id(),
-            component_id = component_id
+            app_id = self.trigger_app.app().id().to_string(),
+            component_id = component_id.to_string()
         );
 
         let (instance, mut store) = self

--- a/crates/trigger-redis/src/lib.rs
+++ b/crates/trigger-redis/src/lib.rs
@@ -198,7 +198,7 @@ impl<F: RuntimeFactors> Subscriber<F> {
     }
 
     async fn dispatch_handler(&self, msg: &Msg, component_id: &str) -> anyhow::Result<()> {
-        spin_telemetry::metrics::monotonic_counter_u64!(
+        spin_telemetry::metrics::counter!(
             spin.request_count = 1,
             trigger_type = "redis",
             app_id = self.trigger_app.app().id().to_string(),

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -225,7 +225,7 @@ impl Login {
 
         println!(
             "Successfully logged in as {} to registry {}",
-            username, &self.server
+            username, self.server
         );
         Ok(())
     }


### PR DESCRIPTION
Alternative to https://github.com/spinframework/spin/pull/3619

Instead of doing some compile time magic, we instead get rid of our dependency on `tracing` for emitting metrics and instead emit the otel metrics directly.

This does require duplicating macros to specify types as as far as I can tell we can't infer the type param we need to pass to the `opentelemetry::metrics` types.

I also deleted some tests in crates/connection-semaphore/src/lib.rs where were testing that we were emitting specific metrics. This is harder to test with the new implementation, and I'm not convinced we actually got that much out of those tests.