### PR TITLE
Use async (tokio) tar crate for OCI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
+dependencies = [
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash",
+ "rustix",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9737,6 +9753,7 @@ name = "spin-oci"
 version = "4.1.0-pre0"
 dependencies = [
  "anyhow",
+ "astral-tokio-tar",
  "async-compression",
  "base64 0.22.1",
  "chrono",
@@ -9755,7 +9772,6 @@ dependencies = [
  "spin-compose",
  "spin-loader",
  "spin-locked-app",
- "tar",
  "tempfile",
  "tokio",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ members = [
 
 [workspace.dependencies]
 anyhow = "1"
+astral-tokio-tar = "0.6"
 async-trait = "0.1"
 base64 = "0.22"
 bytes = "1.11.1"

--- a/crates/oci/Cargo.toml
+++ b/crates/oci/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+astral-tokio-tar = { workspace = true }
 async-compression = { version = "0.4", features = ["gzip", "tokio"] }
 base64 = { workspace = true }
 chrono = { workspace = true }
@@ -29,7 +30,6 @@ spin-common = { path = "../common" }
 spin-compose = { path = "../compose" }
 spin-loader = { path = "../loader" }
 spin-locked-app = { path = "../locked-app" }
-tar = "0.4"
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["fs", "io-util", "rt"] }
 tokio-util = { version = "0.7", features = ["compat"] }

--- a/crates/oci/src/utils.rs
+++ b/crates/oci/src/utils.rs
@@ -1,45 +1,55 @@
 //! Utilities related to distributing Spin apps via OCI registries
 
 use anyhow::{Context, Result};
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
+use async_compression::tokio::bufread::GzipDecoder;
+use async_compression::tokio::write::GzipEncoder;
 use spin_common::ui::quoted_path;
 use std::path::{Path, PathBuf};
-use tar::Archive;
+use tokio_tar::Archive;
 
 /// Create a compressed archive of source, returning its path in working_dir
 pub async fn archive(source: &Path, working_dir: &Path) -> Result<PathBuf> {
     let source = source.to_owned();
     let working_dir = working_dir.to_owned();
 
-    tokio::task::spawn_blocking(move || {
-        // Create tar archive file
-        let tar_gz_path = working_dir
-            .join(source.file_name().unwrap())
-            .with_extension("tar.gz");
-        let tar_gz = std::fs::File::create(tar_gz_path.as_path()).context(format!(
+    // Create tar archive file
+    let tar_gz_path = working_dir
+        .join(source.file_name().unwrap())
+        .with_extension("tar.gz");
+    let tar_gz = tokio::fs::File::create(tar_gz_path.as_path())
+        .await
+        .context(format!(
             "Unable to create tar archive for source {}",
             quoted_path(&source)
         ))?;
 
-        // Create encoder
-        // TODO: use zstd? May be more performant
-        let tar_gz_enc = GzEncoder::new(tar_gz, flate2::Compression::default());
+    // Create encoder
+    // TODO: use zstd? May be more performant
+    let tar_gz_enc = GzipEncoder::new(tar_gz);
 
-        // Build tar archive
-        let mut tar_builder = tar::Builder::new(tar_gz_enc);
-        tar_builder.append_dir_all(".", &source).context(format!(
+    // Build tar archive
+    let mut tar_builder = tokio_tar::Builder::new(tar_gz_enc);
+    tar_builder
+        .append_dir_all(".", &source)
+        .await
+        .context(format!(
             "Unable to create tar archive for source {}",
             quoted_path(&source)
         ))?;
 
-        // Finish writing the archive and shut down the encoder.
-        let inner_enc = tar_builder.into_inner()?;
-        inner_enc.finish()?;
+    // Finish writing the archive
+    tar_builder.finish().await?;
 
-        Ok(tar_gz_path)
-    })
-    .await?
+    // Shut down the encoder
+    use tokio::io::AsyncWriteExt;
+    tar_builder
+        .into_inner()
+        .await?
+        .into_inner()
+        .shutdown()
+        .await?;
+
+    Ok(tar_gz_path)
 }
 
 /// Unpack a compressed archive existing at source into dest
@@ -47,13 +57,12 @@ pub async fn unarchive(source: &Path, dest: &Path) -> Result<()> {
     let source = source.to_owned();
     let dest = dest.to_owned();
 
-    tokio::task::spawn_blocking(move || {
-        let decoder = GzDecoder::new(std::fs::File::open(&source)?);
-        let mut archive = Archive::new(decoder);
-        if let Err(e) = archive.unpack(&dest) {
-            return Err(e.into());
-        };
-        Ok(())
-    })
-    .await?
+    let decoder = GzipDecoder::new(tokio::io::BufReader::new(
+        tokio::fs::File::open(&source).await?,
+    ));
+    let mut archive = Archive::new(decoder);
+    if let Err(e) = archive.unpack(&dest).await {
+        return Err(e.into());
+    };
+    Ok(())
 }


### PR DESCRIPTION
Fixes #2846.

This mostly reverts (the relevant bits of) #3340 but now with `astral-tokio-tar` (which appears to be the current inheritor of the lineage) instead of the old async-std-based `async-tar`.

It is now PERFECT and FLAWLESS and I will NEVER HAVE TO FAFF AROUND WITH `tar` CRATES EVER AGAIN.
