### PR TITLE
feat(kv): support configuring concurrent operation limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9205,6 +9205,7 @@ version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
  "serde",
+ "spin-connection-semaphore",
  "spin-core",
  "spin-factor-otel",
  "spin-factors",

--- a/crates/factor-key-value/Cargo.toml
+++ b/crates/factor-key-value/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 spin-core = { path = "../core" }
+spin-connection-semaphore = { path = "../connection-semaphore" }
 spin-factor-otel = { path = "../factor-otel" }
 spin-factors = { path = "../factors" }
 spin-locked-app = { path = "../locked-app" }

--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -332,10 +332,8 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
             (host.get_store(store).cloned(), host.semaphore.clone())
         });
         let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
-        let _permit = permit_fut
-            .acquire()
+        let _permit = acquire_permit_v3(&permit_fut)
             .await
-            .map_err(log_error_v3)
             .map_err(track_error_on_span_v3)?;
         store
             .get(&key, MAX_HOST_BUFFERED_BYTES)
@@ -356,10 +354,8 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
             (host.get_store(store).cloned(), host.semaphore.clone())
         });
         let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
-        let _permit = semaphore
-            .acquire()
+        let _permit = acquire_permit_v3(&semaphore)
             .await
-            .map_err(log_error_v3)
             .map_err(track_error_on_span_v3)?;
         store
             .set(&key, &value)
@@ -379,10 +375,8 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
             (host.get_store(store).cloned(), host.semaphore.clone())
         });
         let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
-        let _permit = semaphore
-            .acquire()
+        let _permit = acquire_permit_v3(&semaphore)
             .await
-            .map_err(log_error_v3)
             .map_err(track_error_on_span_v3)?;
         store
             .delete(&key)
@@ -402,10 +396,8 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
             (host.get_store(store).cloned(), host.semaphore.clone())
         });
         let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
-        let _permit = semaphore
-            .acquire()
+        let _permit = acquire_permit_v3(&semaphore)
             .await
-            .map_err(log_error_v3)
             .map_err(track_error_on_span_v3)?;
         store
             .exists(&key)
@@ -425,10 +417,8 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
         });
         let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
 
-        let _permit = semaphore
-            .acquire()
+        let _permit = acquire_permit_v3(&semaphore)
             .await
-            .map_err(log_error_v3)
             .map_err(track_error_on_span_v3)?;
 
         let (keys_rx, err_rx) = store.get_keys_async(MAX_HOST_BUFFERED_BYTES).await;
@@ -446,8 +436,9 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
 
 /// Make sure that infrastructure related errors are tracked in the current span.
 fn track_error_on_span(err: Error) -> Error {
-    let blame = match err {
+    let blame = match &err {
         Error::NoSuchStore | Error::AccessDenied => Blame::Guest,
+        Error::Other(msg) if msg.contains("too many requests") => Blame::Guest,
         Error::StoreTableFull | Error::Other(_) => Blame::Host,
     };
     traces::mark_as_error(&err, Some(blame));
@@ -456,12 +447,24 @@ fn track_error_on_span(err: Error) -> Error {
 
 /// Make sure that infrastructure related errors are tracked in the current span.
 fn track_error_on_span_v3(err: v3::Error) -> v3::Error {
-    let blame = match err {
+    let blame = match &err {
         v3::Error::NoSuchStore | v3::Error::AccessDenied => Blame::Guest,
+        v3::Error::Other(msg) if msg.contains("too many requests") => Blame::Guest,
         v3::Error::StoreTableFull | v3::Error::Other(_) => Blame::Host,
     };
     traces::mark_as_error(&err, Some(blame));
     err
+}
+
+/// Maps a semaphore acquisition failure to a v3 error with a consistent "too many requests"
+/// message so that `track_error_on_span_v3` correctly attributes the blame to the guest.
+async fn acquire_permit_v3(
+    semaphore: &ConnectionSemaphore,
+) -> std::result::Result<ConnectionPermit, v3::Error> {
+    semaphore.acquire().await.map_err(|err| {
+        tracing::warn!("key-value error: {err:?}");
+        v3::Error::Other("too many requests".into())
+    })
 }
 
 fn to_wasi_err(e: Error) -> wasi_keyvalue::store::Error {

--- a/crates/factor-key-value/src/host.rs
+++ b/crates/factor-key-value/src/host.rs
@@ -1,5 +1,6 @@
 use super::{Cas, SwapError};
 use anyhow::{Context, Result};
+use spin_connection_semaphore::{ConnectionPermit, ConnectionSemaphore};
 use spin_core::{
     async_trait,
     wasmtime::component::{Accessor, FutureReader, Resource, StreamReader},
@@ -71,15 +72,21 @@ pub struct KeyValueDispatch {
     manager: Arc<dyn StoreManager>,
     stores: Table<Arc<dyn Store>>,
     compare_and_swaps: Table<Arc<dyn Cas>>,
+    semaphore: ConnectionSemaphore,
     otel: OtelFactorState,
 }
 
 impl KeyValueDispatch {
-    pub fn new(allowed_stores: HashSet<String>, manager: Arc<dyn StoreManager>) -> Self {
-        Self::new_with_capacity(
+    pub fn new(
+        allowed_stores: HashSet<String>,
+        manager: Arc<dyn StoreManager>,
+        app_id: Arc<str>,
+    ) -> Self {
+        Self::new_with_capacity_and_semaphore(
             allowed_stores,
             manager,
             DEFAULT_STORE_TABLE_CAPACITY,
+            ConnectionSemaphore::new(None, None, "key-value", app_id, None),
             Default::default(),
         )
     }
@@ -88,6 +95,23 @@ impl KeyValueDispatch {
         allowed_stores: HashSet<String>,
         manager: Arc<dyn StoreManager>,
         capacity: u32,
+        app_id: Arc<str>,
+        otel: OtelFactorState,
+    ) -> Self {
+        Self::new_with_capacity_and_semaphore(
+            allowed_stores,
+            manager,
+            capacity,
+            ConnectionSemaphore::new(None, None, "key-value", app_id, None),
+            otel,
+        )
+    }
+
+    pub fn new_with_capacity_and_semaphore(
+        allowed_stores: HashSet<String>,
+        manager: Arc<dyn StoreManager>,
+        capacity: u32,
+        semaphore: ConnectionSemaphore,
         otel: OtelFactorState,
     ) -> Self {
         Self {
@@ -95,8 +119,25 @@ impl KeyValueDispatch {
             manager,
             stores: Table::new(capacity),
             compare_and_swaps: Table::new(capacity),
+            semaphore,
             otel,
         }
+    }
+
+    async fn acquire_permit(&self) -> std::result::Result<ConnectionPermit, Error> {
+        self.semaphore.acquire().await.map_err(|err| {
+            tracing::warn!("key-value error: {err:?}");
+            Error::Other("too many requests".into())
+        })
+    }
+
+    async fn acquire_permit_wasi(
+        &self,
+    ) -> std::result::Result<ConnectionPermit, wasi_keyvalue::store::Error> {
+        self.semaphore.acquire().await.map_err(|err| {
+            tracing::warn!("key-value error: {err:?}");
+            wasi_keyvalue::store::Error::Other("too many requests".into())
+        })
     }
 
     pub fn get_store<T: 'static>(&self, store: Resource<T>) -> anyhow::Result<&Arc<dyn Store>> {
@@ -172,6 +213,7 @@ impl key_value::HostStore for KeyValueDispatch {
     ) -> Result<Result<Option<Vec<u8>>, Error>> {
         self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
+        let _permit = self.acquire_permit().await.map_err(track_error_on_span)?;
         Ok(store
             .get(&key, MAX_HOST_BUFFERED_BYTES)
             .await
@@ -187,6 +229,7 @@ impl key_value::HostStore for KeyValueDispatch {
     ) -> Result<Result<(), Error>> {
         self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
+        let _permit = self.acquire_permit().await.map_err(track_error_on_span)?;
         Ok(store.set(&key, &value).await.map_err(track_error_on_span))
     }
 
@@ -198,6 +241,7 @@ impl key_value::HostStore for KeyValueDispatch {
     ) -> Result<Result<(), Error>> {
         self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
+        let _permit = self.acquire_permit().await.map_err(track_error_on_span)?;
         Ok(store.delete(&key).await.map_err(track_error_on_span))
     }
 
@@ -209,6 +253,7 @@ impl key_value::HostStore for KeyValueDispatch {
     ) -> Result<Result<bool, Error>> {
         self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
+        let _permit = self.acquire_permit().await.map_err(track_error_on_span)?;
         Ok(store.exists(&key).await.map_err(track_error_on_span))
     }
 
@@ -219,6 +264,7 @@ impl key_value::HostStore for KeyValueDispatch {
     ) -> Result<Result<Vec<String>, Error>> {
         self.otel.reparent_tracing_span();
         let store = self.get_store(store)?;
+        let _permit = self.acquire_permit().await.map_err(track_error_on_span)?;
         Ok(store
             .get_keys(MAX_HOST_BUFFERED_BYTES)
             .await
@@ -280,13 +326,17 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
         store: Resource<v3::Store>,
         key: String,
     ) -> Result<Option<Vec<u8>>, v3::Error> {
-        let store = accessor
-            .with(|mut access| {
-                let host = access.get();
-                host.otel.reparent_tracing_span();
-                host.get_store(store).cloned()
-            })
-            .map_err(|_| v3::Error::NoSuchStore)?;
+        let (store_result, permit_fut) = accessor.with(|mut access| {
+            let host = access.get();
+            host.otel.reparent_tracing_span();
+            (host.get_store(store).cloned(), host.semaphore.clone())
+        });
+        let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
+        let _permit = permit_fut
+            .acquire()
+            .await
+            .map_err(log_error_v3)
+            .map_err(track_error_on_span_v3)?;
         store
             .get(&key, MAX_HOST_BUFFERED_BYTES)
             .await
@@ -300,13 +350,17 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
         key: String,
         value: Vec<u8>,
     ) -> Result<(), v3::Error> {
-        let store = accessor
-            .with(|mut access| {
-                let host = access.get();
-                host.otel.reparent_tracing_span();
-                host.get_store(store).cloned()
-            })
-            .map_err(|_| v3::Error::NoSuchStore)?;
+        let (store_result, semaphore) = accessor.with(|mut access| {
+            let host = access.get();
+            host.otel.reparent_tracing_span();
+            (host.get_store(store).cloned(), host.semaphore.clone())
+        });
+        let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
+        let _permit = semaphore
+            .acquire()
+            .await
+            .map_err(log_error_v3)
+            .map_err(track_error_on_span_v3)?;
         store
             .set(&key, &value)
             .await
@@ -319,13 +373,17 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
         store: Resource<v3::Store>,
         key: String,
     ) -> Result<(), v3::Error> {
-        let store = accessor
-            .with(|mut access| {
-                let host = access.get();
-                host.otel.reparent_tracing_span();
-                host.get_store(store).cloned()
-            })
-            .map_err(|_| v3::Error::NoSuchStore)?;
+        let (store_result, semaphore) = accessor.with(|mut access| {
+            let host = access.get();
+            host.otel.reparent_tracing_span();
+            (host.get_store(store).cloned(), host.semaphore.clone())
+        });
+        let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
+        let _permit = semaphore
+            .acquire()
+            .await
+            .map_err(log_error_v3)
+            .map_err(track_error_on_span_v3)?;
         store
             .delete(&key)
             .await
@@ -338,13 +396,17 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
         store: Resource<v3::Store>,
         key: String,
     ) -> Result<bool, v3::Error> {
-        let store = accessor
-            .with(|mut access| {
-                let host = access.get();
-                host.otel.reparent_tracing_span();
-                host.get_store(store).cloned()
-            })
-            .map_err(|_| v3::Error::NoSuchStore)?;
+        let (store_result, semaphore) = accessor.with(|mut access| {
+            let host = access.get();
+            host.otel.reparent_tracing_span();
+            (host.get_store(store).cloned(), host.semaphore.clone())
+        });
+        let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
+        let _permit = semaphore
+            .acquire()
+            .await
+            .map_err(log_error_v3)
+            .map_err(track_error_on_span_v3)?;
         store
             .exists(&key)
             .await
@@ -356,13 +418,18 @@ impl<T> v3::HostStoreWithStore<T> for crate::KeyValueFactorData {
         accessor: &Accessor<T, Self>,
         store: Resource<v3::Store>,
     ) -> Result<(StreamReader<String>, FutureReader<Result<(), v3::Error>>)> {
-        let store = accessor
-            .with(|mut access| {
-                let host = access.get();
-                host.otel.reparent_tracing_span();
-                host.get_store(store).cloned()
-            })
-            .map_err(|_| v3::Error::NoSuchStore)?;
+        let (store_result, semaphore) = accessor.with(|mut access| {
+            let host = access.get();
+            host.otel.reparent_tracing_span();
+            (host.get_store(store).cloned(), host.semaphore.clone())
+        });
+        let store = store_result.map_err(|_| v3::Error::NoSuchStore)?;
+
+        let _permit = semaphore
+            .acquire()
+            .await
+            .map_err(log_error_v3)
+            .map_err(track_error_on_span_v3)?;
 
         let (keys_rx, err_rx) = store.get_keys_async(MAX_HOST_BUFFERED_BYTES).await;
 
@@ -451,6 +518,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         key: String,
     ) -> Result<Option<Vec<u8>>, wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(self_)?;
+        let _permit = self.acquire_permit_wasi().await?;
         store
             .get(&key, MAX_HOST_BUFFERED_BYTES)
             .await
@@ -465,6 +533,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         value: Vec<u8>,
     ) -> Result<(), wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(self_)?;
+        let _permit = self.acquire_permit_wasi().await?;
         store.set(&key, &value).await.map_err(to_wasi_err)
     }
 
@@ -475,6 +544,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         key: String,
     ) -> Result<(), wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(self_)?;
+        let _permit = self.acquire_permit_wasi().await?;
         store.delete(&key).await.map_err(to_wasi_err)
     }
 
@@ -485,6 +555,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
         key: String,
     ) -> Result<bool, wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(self_)?;
+        let _permit = self.acquire_permit_wasi().await?;
         store.exists(&key).await.map_err(to_wasi_err)
     }
 
@@ -500,6 +571,7 @@ impl wasi_keyvalue::store::HostBucket for KeyValueDispatch {
             )),
             None => {
                 let store = self.get_store_wasi(self_)?;
+                let _permit = self.acquire_permit_wasi().await?;
                 let keys = store
                     .get_keys(MAX_HOST_BUFFERED_BYTES)
                     .await
@@ -527,6 +599,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         if keys.is_empty() {
             return Ok(vec![]);
         }
+        let _permit = self.acquire_permit_wasi().await?;
         store
             .get_many(keys, MAX_HOST_BUFFERED_BYTES)
             .await
@@ -543,6 +616,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         if key_values.is_empty() {
             return Ok(());
         }
+        let _permit = self.acquire_permit_wasi().await?;
         store.set_many(key_values).await.map_err(to_wasi_err)
     }
 
@@ -556,6 +630,7 @@ impl wasi_keyvalue::batch::Host for KeyValueDispatch {
         if keys.is_empty() {
             return Ok(());
         }
+        let _permit = self.acquire_permit_wasi().await?;
         store.delete_many(keys).await.map_err(to_wasi_err)
     }
 }
@@ -592,6 +667,7 @@ impl wasi_keyvalue::atomics::HostCas for KeyValueDispatch {
         let cas = self
             .get_cas(cas)
             .map_err(|e| wasi_keyvalue::store::Error::Other(e.to_string()))?;
+        let _permit = self.acquire_permit_wasi().await?;
         cas.current(MAX_HOST_BUFFERED_BYTES)
             .await
             .map_err(to_wasi_err)
@@ -619,6 +695,7 @@ impl wasi_keyvalue::atomics::Host for KeyValueDispatch {
         delta: i64,
     ) -> Result<i64, wasi_keyvalue::store::Error> {
         let store = self.get_store_wasi(bucket)?;
+        let _permit = self.acquire_permit_wasi().await?;
         store.increment(key, delta).await.map_err(to_wasi_err)
     }
 
@@ -632,6 +709,10 @@ impl wasi_keyvalue::atomics::Host for KeyValueDispatch {
         let cas = self
             .get_cas(Resource::<Bucket>::new_own(cas_rep))
             .map_err(|e| CasError::StoreError(atomics::Error::Other(e.to_string())))?;
+        let _permit = self
+            .acquire_permit_wasi()
+            .await
+            .map_err(CasError::StoreError)?;
 
         match cas.swap(value).await {
             Ok(_) => Ok(()),

--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -8,11 +8,13 @@ use std::{
 };
 
 use anyhow::ensure;
+use spin_connection_semaphore::{ConnectionSemaphore, LimitedSemaphore};
 use spin_factor_otel::OtelFactorState;
 use spin_factors::{
     ConfigureAppContext, Factor, FactorData, FactorInstanceBuilder, InitContext, PrepareContext,
     RuntimeFactors,
 };
+use spin_locked_app::APP_NAME_KEY;
 use spin_locked_app::MetadataKey;
 
 /// Metadata key for key-value stores.
@@ -62,7 +64,8 @@ impl Factor for KeyValueFactor {
         &self,
         mut ctx: ConfigureAppContext<T, Self>,
     ) -> anyhow::Result<Self::AppState> {
-        let store_managers = ctx.take_runtime_config().unwrap_or_default();
+        let runtime_config = ctx.take_runtime_config().unwrap_or_default();
+        let store_managers = runtime_config.clone();
 
         let delegating_manager = DelegatingStoreManager::new(store_managers);
         let store_manager = Arc::new(delegating_manager);
@@ -87,9 +90,26 @@ impl Factor for KeyValueFactor {
             // TODO: warn (?) on unused store?
         }
 
+        let app_id: Arc<str> = ctx
+            .app()
+            .get_metadata(APP_NAME_KEY)?
+            .unwrap_or_else(|| "<unnamed>".into())
+            .into();
+
+        let semaphore = ConnectionSemaphore::new(
+            None,
+            runtime_config
+                .max_concurrent_operations()
+                .map(LimitedSemaphore::new),
+            "key-value",
+            app_id,
+            runtime_config.wait_timeout(),
+        );
+
         Ok(AppState {
             store_manager,
             component_allowed_stores,
+            semaphore,
         })
     }
 
@@ -107,6 +127,7 @@ impl Factor for KeyValueFactor {
         Ok(InstanceBuilder {
             store_manager: app_state.store_manager.clone(),
             allowed_stores,
+            semaphore: app_state.semaphore.clone(),
             otel,
         })
     }
@@ -126,6 +147,8 @@ pub struct AppState {
     /// This is a map from component ID to the set of store labels that the
     /// component is allowed to use.
     component_allowed_stores: HashMap<String, HashSet<String>>,
+    /// App-scoped semaphore used to limit in-flight key-value operations.
+    semaphore: ConnectionSemaphore,
 }
 
 impl AppState {
@@ -187,6 +210,8 @@ pub struct InstanceBuilder {
     store_manager: Arc<AppStoreManager>,
     /// The allowed stores for this component instance.
     allowed_stores: HashSet<String>,
+    /// App-scoped semaphore shared by all component instances for this app.
+    semaphore: ConnectionSemaphore,
     otel: OtelFactorState,
 }
 
@@ -197,12 +222,14 @@ impl FactorInstanceBuilder for InstanceBuilder {
         let Self {
             store_manager,
             allowed_stores,
+            semaphore,
             otel,
         } = self;
-        Ok(KeyValueDispatch::new_with_capacity(
+        Ok(KeyValueDispatch::new_with_capacity_and_semaphore(
             allowed_stores,
             store_manager,
             u32::MAX,
+            semaphore,
             otel,
         ))
     }

--- a/crates/factor-key-value/src/lib.rs
+++ b/crates/factor-key-value/src/lib.rs
@@ -96,6 +96,9 @@ impl Factor for KeyValueFactor {
             .unwrap_or_else(|| "<unnamed>".into())
             .into();
 
+        // The global connection semaphore is not used here because the KV factor limits
+        // operations (not connections) and cannot access the underlying client through the
+        // `Store` trait abstraction.
         let semaphore = ConnectionSemaphore::new(
             None,
             runtime_config

--- a/crates/factor-key-value/src/runtime_config.rs
+++ b/crates/factor-key-value/src/runtime_config.rs
@@ -1,6 +1,6 @@
 pub mod spin;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use crate::StoreManager;
 
@@ -9,6 +9,10 @@ use crate::StoreManager;
 pub struct RuntimeConfig {
     /// Map of store names to store managers.
     store_managers: HashMap<String, Arc<dyn StoreManager>>,
+    /// Maximum number of concurrent in-flight key-value operations for this app.
+    max_concurrent_operations: Option<usize>,
+    /// Optional timeout for waiting to acquire a key-value operation permit.
+    wait_timeout: Option<Duration>,
 }
 
 impl RuntimeConfig {
@@ -28,6 +32,26 @@ impl RuntimeConfig {
     pub fn get_store_manager(&self, label: &str) -> Option<Arc<dyn StoreManager>> {
         self.store_managers.get(label).cloned()
     }
+
+    /// Sets the maximum number of concurrent in-flight key-value operations for this app.
+    pub fn set_max_concurrent_operations(&mut self, max: Option<usize>) {
+        self.max_concurrent_operations = max;
+    }
+
+    /// Sets the timeout used when waiting to acquire a key-value operation permit.
+    pub fn set_wait_timeout(&mut self, wait_timeout: Option<Duration>) {
+        self.wait_timeout = wait_timeout;
+    }
+
+    /// Returns the maximum number of concurrent in-flight key-value operations for this app.
+    pub fn max_concurrent_operations(&self) -> Option<usize> {
+        self.max_concurrent_operations
+    }
+
+    /// Returns the timeout used when waiting to acquire a key-value operation permit.
+    pub fn wait_timeout(&self) -> Option<Duration> {
+        self.wait_timeout
+    }
 }
 
 impl IntoIterator for RuntimeConfig {
@@ -36,5 +60,24 @@ impl IntoIterator for RuntimeConfig {
 
     fn into_iter(self) -> Self::IntoIter {
         self.store_managers.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RuntimeConfig;
+    use std::time::Duration;
+
+    #[test]
+    fn runtime_config_can_set_operation_limits() {
+        let mut config = RuntimeConfig::default();
+        assert_eq!(config.max_concurrent_operations(), None);
+        assert_eq!(config.wait_timeout(), None);
+
+        config.set_max_concurrent_operations(Some(7));
+        config.set_wait_timeout(Some(Duration::from_millis(250)));
+
+        assert_eq!(config.max_concurrent_operations(), Some(7));
+        assert_eq!(config.wait_timeout(), Some(Duration::from_millis(250)));
     }
 }

--- a/crates/key-value-spin/src/store.rs
+++ b/crates/key-value-spin/src/store.rs
@@ -478,6 +478,7 @@ mod test {
                 "default".to_owned(),
                 Arc::new(KeyValueSqlite::new(DatabaseLocation::InMemory)) as _,
             )])),
+            Arc::from("test"),
         );
 
         assert!(matches!(


### PR DESCRIPTION
- uses a semaphore to control concurrent KV operations
- follows a similar pattern that we took with other factors here https://github.com/spinframework/spin/pull/3552
- limit is still unset in cosmos and redis KV factors 