### PR TITLE
Count TCP sockets from creation

### DIFF
--- a/crates/factor-outbound-networking/tests/factor_test.rs
+++ b/crates/factor-outbound-networking/tests/factor_test.rs
@@ -17,6 +17,7 @@ use wasmtime_wasi::p2::bindings::sockets::network::{ErrorCode, IpAddressFamily};
 use wasmtime_wasi::p2::bindings::sockets::tcp as p2_tcp;
 use wasmtime_wasi::p2::bindings::sockets::tcp_create_socket as p2_tcp_create;
 use wasmtime_wasi::p2::bindings::sockets::udp_create_socket as p2_udp_create;
+use wasmtime_wasi::p3::bindings::sockets::types as p3_types;
 use wasmtime_wasi::sockets::{SocketAddrUse, WasiSocketsCtxView};
 
 struct MockMqttClient;
@@ -146,7 +147,7 @@ async fn wasi_factor_is_optional() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
-async fn socket_quota_blocks_excess_connections() -> anyhow::Result<()> {
+async fn tcp_socket_quota_applies_at_creation() -> anyhow::Result<()> {
     let factors = TestFactors {
         wasi: WasiFactor::new(DummyFilesMounter),
         variables: VariablesFactor::default(),
@@ -168,23 +169,25 @@ async fn socket_quota_blocks_excess_connections() -> anyhow::Result<()> {
 
     let mut state = env.build_instance_state().await?;
     let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view).unwrap();
-    let addr: std::net::SocketAddr = "123.0.2.1:12345".parse().unwrap();
 
-    // First two connections should be accepted (non-blocking connect initiated)
-    let net1 = sockets.instance_network()?;
     let sock1 = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
-    p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock1, net1, addr.into())?;
-
-    let net2 = sockets.instance_network()?;
     let sock2 = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
-    p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock2, net2, addr.into())?;
-
-    // Third should fail — quota exhausted
-    let net3 = sockets.instance_network()?;
-    let sock3 = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
     let err =
-        p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock3, net3, addr.into()).unwrap_err();
+        p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4).unwrap_err();
     assert_eq!(err.downcast_ref(), Some(&ErrorCode::NewSocketLimit));
+
+    p2_tcp::HostTcpSocket::drop(&mut sockets, sock1)?;
+    p2_tcp::HostTcpSocket::drop(&mut sockets, sock2)?;
+
+    p3_types::HostTcpSocket::create(&mut sockets, p3_types::IpAddressFamily::Ipv4)?;
+    p3_types::HostTcpSocket::create(&mut sockets, p3_types::IpAddressFamily::Ipv4)?;
+    let err =
+        p3_types::HostTcpSocket::create(&mut sockets, p3_types::IpAddressFamily::Ipv4).unwrap_err();
+    assert!(matches!(
+        err.downcast_ref(),
+        Some(p3_types::ErrorCode::Other(Some(message)))
+            if message == "connection quota exhausted"
+    ));
     Ok(())
 }
 
@@ -353,11 +356,9 @@ async fn socket_quota_releases_on_socket_drop() -> anyhow::Result<()> {
     let sock1_rep = sock1.rep();
     p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock1, net1, addr.into())?;
 
-    // A second start_connect should fail while the permit is held.
-    let net2 = sockets.instance_network()?;
-    let sock2 = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
+    // A second socket should fail while the permit is held.
     let err =
-        p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock2, net2, addr.into()).unwrap_err();
+        p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4).unwrap_err();
     assert_eq!(err.downcast_ref(), Some(&ErrorCode::NewSocketLimit));
 
     // Explicitly drop sock1 before finish_connect — this should release the permit.
@@ -449,10 +450,8 @@ async fn socket_quota_shared_between_tcp_and_udp() -> anyhow::Result<()> {
         .unwrap_err();
     assert_eq!(err.downcast_ref(), Some(&ErrorCode::NewSocketLimit));
     // TCP:
-    let net = sockets.instance_network()?;
-    let tcp_sock2 = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
-    let err = p2_tcp::HostTcpSocket::start_connect(&mut sockets, tcp_sock2, net, addr.into())
-        .unwrap_err();
+    let err =
+        p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4).unwrap_err();
     assert_eq!(err.downcast_ref(), Some(&ErrorCode::NewSocketLimit));
     Ok(())
 }
@@ -496,13 +495,11 @@ async fn global_connection_limit_enforced_across_factors() -> anyhow::Result<()>
         )
         .await?;
 
-    // With the global permit held by MQTT, a TCP socket start_connect must fail immediately.
+    // With the global permit held by MQTT, TCP socket creation must fail immediately.
     let mut sockets = WasiFactor::get_sockets_impl(&mut state, get_sockets_view_with_mqtt).unwrap();
     let addr: std::net::SocketAddr = "123.0.2.1:12345".parse().unwrap();
-    let net = sockets.instance_network()?;
-    let sock = p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4)?;
     let err =
-        p2_tcp::HostTcpSocket::start_connect(&mut sockets, sock, net, addr.into()).unwrap_err();
+        p2_tcp_create::Host::create_tcp_socket(&mut sockets, IpAddressFamily::Ipv4).unwrap_err();
     assert_eq!(
         err.downcast_ref(),
         Some(&ErrorCode::NewSocketLimit),

--- a/crates/factor-wasi/src/sockets.rs
+++ b/crates/factor-wasi/src/sockets.rs
@@ -25,8 +25,8 @@ use wasmtime_wasi::{
 };
 
 /// Shared state for tracking per-socket semaphore permits. Permits are
-/// acquired when a socket is allocated (at `start_connect` for TCP, at
-/// `create_udp_socket` for UDP) and released when the socket resource is dropped.
+/// acquired when a socket is allocated and released when the socket resource
+/// is dropped.
 pub struct SocketPermitState {
     semaphore: ConnectionSemaphore,
     /// Active permits keyed by socket resource rep, released when the resource is dropped.
@@ -64,7 +64,7 @@ impl<T> std::ops::DerefMut for SpinSocketsView<'_, T> {
 }
 
 /// [`HasData`] accessor for [`SpinSocketsView`], used in place of [`WasiSockets`]
-/// when registering TCP socket bindings so that `start_connect` and `drop` can
+/// when registering TCP socket bindings so that socket creation and `drop` can
 /// participate in socket quota tracking.
 pub struct SpinSockets<T>(PhantomData<fn() -> T>);
 
@@ -141,22 +141,7 @@ impl<T> p2_tcp::HostTcpSocket for SpinSocketsView<'_, T> {
         network: Resource<Network>,
         remote_address: IpSocketAddress,
     ) -> wasmtime_wasi::p2::SocketResult<()> {
-        let socket_rep = this.rep();
-        // Unlike outbound HTTP (which queues when its permit pool is exhausted),
-        // sockets fail immediately. Waiting would risk deadlock if a component
-        // holds sockets open across async yield points, and raw-socket callers
-        // are better positioned to implement their own retry logic.
-        let Ok(permit) = self.try_acquire() else {
-            tracing::warn!("TCP socket connection refused: connection quota exhausted");
-            return Err(SocketErrorCode::NewSocketLimit.into());
-        };
-        let result =
-            p2_tcp::HostTcpSocket::start_connect(&mut self.inner, this, network, remote_address);
-        if result.is_ok() {
-            self.register_permit(socket_rep, permit);
-        }
-        // On error, `permit` is dropped here, automatically releasing the semaphore slot.
-        result
+        p2_tcp::HostTcpSocket::start_connect(&mut self.inner, this, network, remote_address)
     }
 
     fn finish_connect(
@@ -369,7 +354,15 @@ impl<T> p2_tcp_create::Host for SpinSocketsView<'_, T> {
         &mut self,
         address_family: wasmtime_wasi::p2::bindings::sockets::network::IpAddressFamily,
     ) -> wasmtime_wasi::p2::SocketResult<Resource<TcpSocket>> {
-        p2_tcp_create::Host::create_tcp_socket(&mut self.inner, address_family)
+        // Unlike outbound HTTP, socket creation fails immediately when the
+        // quota is full. Waiting could deadlock a guest that keeps sockets open.
+        let Ok(permit) = self.try_acquire() else {
+            tracing::warn!("TCP socket creation refused: connection quota exhausted");
+            return Err(SocketErrorCode::NewSocketLimit.into());
+        };
+        let socket = p2_tcp_create::Host::create_tcp_socket(&mut self.inner, address_family)?;
+        self.register_permit(socket.rep(), permit);
+        Ok(socket)
     }
 }
 
@@ -539,9 +532,8 @@ impl<T> p2_udp_create::Host for SpinSocketsView<'_, T> {
         &mut self,
         address_family: wasmtime_wasi::p2::bindings::sockets::network::IpAddressFamily,
     ) -> wasmtime_wasi::p2::SocketResult<Resource<UdpSocket>> {
-        // Check quota before allocating the socket resource.
-        // See the analogous comment in `start_connect` for why we fail
-        // immediately rather than waiting (as outbound HTTP does).
+        // Fail immediately rather than wait. Waiting could deadlock a guest
+        // that keeps sockets open.
         let Ok(permit) = self.try_acquire() else {
             tracing::warn!("UDP socket creation refused: connection quota exhausted");
             return Err(SocketErrorCode::NewSocketLimit.into());
@@ -586,7 +578,13 @@ impl<T> p3_HostTcpSocket for SpinSocketsView<'_, T> {
         &mut self,
         address_family: p3_IpAddressFamily,
     ) -> P3SocketResult<Resource<p3_types::TcpSocket>> {
-        p3_HostTcpSocket::create(&mut self.inner, address_family)
+        let Ok(permit) = self.try_acquire() else {
+            tracing::warn!("TCP socket creation refused: connection quota exhausted");
+            return Err(p3_ErrorCode::Other(Some("connection quota exhausted".into())).into());
+        };
+        let socket = p3_HostTcpSocket::create(&mut self.inner, address_family)?;
+        self.register_permit(socket.rep(), permit);
+        Ok(socket)
     }
 
     fn get_local_address(
@@ -754,9 +752,8 @@ impl<T> p3_HostUdpSocket for SpinSocketsView<'_, T> {
         &mut self,
         address_family: p3_IpAddressFamily,
     ) -> P3SocketResult<Resource<p3_types::UdpSocket>> {
-        // Check quota before allocating the socket resource.
-        // See the analogous comment in `start_connect` for why we fail
-        // immediately rather than waiting (as outbound HTTP does).
+        // Fail immediately rather than wait. Waiting could deadlock a guest
+        // that keeps sockets open.
         let Ok(permit) = self.try_acquire() else {
             tracing::warn!("UDP socket creation refused: connection quota exhausted");
             return Err(p3_ErrorCode::Other(Some("connection quota exhausted".into())).into());
@@ -848,30 +845,10 @@ impl<T: Send + 'static> HostTcpSocketWithStore<T> for SpinSockets<T> {
         socket: Resource<p3_types::TcpSocket>,
         remote_address: p3_IpSocketAddress,
     ) -> P3SocketResult<()> {
-        let socket_rep = socket.rep();
-        // Unlike outbound HTTP (which queues when its permit pool is exhausted),
-        // sockets fail immediately. See p2 `start_connect` for rationale.
-        let permit = match store.with(|mut access| access.get().try_acquire()) {
-            Ok(p) => p,
-            Err(()) => {
-                tracing::warn!("TCP socket connection refused: connection quota exhausted");
-                return Err(p3_ErrorCode::Other(Some("connection quota exhausted".into())).into());
-            }
-        };
         let getter = store.with(|mut store| store.get().getter);
         let wasi_accessor = store.with_getter::<WasiSockets>(getter);
-        let result: P3SocketResult<()> = <WasiSockets as HostTcpSocketWithStore<T>>::connect(
-            &wasi_accessor,
-            socket,
-            remote_address,
-        )
-        .await;
-        if result.is_ok() {
-            store.with(|mut access| {
-                access.get().register_permit(socket_rep, permit);
-            });
-        }
-        result
+        <WasiSockets as HostTcpSocketWithStore<T>>::connect(&wasi_accessor, socket, remote_address)
+            .await
     }
 
     async fn listen(


### PR DESCRIPTION
Fixes #3706.

TCP socket creation already opens an operating-system socket, but Spin did not acquire quota until connect. Unconnected sockets could therefore bypass `max_socket_connections` and `max_total_connections`.

This change acquires quota when P2 or P3 creates the socket. The existing resource tracking releases it when the socket is dropped.

Tests cover both APIs, socket and instance cleanup, and shared limits.

## Tests

- `cargo test -p spin-factor-wasi`
- `cargo test -p spin-factor-outbound-networking`
- `make test-unit`
- `make lint`
- `make build`
