### PR TITLE
Accept boolish values for env-settable bool flags

### DIFF
--- a/crates/trigger/src/cli.rs
+++ b/crates/trigger/src/cli.rs
@@ -73,6 +73,7 @@ pub struct FactorsTriggerCommand<T: Trigger<B::Factors>, B: RuntimeFactorsBuilde
         long = "disable-cache",
         env = DISABLE_WASMTIME_CACHE,
         conflicts_with = WASMTIME_CACHE_FILE,
+        value_parser = clap::builder::BoolishValueParser::new(),
     )]
     pub disable_cache: bool,
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -64,7 +64,7 @@ pub struct Push {
     pub compose: bool,
 
     /// Specifies to perform `spin build` (with the default options) before pushing the application.
-    #[clap(long, env = ALWAYS_BUILD_ENV)]
+    #[clap(long, env = ALWAYS_BUILD_ENV, value_parser = clap::builder::BoolishValueParser::new())]
     pub build: bool,
 
     /// Reference in the registry of the Spin application.

--- a/src/commands/up.rs
+++ b/src/commands/up.rs
@@ -157,7 +157,7 @@ pub(crate) struct UpCommandInner {
     /// For local apps, specifies to perform `spin build` (with the default options) before running the application.
     ///
     /// This is ignored on remote applications, as they are already built.
-    #[clap(long, env = ALWAYS_BUILD_ENV)]
+    #[clap(long, env = ALWAYS_BUILD_ENV, value_parser = clap::builder::BoolishValueParser::new())]
     pub build: bool,
 
     /// [Experimental] Component ID to run. This can be specified multiple times. The default is all components.


### PR DESCRIPTION
Supporting broader boolish values, like `1`, `0`, `yes` by adding [BoolishValueParser](https://gitlab-com.gitlab.io/support/toolbox/gitlabsar/clap/builder/struct.BoolishValueParser.html).

Note that some input arguments are impacted by a conflicting issue caused by a clap issue https://github.com/clap-rs/clap/issues/5591 which is a pre-existing issue before this PR. An example is even if `DISABLE_WASMTIME_CACHE` is set to false, it still conflicts to `WASMTIME_CACHE_FILE`. Clap check whether it's set rather than whether it's set to true.