### PR TITLE
Break WASIp3 HTTP server ownership cycle

### DIFF
--- a/crates/trigger-http/src/server.rs
+++ b/crates/trigger-http/src/server.rs
@@ -4,7 +4,7 @@ use std::{
     marker::PhantomData,
     net::SocketAddr,
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::{Arc, OnceLock, Weak},
     task::{Context, Poll},
     time::{Duration, Instant},
 };
@@ -799,13 +799,13 @@ impl<F: RuntimeFactors> WorkerState for HttpWorkerState<F> {
 pub(crate) struct HttpHandlerState<F: RuntimeFactors> {
     component_id: String,
     reuse_config: InstanceReuseConfig,
-    server: OnceLock<Arc<HttpServer<F>>>,
+    server: OnceLock<Weak<HttpServer<F>>>,
     self_scheme: OnceLock<Scheme>,
 }
 
 impl<F: RuntimeFactors> HttpHandlerState<F> {
     pub(crate) fn init_once(&self, server: &Arc<HttpServer<F>>, first_uri: &Uri) {
-        self.server.get_or_init(|| server.clone());
+        self.server.get_or_init(|| Arc::downgrade(server));
         if let Some(scheme) = first_uri.scheme() {
             self.self_scheme.get_or_init(|| scheme.clone());
         }
@@ -821,10 +821,13 @@ impl<F: RuntimeFactors> HandlerState for HttpHandlerState<F> {
         &self,
     ) -> wasmtime::Result<Instance<Self::StoreData, Self::WorkerExpiration, Self::WorkerState>>
     {
-        let (instance, mut store) = self
+        let server = self
             .server
             .get()
             .expect("server should have been set")
+            .upgrade()
+            .ok_or_else(|| wasmtime::format_err!("HTTP server is no longer available"))?;
+        let (instance, mut store) = server
             .trigger_instance_builder(&self.component_id, self.self_scheme.get())
             .to_wasmtime_result()?
             .instantiate(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -42,6 +42,39 @@ mod integration_tests {
         Ok(())
     }
 
+    #[test]
+    fn wasip3_handler_does_not_retain_http_server() -> anyhow::Result<()> {
+        use spin_trigger_http::InstanceReuseConfig;
+        use std::time::Duration;
+        use test_environment::TestEnvironment;
+        use testing_framework::runtimes::in_process_spin::InProcessSpin;
+
+        let config = InProcessSpin::config_with_reuse_config(
+            ServicesConfig::none(),
+            InstanceReuseConfig::single_use_with_request_deadline(Duration::from_secs(1)),
+            |env| preboot("wasi-http-p3-streaming", env),
+        );
+        let mut env = TestEnvironment::up(config, |_| Ok(()))?;
+        let weak_server = env.runtime_mut().weak_server();
+
+        for _ in 0..2 {
+            let response = env.runtime_mut().make_http_request(Request::full(
+                Method::Post,
+                "/echo",
+                &[("Host", "localhost")],
+                None,
+            ))?;
+            assert_eq!(response.status(), 200);
+        }
+
+        drop(env);
+        assert!(
+            weak_server.upgrade().is_none(),
+            "WASIp3 handler retained the HTTP server after its owner was dropped"
+        );
+        Ok(())
+    }
+
     #[cfg(feature = "extern-dependencies-tests")]
     /// Helper macro to assert that a condition is true eventually
     macro_rules! assert_eventually {

--- a/tests/testing-framework/src/runtimes/in_process_spin.rs
+++ b/tests/testing-framework/src/runtimes/in_process_spin.rs
@@ -50,6 +50,11 @@ impl InProcessSpin {
         Self { server }
     }
 
+    /// Return a weak reference to the in-process HTTP server.
+    pub fn weak_server(&self) -> std::sync::Weak<HttpServer<TriggerFactors>> {
+        Arc::downgrade(&self.server)
+    }
+
     /// Make an HTTP request to the Spin instance
     pub fn make_http_request(&self, req: Request<'_, &[u8]>) -> anyhow::Result<Response> {
         tokio::runtime::Runtime::new()?.block_on(async {


### PR DESCRIPTION
Fixes #3703.

The WASIp3 handler state stored a strong reference to `HttpServer`. The server also owns that handler state. After the first WASIp3 request, these references kept each other alive and prevented the server and its application state from being released.

This change stores a weak reference in the handler state. Spin upgrades it while it creates a new WASIp3 worker. If the server is already gone, worker creation returns an error.

The regression test sends two single-use WASIp3 requests. It then drops the in-process server and verifies that the server was released. The test failed on upstream `main` before the production change and passes with this change.

Active workers can still keep the server alive until they end. This change only removes the permanent server-to-handler-to-server reference cycle.

No dependencies or services were added.

## Tests

- `make lint`
- `make build`
- `cargo test -p spin-trigger-http --no-fail-fast -- --nocapture`
- `cargo test --test integration wasi_http_p3 -- --nocapture`
- `cargo test --test integration wasip3_handler_does_not_retain_http_server -- --nocapture`
