### PR TITLE
Limit the blast radius when updating Wasmtime

### DIFF
--- a/.github/workflows/bump-wasmtime.yml
+++ b/.github/workflows/bump-wasmtime.yml
@@ -30,10 +30,10 @@ jobs:
           sed -i -E "s/wasmtime-wasi = \"[0-9]+[0-9.]*\"/wasmtime-wasi = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\" }/g" Cargo.toml
           sed -i -E "s/wasmtime-wasi-http = \{ version = \"[0-9]+[0-9.]*\"/wasmtime-wasi-http = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\"/g" Cargo.toml
           sed -i -E "s/wasmtime-wasi-http = \"[0-9]+[0-9.]*\"/wasmtime-wasi = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\" }/g" Cargo.toml
-          cargo update
+          cargo update wasmtime wasmtime-wasi wasmtime-wasi-http
           sed -i -E "s/wasmtime = \{ version = \"[0-9]+[0-9.]*\"/wasmtime = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\"/g" examples/spin-timer/Cargo.toml
           sed -i -E "s/wasmtime = \"[0-9]+[0-9.]*\"/wasmtime = \{ git = \"https:\/\/github.com\/bytecodealliance\/wasmtime\", branch = \"release-${{ steps.wasmtime-release.outputs.last_wasmtime }}\" }/g" examples/spin-timer/Cargo.toml
-          cargo update --manifest-path examples/spin-timer/Cargo.toml
+          cargo update wasmtime wasmtime-wasi wasmtime-wasi-http --manifest-path examples/spin-timer/Cargo.toml
 
       # Import GPG key for signing commits
       - name: Import GPG key


### PR DESCRIPTION
To minimise the risk of triggering the "none of yer filthy new crates" action.
