### PR TITLE
chore(rust-sdk-release): bump Spin Rust SDK to v7.0.0

### DIFF
--- a/examples/http-rust/Cargo.toml
+++ b/examples/http-rust/Cargo.toml
@@ -9,6 +9,6 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1"
 http = "1.3.1"
-spin-sdk = "6.0.0"
+spin-sdk = "7.0.0"
 
 [workspace]

--- a/examples/open-ai-rust/Cargo.toml
+++ b/examples/open-ai-rust/Cargo.toml
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-spin-sdk = "6.0.0"
+spin-sdk = "7.0.0"
 
 [workspace]

--- a/templates/http-rust/content/Cargo.toml.tmpl
+++ b/templates/http-rust/content/Cargo.toml.tmpl
@@ -11,6 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1"
-spin-sdk = "6.0.0"
+spin-sdk = "7.0.0"
 
 [workspace]

--- a/templates/redis-rust/content/Cargo.toml.tmpl
+++ b/templates/redis-rust/content/Cargo.toml.tmpl
@@ -13,6 +13,6 @@ crate-type = [ "cdylib" ]
 # Useful crate to handle errors.
 anyhow = "1"
 # The Spin SDK.
-spin-sdk = "6.0.0"
+spin-sdk = "7.0.0"
 
 [workspace]


### PR DESCRIPTION
Update the Spin Rust Templates & Examples SDK dependency to v7.0.0.