### PR TITLE
Fix duration parsing order in ParsedDuration implementation

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -214,14 +214,14 @@ impl FromStr for ParsedDuration {
         Ok(Self(match s.parse() {
             Ok(val) => Duration::from_secs(val),
             Err(err) => {
-                if let Some(num) = s.strip_suffix("s") {
-                    Duration::from_secs(num.parse().map_err(error)?)
-                } else if let Some(num) = s.strip_suffix("ms") {
+                if let Some(num) = s.strip_suffix("ms") {
                     Duration::from_millis(num.parse().map_err(error)?)
                 } else if let Some(num) = s.strip_suffix("us").or(s.strip_suffix("μs")) {
                     Duration::from_micros(num.parse().map_err(error)?)
                 } else if let Some(num) = s.strip_suffix("ns") {
                     Duration::from_nanos(num.parse().map_err(error)?)
+                } else if let Some(num) = s.strip_suffix("s") {
+                    Duration::from_secs(num.parse().map_err(error)?)
                 } else {
                     return Err(error(err));
                 }


### PR DESCRIPTION
Fix the time duration parsing to handle `ms`, `us`, and `ns` correctly. In the current version, they could never be reached because all of them are matched by the `s` branch.
I think this is simple and may not need the tests, but let me know if tests are needed.