### PR TITLE
WAGI future deprecation alert

### DIFF
--- a/crates/trigger-http/src/lib.rs
+++ b/crates/trigger-http/src/lib.rs
@@ -395,6 +395,11 @@ impl HttpTrigger {
     }
 
     fn validate_app(app: &App) -> anyhow::Result<()> {
+        use spin_http::{
+            config::{HttpExecutorType, HttpTriggerConfig},
+            routes::HttpTriggerRouteConfig,
+        };
+
         #[derive(Deserialize)]
         #[serde(deny_unknown_fields)]
         struct TriggerMetadata {
@@ -411,6 +416,31 @@ impl HttpTrigger {
                 )
             }
         }
+
+        let mut explain_wagi_deprecation = false;
+        for trigger in app.triggers_with_type("http") {
+            if let Ok(config) = trigger.typed_config::<HttpTriggerConfig>()
+                && let Some(executor) = config.executor
+                && let HttpExecutorType::Wagi(_) = executor
+            {
+                let description = match config.route {
+                    HttpTriggerRouteConfig::Route(r) => format!("route {r}"),
+                    HttpTriggerRouteConfig::Private(_) => format!(
+                        "private endpoint for {}",
+                        config.component.unwrap_or_else(|| "<unknown>".into())
+                    ),
+                };
+                terminal::warn!("HTTP {description} uses the WAGI executor.");
+                explain_wagi_deprecation = true;
+            }
+        }
+        if explain_wagi_deprecation {
+            terminal::warn!("WAGI will be deprecated in a future version of Spin.");
+            eprintln!(
+                "To provide feedback, please visit https://github.com/spinframework/spin/issues/3520.\n"
+            );
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
A journey of a thousand miles begins with a single 10-line stanza of validation code.

<img width="602" height="126" alt="image" src="https://github.com/user-attachments/assets/cf659168-17e0-4969-b48a-41210415f99e" />

Submitting this now in the expectation that we are okay with starting the process in 4.1 (with 5.0 and 6.0 having the subsequent phases Lann outlined in https://github.com/spinframework/spin/issues/3520#issuecomment-4501825640); if we want to hold off then no worries.
