### PR TITLE
Deny named imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9014,6 +9014,7 @@ dependencies = [
  "wac-graph",
  "wasm-encoder 0.247.0",
  "wasmparser 0.247.0",
+ "wat",
 ]
 
 [[package]]
@@ -11512,9 +11513,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wac-graph"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc8c5ffe944e002a24ba9d0fa67f51d4a761c1fc97718a17d1d7379753a6f8e"
+checksum = "0bf6c75ac6a3c0351b04ee506e6c39b5b01b4204364264b034e23f8df7cc9946"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -11524,23 +11525,23 @@ dependencies = [
  "semver",
  "thiserror 1.0.69",
  "wac-types",
- "wasm-encoder 0.247.0",
- "wasm-metadata 0.247.0",
- "wasmparser 0.247.0",
+ "wasm-encoder 0.258.0",
+ "wasm-metadata 0.258.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
 name = "wac-types"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b90654c08294d879e85f0b8b2c5a7efc3a7a10df3009dd1578d98902d1ec8a2"
+checksum = "fc44aa9e8f525d1f0c9800a4c082c33b4ac0781a84e83465923afdaf4a25755b"
 dependencies = [
  "anyhow",
  "id-arena",
  "indexmap 2.14.0",
  "semver",
- "wasm-encoder 0.247.0",
- "wasmparser 0.247.0",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -11910,6 +11911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.258.0",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.224.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11986,6 +11997,25 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder 0.254.0",
  "wasmparser 0.254.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a11585adb92fe9b55ad1d760e8d8fb5d87e0d2e303cb8eed57f078d54293a2"
+dependencies = [
+ "anyhow",
+ "auditable-serde 0.9.0",
+ "flate2",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx 0.13.5",
+ "url",
+ "wasm-encoder 0.258.0",
+ "wasmparser 0.258.0",
 ]
 
 [[package]]
@@ -12151,6 +12181,19 @@ dependencies = [
  "bitflags 2.13.1",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.258.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
+dependencies = [
+ "bitflags 2.13.1",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,8 +197,8 @@ tracing = { version = "0.1.44", features = ["log"] }
 url = "2.5.7"
 tracing-opentelemetry = { version = "0.30", default-features = false, features = ["metrics"] }
 walkdir = "2"
-wac-graph = "0.10.0"
-wac-types = "0.10.0"
+wac-graph = "0.11.0"
+wac-types = "0.11.0"
 wasm-encoder = "0.247.0"
 wasm-metadata = "0.247.0"
 wasm-pkg-client = "0.11"

--- a/crates/capabilities/Cargo.toml
+++ b/crates/capabilities/Cargo.toml
@@ -14,5 +14,8 @@ wac-graph = { workspace = true }
 wasm-encoder = { workspace = true }
 wasmparser = { workspace = true }
 
+[dev-dependencies]
+wat = "1"
+
 [lints]
 workspace = true

--- a/crates/capabilities/src/deny.rs
+++ b/crates/capabilities/src/deny.rs
@@ -2,7 +2,7 @@ use crate::{
     AI_MODELS, ALLOWED_OUTBOUND_HOSTS, CAPABILITY_SETS, ENVIRONMENT, FILES, InheritConfiguration,
     KEY_VALUE_STORES, SQLITE_DATABASES, VARIABLES,
 };
-use wac_graph::types::{SubtypeChecker, are_semver_compatible};
+use wac_graph::types::{ItemKind, SubtypeChecker, are_semver_compatible};
 use wac_graph::{CompositionGraph, types::Package};
 
 /// Composes a deny adapter into a Wasm component to block host capabilities that
@@ -14,6 +14,10 @@ use wac_graph::{CompositionGraph, types::Package};
 /// Interfaces listed in the allow set (derived from `inherits`) are left untouched
 /// so the host can satisfy them at runtime; all other matching imports are fulfilled
 /// by the deny adapter, which traps on any call.
+///
+/// Imports are matched on the interface they implement, so a named import such as
+/// `primary (implements spin:key-value/key-value@3.0.0)` is treated the same as a
+/// plain import of that interface; the label itself is irrelevant.
 ///
 /// If the deny adapter has no exports that match the component's imports (i.e. no
 /// plugging is needed), the original `source` bytes are returned unchanged.
@@ -40,36 +44,44 @@ pub fn apply_deny_adapter(
 
     let deny_adapter_id = graph.register_package(deny_adapter_package)?;
 
-    // Selective plug: wire up only exports NOT in the allow list.
+    // Selective plug: wire up only imports NOT in the allow list.
     let socket_instantiation = graph.instantiate(dependency_id);
+
+    let types = graph.types();
+    let adapter_exports = &types[graph[deny_adapter_id].ty()].exports;
 
     let mut plug_exports: Vec<(String, String)> = Vec::new();
     let mut cache = Default::default();
     let mut checker = SubtypeChecker::new(&mut cache);
-    for (name, plug_ty) in &graph.types()[graph[deny_adapter_id].ty()].exports {
+    for (import_name, socket_ty) in &types[graph[dependency_id].ty()].imports {
+        let ItemKind::Instance(iface) = socket_ty else {
+            continue;
+        };
+
+        // Named imports resolve to the interface they implement; plain imports to their own name.
+        let iface_name = types[*iface].id.as_deref().unwrap_or(import_name);
+
         // Skip interfaces that should be allowed (inherited from host).
-        if allow.iter().any(|a| *a == name) {
+        if allow.contains(&iface_name) {
             continue;
         }
 
-        let matching_import = graph.types()[graph[dependency_id].ty()]
-            .imports
-            .get(name)
-            .map(|ty| (name.clone(), ty))
+        let matching_export = adapter_exports
+            .get(iface_name)
+            .map(|ty| (iface_name, ty))
             .or_else(|| {
-                graph.types()[graph[dependency_id].ty()]
-                    .imports
+                adapter_exports
                     .iter()
-                    .find(|(import_name, _)| are_semver_compatible(name, import_name))
-                    .map(|(import_name, ty)| (import_name.clone(), ty))
+                    .find(|(export_name, _)| are_semver_compatible(export_name, iface_name))
+                    .map(|(export_name, ty)| (export_name.as_str(), ty))
             });
 
-        if let Some((socket_name, socket_ty)) = matching_import
+        if let Some((plug_name, plug_ty)) = matching_export
             && checker
-                .is_subtype(*plug_ty, graph.types(), *socket_ty, graph.types())
+                .is_subtype(*plug_ty, types, *socket_ty, types)
                 .is_ok()
         {
-            plug_exports.push((name.clone(), socket_name));
+            plug_exports.push((plug_name.to_owned(), import_name.clone()));
         }
     }
 
@@ -126,4 +138,117 @@ fn allow_list(inherits: InheritConfiguration) -> Vec<&'static str> {
     }
 
     allow
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wac_graph::types::Types;
+
+    const KV: &str = "spin:key-value/key-value@3.0.0";
+    const ENV: &str = "wasi:cli/environment@0.2.6";
+
+    // Imports use an empty instance type, which any adapter export trivially satisfies.
+    fn component(imports: &[(&str, Option<&str>)]) -> Vec<u8> {
+        let mut wat = String::from("(component\n");
+        for (name, implements) in imports {
+            match implements {
+                Some(iface) => wat.push_str(&format!(
+                    "  (import \"{name}\" (implements \"{iface}\") (instance))\n"
+                )),
+                None => wat.push_str(&format!("  (import \"{name}\" (instance))\n")),
+            }
+        }
+        wat.push(')');
+        wat::parse_str(&wat).expect("valid WAT")
+    }
+
+    // The composed component also carries the deny adapter's own imports (wasi:io etc.),
+    // so tests check for specific names rather than an empty import set.
+    fn remaining_imports(bytes: &[u8]) -> Vec<String> {
+        let mut types = Types::default();
+        let package = Package::from_bytes("out", None, bytes, &mut types).expect("valid component");
+        types[package.ty()].imports.keys().cloned().collect()
+    }
+
+    fn assert_denied(bytes: &[u8], names: &[&str]) {
+        let remaining = remaining_imports(bytes);
+        for name in names {
+            assert!(
+                !remaining.iter().any(|r| r == name),
+                "`{name}` should have been denied"
+            );
+        }
+    }
+
+    fn assert_retained(bytes: &[u8], names: &[&str]) {
+        let remaining = remaining_imports(bytes);
+        for name in names {
+            assert!(
+                remaining.iter().any(|r| r == name),
+                "`{name}` should have been retained"
+            );
+        }
+    }
+
+    fn some(sets: &[&str]) -> InheritConfiguration {
+        InheritConfiguration::Some(sets.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn plain_import_is_denied() {
+        let source = component(&[(KV, None)]);
+        let out = apply_deny_adapter(&source, InheritConfiguration::None).unwrap();
+        assert_denied(&out, &[KV]);
+    }
+
+    #[test]
+    fn named_import_is_denied() {
+        let source = component(&[("primary", Some(KV))]);
+        let out = apply_deny_adapter(&source, InheritConfiguration::None).unwrap();
+        assert_denied(&out, &["primary"]);
+    }
+
+    #[test]
+    fn named_import_is_allowed_when_inherited() {
+        let source = component(&[("primary", Some(KV))]);
+        let out = apply_deny_adapter(&source, some(&["key_value_stores"])).unwrap();
+        assert_eq!(out, source);
+    }
+
+    #[test]
+    fn multiple_labels_of_same_interface_are_all_denied() {
+        let source = component(&[("primary", Some(KV)), ("backup", Some(KV))]);
+        let out = apply_deny_adapter(&source, InheritConfiguration::None).unwrap();
+        assert_denied(&out, &["primary", "backup"]);
+    }
+
+    #[test]
+    fn mixed_named_imports_are_filtered_by_interface() {
+        let source = component(&[("primary", Some(KV)), ("env", Some(ENV))]);
+        let out = apply_deny_adapter(&source, some(&["key_value_stores"])).unwrap();
+        assert_retained(&out, &["primary"]);
+        assert_denied(&out, &["env"]);
+    }
+
+    #[test]
+    fn plain_and_named_imports_of_same_interface_are_both_denied() {
+        let source = component(&[(KV, None), ("secondary", Some(KV))]);
+        let out = apply_deny_adapter(&source, InheritConfiguration::None).unwrap();
+        assert_denied(&out, &[KV, "secondary"]);
+    }
+
+    #[test]
+    fn unknown_interface_is_left_untouched() {
+        let source = component(&[("thing", Some("example:unknown/iface@1.0.0"))]);
+        let out = apply_deny_adapter(&source, InheritConfiguration::None).unwrap();
+        assert_eq!(out, source);
+    }
+
+    #[test]
+    fn inherit_all_is_passthrough() {
+        let source = component(&[(KV, None), ("primary", Some(KV)), ("env", Some(ENV))]);
+        let out = apply_deny_adapter(&source, InheritConfiguration::All).unwrap();
+        assert_eq!(out, source);
+    }
 }


### PR DESCRIPTION
A dependency importing one interface under several labels now has all of them denied (previously at most one could be plugged).